### PR TITLE
Add error for attempting to filter on array types

### DIFF
--- a/lib/odata_duty/errors.rb
+++ b/lib/odata_duty/errors.rb
@@ -5,6 +5,7 @@ module OdataDuty
 
   class ServerError < Error; end
   class NoImplementationError < ServerError; end
+  class NoYetSupportedError < NoImplementationError; end
   class InvalidValue < ServerError; end
 
   class ClientError < Error; end
@@ -16,4 +17,5 @@ module OdataDuty
   class InvalidPropertyReferenceValue < ClientError; end
   class InvalidType < ClientError; end
   class NoSuchPropertyError < ClientError; end
+  class InvalidQueryOptionError < ClientError; end
 end

--- a/lib/odata_duty/errors.rb
+++ b/lib/odata_duty/errors.rb
@@ -5,7 +5,7 @@ module OdataDuty
 
   class ServerError < Error; end
   class NoImplementationError < ServerError; end
-  class NoYetSupportedError < NoImplementationError; end
+  class NotYetSupportedError < NoImplementationError; end
   class InvalidValue < ServerError; end
 
   class ClientError < Error; end

--- a/lib/odata_duty/filter.rb
+++ b/lib/odata_duty/filter.rb
@@ -8,13 +8,13 @@ module OdataDuty
     def self.validate(str)
       %w[add sub mul div mod].each do |operator|
         if str.include?(" #{operator} ")
-          raise NoYetSupportedError,
+          raise NotYetSupportedError,
                 'filtering with arithmetic operators not supported'
         end
       end
       return unless str.include?('(')
 
-      raise NoYetSupportedError,
+      raise NotYetSupportedError,
             'filtering does not support functions or Grouping Operators'
     end
 
@@ -40,7 +40,7 @@ module OdataDuty
     def property_name
       @components.first.tap do |name|
         if name.include?('/')
-          raise NoYetSupportedError, 'nested property filtering not supported yet'
+          raise NotYetSupportedError, 'nested property filtering not supported yet'
         end
       end.to_sym
     end

--- a/lib/odata_duty/filter.rb
+++ b/lib/odata_duty/filter.rb
@@ -8,13 +8,13 @@ module OdataDuty
     def self.validate(str)
       %w[add sub mul div mod].each do |operator|
         if str.include?(" #{operator} ")
-          raise NoImplementationError,
+          raise NoYetSupportedError,
                 'filtering with arithmetic operators not supported'
         end
       end
       return unless str.include?('(')
 
-      raise NoImplementationError,
+      raise NoYetSupportedError,
             'filtering does not support functions or Grouping Operators'
     end
 
@@ -33,11 +33,14 @@ module OdataDuty
       @components[1].to_sym
     end
 
+    def collection_operation?
+      false # no support for collection operation yet
+    end
+
     def property_name
       @components.first.tap do |name|
         if name.include?('/')
-          raise NoImplementationError,
-                'nested property filtering not supported'
+          raise NoYetSupportedError, 'nested property filtering not supported yet'
         end
       end.to_sym
     end

--- a/odata_duty.gemspec
+++ b/odata_duty.gemspec
@@ -2,7 +2,7 @@
 
 Gem::Specification.new do |spec|
   spec.name          = 'odata_duty'
-  spec.version       = '0.5.0'
+  spec.version       = '0.5.1'
   spec.authors       = ['Grant Petersen-Speelman']
   spec.email         = ['grant@nexl.io']
 

--- a/spec/odata_duty/schema_builder/entity_type/boolean_array_type_spec.rb
+++ b/spec/odata_duty/schema_builder/entity_type/boolean_array_type_spec.rb
@@ -1,0 +1,108 @@
+require 'spec_helper'
+
+class BoolArrayResolver < OdataDuty::SetResolver
+  def od_after_init
+    @records = [
+      OpenStruct.new(id: '1', booleans: [true]),
+      OpenStruct.new(id: '2', booleans: [false]),
+      OpenStruct.new(id: '3', booleans: [true])
+    ]
+  end
+
+  def collection
+    @records
+  end
+
+  def count
+    @records.count
+  end
+end
+
+class BoolArrayWithInvalidResolver < OdataDuty::SetResolver
+  def collection
+    [
+      OpenStruct.new(id: '1', booleans: ['boolean'])
+    ]
+  end
+end
+
+module OdataDuty
+  RSpec.describe SchemaBuilder::EntityType, 'Can use array boolean primitive type' do
+    subject(:schema) do
+      SchemaBuilder.build(namespace: 'SampleSpace', host: 'localhost') do |s|
+        bool_entity = s.add_entity_type(name: 'BoolValues') do |et|
+          et.property_ref 'id', String
+          et.property 'booleans', [TrueClass], nullable: false
+        end
+
+        s.add_entity_set(name: 'BoolWithInvalid', entity_type: bool_entity,
+                         resolver: 'BoolArrayWithInvalidResolver')
+        s.add_entity_set(name: 'Bool', entity_type: bool_entity,
+                         resolver: 'BoolArrayResolver')
+      end
+    end
+
+    describe '#metadata_xml' do
+      let(:parsed_xml) do
+        parse_xml_from_string(EdmxSchema.metadata_xml(schema))
+      end
+      let(:entity_types) { entity_types_from_doc(parsed_xml) }
+      let(:keys) { entity_type.fetch(:keys) }
+      let(:properties) { entity_type.fetch(:properties) }
+
+      it { expect(entity_types.keys).to contain_exactly('BoolValues') }
+
+      describe 'BoolValues' do
+        let(:entity_type) { entity_types['BoolValues'] }
+
+        it { expect(keys).to eq(['id']) }
+        it do
+          expect(properties).to include(name: 'booleans',
+                                        nullable: 'false',
+                                        type: 'Collection(Edm.Boolean)')
+        end
+      end
+    end
+
+    describe '#collection' do
+      describe 'BoolSet' do
+        it do
+          json_string = schema.execute('Bool', context: Context.new)
+          response = Oj.load(json_string)
+          expect(response).to eq(
+            {
+              '@odata.context' => '$metadata#Bool',
+              'value' => [
+                { '@odata.id' => 'Bool(\'1\')', 'id' => '1', 'booleans' => [true] },
+                { '@odata.id' => 'Bool(\'2\')', 'id' => '2', 'booleans' => [false] },
+                { '@odata.id' => 'Bool(\'3\')', 'id' => '3', 'booleans' => [true] }
+              ]
+            }
+          )
+        end
+
+        it 'raises an error for invalid filter on collection property' do
+          expect do
+            schema.execute('Bool', context: Context.new,
+                                   query_options: { '$filter' => 'booleans eq true' })
+          end.to raise_error(OdataDuty::InvalidQueryOptionError)
+        end
+
+        it 'raises a not supported error for unsupported filter syntax' do
+          expect do
+            schema.execute('Bool', context: Context.new,
+                                   query_options: { '$filter' => 'booleans/any(t: t eq true)' })
+          end.to raise_error(OdataDuty::NoYetSupportedError)
+        end
+      end
+
+      describe 'BoolWithInvalid' do
+        it 'raises an error for invalid value in the collection' do
+          expect do
+            schema.execute('BoolWithInvalid', context: Context.new)
+          end.to raise_error(OdataDuty::InvalidValue)
+        end
+      end
+    end
+  end
+end

--- a/spec/odata_duty/schema_builder/entity_type/boolean_array_type_spec.rb
+++ b/spec/odata_duty/schema_builder/entity_type/boolean_array_type_spec.rb
@@ -92,7 +92,7 @@ module OdataDuty
           expect do
             schema.execute('Bool', context: Context.new,
                                    query_options: { '$filter' => 'booleans/any(t: t eq true)' })
-          end.to raise_error(OdataDuty::NoYetSupportedError)
+          end.to raise_error(OdataDuty::NotYetSupportedError)
         end
       end
 


### PR DESCRIPTION
The error raised when attempting to filter on collection types is not clear that this is not possible with the gem yet. 
This PR updates the code to raise a more specific error so it's clear that it's not supported