### PR TITLE
Add native support for the $select query parameter

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -33,5 +33,12 @@ jobs:
       with:
         ruby-version: ${{ matrix.ruby-version }}
         bundler-cache: true # runs 'bundle install' and caches installed gems automatically
+    # run tests multiple times in an attempt to cache flaky test failures
+    - name: Run tests
+      run: bundle exec rake
+    - name: Run tests
+      run: bundle exec rake
+    - name: Run tests
+      run: bundle exec rake
     - name: Run tests
       run: bundle exec rake

--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,6 @@
 /.yardoc
 /_yardoc/
 /coverage/
-/doc/
 /pkg/
 /spec/reports/
 /tmp/

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -18,7 +18,7 @@ Metrics/ModuleLength:
 Metrics/CyclomaticComplexity:
   Max: 7
 Metrics/MethodLength:
-  Max: 17
+  Max: 13
 Style/FrozenStringLiteralComment:
   Enabled: false
 Style/Documentation:

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -18,7 +18,7 @@ Metrics/ModuleLength:
 Metrics/CyclomaticComplexity:
   Max: 7
 Metrics/MethodLength:
-  Max: 9
+  Max: 17
 Style/FrozenStringLiteralComment:
   Enabled: false
 Style/Documentation:

--- a/Gemfile
+++ b/Gemfile
@@ -7,6 +7,7 @@ gemspec
 
 gem 'benchmark-ips', '>= 2.14'
 gem 'byebug'
+gem 'camel_snake_struct'
 gem 'nokogiri'
 gem 'profile-viewer', '>= 0.0.2'
 gem 'rake', '>= 13.0'

--- a/README.md
+++ b/README.md
@@ -20,6 +20,8 @@ Or install it yourself as:
 
 ## Usage
 
+The gem assumes some familiarity with OData concepts. If you're new to OData, you may want to check out the [OData Crash Course](doc/odata_crash_course.md) to get a quick overview of the core concepts.
+
 ### Key Features
 
 - **Define Entities and Properties**: Easily define your OData entities and their properties using simple Ruby classes.
@@ -47,13 +49,8 @@ end
 class PeopleSet < OdataDuty::EntitySet
   entity_type PersonEntity
 
-  ALL_RECORDS = [
-    OpenStruct.new(id: '1', user_name: 'user1', name: 'User One', emails: ['user1@example.com']),
-    OpenStruct.new(id: '2', user_name: 'user2', name: 'User Two', emails: ['user2@example.com'])
-  ]
-
   def od_after_init
-    @records = ALL_RECORDS
+    @records = Person.active
   end
 
   def collection

--- a/README.md
+++ b/README.md
@@ -207,6 +207,10 @@ class PeopleResolver < OdataDuty::SetResolver
 end
 ```
 
+## Further documentation
+
+- [Using `$select`](doc/using_select.md)
+
 ## TODO
 
 * add support for composite keys

--- a/README.md
+++ b/README.md
@@ -58,13 +58,11 @@ class PeopleSet < OdataDuty::EntitySet
   end
 
   def individual(id)
-    @records.find { |record| record.id == id }
+    @records.find(id)
   end
 
   def create(data)
-    record = OpenStruct.new(id: ALL_RECORDS.size + 1, username: data.user_name, name: data.name, emails: data.emails)
-    ALL_RECORDS << record
-    record
+    Person.create!(username: data.user_name, name: data.name, emails: data.emails)
   end
 end
 

--- a/doc/odata_crash_course.md
+++ b/doc/odata_crash_course.md
@@ -1,0 +1,66 @@
+# OData Crash Course: Key Concepts and Terminology
+
+OData (Open Data Protocol) is a standard protocol for building and consuming RESTful APIs. It provides a consistent way to query and manipulate data using HTTP. Here’s a quick overview of the core concepts:
+
+## 1. Entities and Entity Types
+- **Entity:**  
+  An entity represents a single record or object within a data source. It is analogous to a row in a database table.
+  
+- **Entity Type:**  
+  This defines the structure of an entity, including its properties (or fields) and their types. For example, an entity type called "Person" might include properties such as `id`, `name`, and `email`.
+
+## 2. Entity Sets
+- **Entity Set:**  
+  An entity set is a collection of entities of the same type. Think of it as a database table that holds multiple records of a particular entity type. For instance, a "People" entity set contains all "Person" entities.
+
+## 3. Properties
+- **Properties:**  
+  These are the individual pieces of data that make up an entity. Properties can be:
+  - **Primitive Properties:** Simple values like strings, numbers, or dates.
+  - **Complex Properties:** Structured types that group multiple primitive properties (similar to a sub-object) without a separate key.
+  
+## 4. Complex Types
+- **Complex Type:**  
+  A complex type is a composite data type that groups several properties together. Unlike entities, complex types do not have a unique identity and cannot exist independently.
+
+## 5. Enum Types
+- **Enum Type:**  
+  An enumeration (enum) defines a set of named constants. Enum types are useful for properties that can have only one value out of a predefined set. For example, a "PersonGender" enum might have the values "Male", "Female", and "Unknown".
+
+## 6. Keys
+- **Key:**  
+  A key is a property (or a combination of properties) that uniquely identifies an entity within an entity set. The key property is essential for operations like retrieving a specific entity or updating data.
+
+## 7. Query Options
+OData provides several query options that allow clients to interact with the API in flexible ways. Some of the most common include:
+- **$select:**  
+  Specifies which properties of an entity should be returned. This helps reduce the amount of data transmitted.
+  
+- **$filter:**  
+  Allows clients to filter results based on specific criteria (e.g., filtering people by age).
+  
+- **$expand:**  
+  Used to include related entities in the response. This is especially useful for complex types or navigation properties.
+  
+- **$orderby, $top, $skip, and $count:**  
+  These options control the order, pagination, and count of results.
+
+## 8. How an OData API Works
+- **Standardized Endpoints:**  
+  An OData service exposes endpoints for entity sets and individual entities. Clients can query these endpoints using standard HTTP methods.
+  
+- **Uniform Data Format:**  
+  Responses are typically returned in JSON (or XML) following a defined structure that includes both the data and metadata such as `@odata.id` (which provides a unique URI for each entity).
+  
+- **Error Handling:**  
+  OData defines a standard format for error responses. When a client sends an invalid request (e.g., selecting a property that does not exist), the server returns an error with a specific code and message to help diagnose the issue.
+
+## Summary
+
+- **Entities** represent individual records defined by **entity types**.
+- **Entity Sets** are collections of similar entities.
+- **Properties** are the fields within an entity, and they can be either **primitive** or **complex**.
+- **Enum Types** allow for a controlled set of constant values.
+- **Keys** uniquely identify each entity.
+- **Query Options** like `$select`, `$filter`, and `$expand` empower clients to customize data retrieval.
+- An OData API follows standardized conventions for data representation, querying, and error handling.

--- a/doc/using_select.md
+++ b/doc/using_select.md
@@ -1,0 +1,91 @@
+# Using `$select` with OdataDuty
+
+The `$select` query option in OData allows clients to request only a subset of properties from an entity. This reduces the payload size and improves performance by returning only the data you need.  
+OdataDuty will call the `od_select` method on your entity set—if defined—to allow you to further optimize data loading and performance. Even if your `OdataDuty::EntitySet` does not implement `od_select`, OdataDuty will still return only the selected properties.
+
+This guide explains how to implement `od_select` in your custom `OdataDuty::EntitySet` class.
+
+## Overview
+
+- **Purpose:** Return only the selected properties from your entities, reducing payload size and improving performance.
+- **Mechanism:** When a `$select` query option is provided, OdataDuty parses it into an array of properties and passes that array to your `od_select` method.
+- **Metadata:** Essential metadata (like `@odata.id`) is always included, regardless of the selection.
+
+## Implementing `od_select`
+
+To support `$select`, you implement the `od_select` method on your `OdataDuty::EntitySet` subclass. This method should:
+- Accept an array of property names.
+- Ensure that required properties (such as `id`) are always included.
+- Filter your internal record collection to include only the specified properties.
+
+### Example Implementation
+
+Below is a sample implementation for an entity set that uses ActiveRecord:
+
+```ruby
+class MyCustomEntitySet < OdataDuty::EntitySet
+  # Associate the entity type with this set
+  entity_type MyEntity
+
+  def od_after_init
+    # Assume People.active returns an ActiveRecord collection
+    @records = People.active
+  end
+
+  # Implements the $select logic.
+  # Receives an array of property names (e.g., ['name', 'email'])
+  def od_select(select)
+    # Ensure that the 'id' property is always included
+    columns = select.map(&:to_s)
+    @records = @records.select(*columns)
+  end
+
+  # Return a collection of records
+  def collection
+    @records
+  end
+
+  # Return a single record based on its id
+  def individual(id)
+    collection.find(id)
+  end
+end
+```
+
+### How It Works
+
+1. **Parsing `$select`:**  
+   When a client makes a request such as:  
+   ```
+   GET /MyEntitySet?$select=name,email
+   ```  
+   OdataDuty converts the `$select` value into an array like `[:id, :name, :email]`—always including the key property (`:id`).
+
+2. **Invoking `od_select`:**  
+   The framework calls your `od_select` method with the array. In the example above, it uses that array to select only the `name`, `email`, and `id` columns from the `@records` collection.
+
+## Common Error Cases
+
+While implementing `$select`, note the following error scenarios that your service should handle:
+
+- **Unknown Property:**  
+  If a property specified in `$select` does not exist on the entity, an `UnknownPropertyError` will be raised.
+
+- **Nested Selection on Complex Types:**  
+  Directly selecting nested properties (e.g., `c/s`) is not supported. This will result in an `InvalidQueryOptionError`.
+
+- **Quoted Identifiers:**  
+  Property names should not be enclosed in quotes. If quotes are detected, an `InvalidQueryOptionError` will be raised.
+
+## Summary
+
+- **Custom Entity Set:**  
+  Subclass `OdataDuty::EntitySet` and implement the required methods (`od_after_init`, `collection`, `individual`), along with your custom `od_select`.
+
+- **Implementing `od_select`:**  
+  Update your internal records based on the array of selected properties—ensuring that mandatory keys like `id` are always included.
+
+- **Usage:**  
+  When clients pass a `$select` parameter, OdataDuty routes it to your `od_select` implementation to return a filtered response.
+
+By following these guidelines, you'll provide robust support for the `$select` option in your OData API.

--- a/lib/odata_duty.rb
+++ b/lib/odata_duty.rb
@@ -68,37 +68,35 @@ module OdataDuty
         entity_set.new(context: context)
       end
 
-      def collection(set_builder, context:)
+      def collection(set_builder, context:, selected:)
         begin
           values = set_builder.collection
         rescue NoMethodError
           raise NoImplementationError, "collection not implemented for #{entity_set}"
         end
 
-        mapper = entity_type.mapper(context)
+        mapper = entity_type.mapper(context, selected: selected)
 
         values.map { |v| mapper.obj_to_hash(v, context) }
       end
 
-      def individual(id, context:)
+      def individual(set_builder, id, context:, selected:)
         begin
-          result = entity_set.new(context: context).individual(converted_id(id, context))
+          result = set_builder.individual(converted_id(id, context))
         rescue NoMethodError
           raise NoImplementationError, "individual not implemented for #{entity_set}"
         end
 
         raise ResourceNotFoundError, "No such entity #{id}" unless result
 
-        mapper = entity_type.mapper(context)
-
-        mapper.obj_to_hash(result, context)
+        entity_type.mapper(context, selected: selected).obj_to_hash(result, context)
       end
 
       def create(context:)
         wrapper = CreateComplexTypeHashWrapper.new(context.query_options, entity_type, context)
         result = entity_set.new(context: context)
                            .create(wrapper)
-        mapper = entity_type.mapper(context)
+        mapper = entity_type.mapper(context, selected: nil)
         mapper.obj_to_hash(result, context)
       end
 

--- a/lib/odata_duty/dynamic_object_wrapper.rb.erb
+++ b/lib/odata_duty/dynamic_object_wrapper.rb.erb
@@ -1,6 +1,6 @@
 Class.new(MapperBuilder) do
   def to_h
-  <% complex_type.properties.each do |property| %>
+  <% properties.each do |property| %>
     <% if property.calling_method? %>
     <%= property.name %>_value = calling_methods.fetch(:<%= property.method_name %>).call(obj)
     <% elsif complex_type.respond_to?(:instance_methods) && complex_type.instance_methods.include?(property.method_name) %>
@@ -50,14 +50,14 @@ Class.new(MapperBuilder) do
   <% end %>
   <% end %>
     {
-    <% complex_type.properties.each do |property| %>
+    <% properties.each do |property| %>
       '<%= property.name %>' => <% unless property.nullable? %>not_nullable("<%= property.name %>",<% end %><%= property.name %>_value<% unless property.nullable? %>)<% end %>,
     <% end %>
     }
   end
 
   def initialize_mappers
-  <% complex_type.properties.reject(&:scalar?).each do |property| %>
+  <% properties.reject(&:scalar?).each do |property| %>
     @<%= property.name %>_mapper = MapperBuilder.build(complex_types.fetch(:<%= property.name %>))
   <% end %>
   end

--- a/lib/odata_duty/edms.rb
+++ b/lib/odata_duty/edms.rb
@@ -117,5 +117,6 @@ module OdataDuty
                     String => EdmString,
                     Date => EdmDate,
                     DateTime => EdmDateTimeOffset,
+                    Time => EdmDateTimeOffset,
                     TrueClass => EdmBool }.freeze
 end

--- a/lib/odata_duty/entity_type.rb
+++ b/lib/odata_duty/entity_type.rb
@@ -43,25 +43,29 @@ module OdataDuty
       od_context.endpoint
     end
 
-    def self.mapper(context)
+    def self.mapper(context, selected:)
       context.current['odata_url_base'] ||= context.url_for(url: context.endpoint.url)
       if property_refs.first.raw_type == EdmInt64
-        int_mapper(context)
+        int_mapper(context, selected: selected)
       else
-        string_mapper(context)
+        string_mapper(context, selected: selected)
       end
     end
 
-    def self.int_mapper(context)
-      MapperBuilder.build(self) do |result, obj|
+    def self.int_mapper(context, selected:)
+      MapperBuilder.build(self, selected: selected) do |result, obj|
         result['@odata.id'] = "#{context.current['odata_url_base']}(#{obj.id})"
       end
     end
 
-    def self.string_mapper(context)
-      MapperBuilder.build(self) do |result, obj|
+    def self.string_mapper(context, selected:)
+      MapperBuilder.build(self, selected: selected) do |result, obj|
         result['@odata.id'] = "#{context.current['odata_url_base']}('#{obj.id}')"
       end
+    end
+
+    def self._defined_at_
+      Object.const_source_location(to_s).join(':')
     end
 
     private

--- a/lib/odata_duty/errors.rb
+++ b/lib/odata_duty/errors.rb
@@ -2,6 +2,7 @@ module OdataDuty
   class Error < StandardError; end
 
   class PropertyAlreadyDefinedError < ArgumentError; end
+  class InvalidNCNamesError < ArgumentError; end
 
   class RequestError < Error
     attr_reader :code, :target

--- a/lib/odata_duty/property.rb
+++ b/lib/odata_duty/property.rb
@@ -5,15 +5,19 @@ require 'odata_duty/property/collection_prop'
 module OdataDuty
   module Property
     def self.new(name, type = String, line__defined__at: nil, nullable: true, method: nil)
-      prop_class = if type.is_a?(Array)
-                     CollectionProp
-                   else
-                     SingleProp
-                   end
+      unless valid_name?(name)
+        raise InvalidNCNamesError, "\"#{name}\" is not a valid property name"
+      end
+
+      prop_class = type.is_a?(Array) ? CollectionProp : SingleProp
       prop_class.new(name, type,
                      line__defined__at: line__defined__at,
                      nullable: nullable,
                      method: method)
+    end
+
+    def self.valid_name?(name)
+      name.to_s.match?(/\A(?:\p{L}|_)(?:[\p{L}\p{Nd}_])*\z/)
     end
   end
 end

--- a/lib/odata_duty/schema_builder/data_type.rb
+++ b/lib/odata_duty/schema_builder/data_type.rb
@@ -1,10 +1,15 @@
 module OdataDuty
   module SchemaBuilder
     class DataType
-      attr_reader :name
+      attr_reader :name, :_defined_at_
 
       def initialize(name:)
         @name = name.to_str.clone.freeze
+        @_defined_at_ = caller.find { |line| !line.include?('/lib/odata_duty/') }
+
+        return if Property.valid_name?(@name)
+
+        raise InvalidNCNamesError, "\"#{@name}\" is not a valid property name"
       end
 
       def scalar?

--- a/lib/odata_duty/schema_builder/endpoint.rb
+++ b/lib/odata_duty/schema_builder/endpoint.rb
@@ -17,36 +17,34 @@ module OdataDuty
 
       def entity_type = entity_set.entity_type
 
-      def collection(set_builder, context:)
+      def collection(set_builder, context:, selected:)
         begin
           values = set_builder.collection
         rescue NoMethodError
           raise NoImplementationError, "collection not implemented for #{entity_set}"
         end
 
-        mapper = entity_type.mapper(context)
+        mapper = entity_type.mapper(context, selected: selected)
 
         values.map { |v| mapper.obj_to_hash(v, context) }
       end
 
-      def individual(id, context:)
+      def individual(set_builder, id, context:, selected:)
         begin
-          result = new_entity_set(context: context).individual(converted_id(id, context))
+          result = set_builder.individual(converted_id(id, context))
         rescue NoMethodError
           raise NoImplementationError, "individual not implemented for #{entity_set}"
         end
 
         raise ResourceNotFoundError, "No such entity #{id}" unless result
 
-        mapper = entity_type.mapper(context)
-
-        mapper.obj_to_hash(result, context)
+        entity_type.mapper(context, selected: selected).obj_to_hash(result, context)
       end
 
       def create(context:)
         wrapper = CreateComplexTypeHashWrapper.new(context.query_options, entity_type, context)
         result = new_entity_set(context: context).create(wrapper)
-        mapper = entity_type.mapper(context)
+        mapper = entity_type.mapper(context, selected: nil)
         mapper.obj_to_hash(result, context)
       end
 

--- a/lib/odata_duty/schema_builder/entity_type.rb
+++ b/lib/odata_duty/schema_builder/entity_type.rb
@@ -22,23 +22,23 @@ module OdataDuty
         property_refs.first
       end
 
-      def mapper(context)
+      def mapper(context, selected:)
         context.current['odata_url_base'] ||= context.url_for(url: context.endpoint.url)
         if integer_property_ref?
-          int_mapper(context)
+          int_mapper(context, selected: selected)
         else
-          string_mapper(context)
+          string_mapper(context, selected: selected)
         end
       end
 
-      def int_mapper(context)
-        MapperBuilder.build(self) do |result, obj|
+      def int_mapper(context, selected:)
+        MapperBuilder.build(self, selected: selected) do |result, obj|
           result['@odata.id'] = "#{context.current['odata_url_base']}(#{obj.id})"
         end
       end
 
-      def string_mapper(context)
-        MapperBuilder.build(self) do |result, obj|
+      def string_mapper(context, selected:)
+        MapperBuilder.build(self, selected: selected) do |result, obj|
           result['@odata.id'] = "#{context.current['odata_url_base']}('#{obj.id}')"
         end
       end

--- a/odata_duty.gemspec
+++ b/odata_duty.gemspec
@@ -2,7 +2,7 @@
 
 Gem::Specification.new do |spec|
   spec.name          = 'odata_duty'
-  spec.version       = '0.8.1'
+  spec.version       = '0.9.0'
   spec.authors       = ['Grant Petersen-Speelman']
   spec.email         = ['grant@nexl.io']
 

--- a/spec/odata_duty/entity_set/select_spec.rb
+++ b/spec/odata_duty/entity_set/select_spec.rb
@@ -1,0 +1,248 @@
+require 'spec_helper'
+
+class CollectionSelectTestComplexEntity < OdataDuty::ComplexType
+  property 's', String
+end
+
+class CollectionSelectTestEntity < OdataDuty::EntityType
+  property_ref 'id', String
+  property 'i', Integer
+  property 't', Time
+  property 'c', CollectionSelectTestComplexEntity
+end
+
+class SupportsCollectionSelectSet < OdataDuty::EntitySet
+  entity_type CollectionSelectTestEntity
+
+  ALL_RECORDS = (1..2).map do |i|
+    { 'id' => i.to_s, 'i' => i, 't' => Time.at(i), 'c' => CamelSnakeStruct.new('s' => i.to_s) }
+  end
+
+  def od_after_init
+    @records = ALL_RECORDS
+  end
+
+  def od_select(select)
+    keys = select.map(&:to_s)
+    @records = @records.map { |r| r.slice(*keys) }
+  end
+
+  def collection
+    @records.map { |r| CamelSnakeStruct.new(r) }
+  end
+
+  def individual(id)
+    collection.find { |r| r.id == id }
+  end
+end
+
+class SelectlessCollectionSet < OdataDuty::EntitySet
+  entity_type CollectionSelectTestEntity
+
+  ALL_RECORDS = (1..2).map do |i|
+    CamelSnakeStruct.new('id' => i.to_s, 'i' => i, 't' => Time.at(i),
+                         'c' => OpenStruct.new(s: i.to_s))
+  end
+
+  def od_after_init
+    @records = ALL_RECORDS
+  end
+
+  def collection
+    @records
+  end
+
+  def individual(id)
+    @records.find { |r| r.id == id }
+  end
+end
+
+class CollectionSelectTestSchema < OdataDuty::Schema
+  entity_sets [SupportsCollectionSelectSet, SelectlessCollectionSet]
+end
+
+RSpec.describe OdataDuty::EntitySet, 'Can specific individual result' do
+  subject(:schema) { CollectionSelectTestSchema }
+
+  describe '#execute' do
+    describe 'individual' do
+      it do
+        json_string = schema.execute("SelectlessCollection('1')",
+                                     context: Context.new,
+                                     query_options: { '$select' => 'id,i' })
+        response = Oj.load(json_string)
+        expect(response).to eq(
+          {
+            '@odata.context' => '$metadata#SelectlessCollection/$entity',
+            '@odata.id' => 'SelectlessCollection(\'1\')',
+            'id' => '1', 'i' => 1
+          }
+        )
+      end
+
+      it do
+        json_string = schema.execute("SelectlessCollection('1')",
+                                     context: Context.new,
+                                     query_options: { '$select' => 'c' })
+        response = Oj.load(json_string)
+        expect(response).to eq(
+          {
+            '@odata.context' => '$metadata#SelectlessCollection/$entity',
+            '@odata.id' => 'SelectlessCollection(\'1\')',
+            'c' => { 's' => '1' }
+          }
+        )
+      end
+
+      it do
+        expect do
+          schema.execute("SelectlessCollection('1')",
+                         context: Context.new,
+                         query_options: { '$select' => 'id,a' })
+        end.to raise_error(OdataDuty::UnknownPropertyError)
+      end
+
+      it do
+        expect do
+          schema.execute("SelectlessCollection('1')",
+                         context: Context.new,
+                         query_options: { '$select' => 'id,c/s' })
+        end.to raise_error(OdataDuty::InvalidQueryOptionError)
+      end
+
+      it do
+        expect do
+          schema.execute("SelectlessCollection('1')",
+                         context: Context.new,
+                         query_options: { '$select' => '"id"' })
+        end.to raise_error(OdataDuty::InvalidQueryOptionError)
+      end
+
+      it do
+        expect_any_instance_of(SupportsCollectionSelectSet)
+          .to receive(:od_select).with(%i[id i]).and_call_original
+        json_string = schema.execute("SupportsCollectionSelect('1')",
+                                     context: Context.new,
+                                     query_options: { '$select' => 'id,i' })
+        response = Oj.load(json_string)
+        expect(response).to eq(
+          {
+            '@odata.context' => '$metadata#SupportsCollectionSelect/$entity',
+            '@odata.id' => 'SupportsCollectionSelect(\'1\')',
+            'id' => '1', 'i' => 1
+          }
+        )
+      end
+
+      it do
+        expect_any_instance_of(SupportsCollectionSelectSet)
+          .to receive(:od_select).with(%i[c id]).and_call_original
+        json_string = schema.execute("SupportsCollectionSelect('1')",
+                                     context: Context.new,
+                                     query_options: { '$select' => 'c' })
+        response = Oj.load(json_string)
+        expect(response).to eq(
+          {
+            '@odata.context' => '$metadata#SupportsCollectionSelect/$entity',
+            '@odata.id' => 'SupportsCollectionSelect(\'1\')',
+            'c' => { 's' => '1' }
+          }
+        )
+      end
+    end
+
+    describe 'collection' do
+      it do
+        json_string = schema.execute('SelectlessCollection',
+                                     context: Context.new,
+                                     query_options: { '$select' => 'id,i' })
+        response = Oj.load(json_string)
+        expect(response).to eq(
+          {
+            '@odata.context' => '$metadata#SelectlessCollection',
+            'value' => [{ '@odata.id' => 'SelectlessCollection(\'1\')',
+                          'id' => '1', 'i' => 1 },
+                        { '@odata.id' => 'SelectlessCollection(\'2\')',
+                          'id' => '2', 'i' => 2 }]
+          }
+        )
+      end
+
+      it do
+        json_string = schema.execute('SelectlessCollection',
+                                     context: Context.new,
+                                     query_options: { '$select' => 'c' })
+        response = Oj.load(json_string)
+        expect(response).to eq(
+          {
+            '@odata.context' => '$metadata#SelectlessCollection',
+            'value' => [{ '@odata.id' => 'SelectlessCollection(\'1\')',
+                          'c' => { 's' => '1' } },
+                        { '@odata.id' => 'SelectlessCollection(\'2\')',
+                          'c' => { 's' => '2' } }]
+          }
+        )
+      end
+
+      it do
+        expect do
+          schema.execute('SelectlessCollection',
+                         context: Context.new,
+                         query_options: { '$select' => 'id,a' })
+        end.to raise_error(OdataDuty::UnknownPropertyError)
+      end
+
+      it do
+        expect do
+          schema.execute('SelectlessCollection',
+                         context: Context.new,
+                         query_options: { '$select' => 'id,c/s' })
+        end.to raise_error(OdataDuty::InvalidQueryOptionError)
+      end
+
+      it do
+        expect do
+          schema.execute('SelectlessCollection',
+                         context: Context.new,
+                         query_options: { '$select' => '"id"' })
+        end.to raise_error(OdataDuty::InvalidQueryOptionError)
+      end
+
+      it do
+        expect_any_instance_of(SupportsCollectionSelectSet)
+          .to receive(:od_select).with(%i[id i]).and_call_original
+        json_string = schema.execute('SupportsCollectionSelect',
+                                     context: Context.new,
+                                     query_options: { '$select' => 'id,i' })
+        response = Oj.load(json_string)
+        expect(response).to eq(
+          {
+            '@odata.context' => '$metadata#SupportsCollectionSelect',
+            'value' => [{ '@odata.id' => 'SupportsCollectionSelect(\'1\')',
+                          'id' => '1', 'i' => 1 },
+                        { '@odata.id' => 'SupportsCollectionSelect(\'2\')',
+                          'id' => '2', 'i' => 2 }]
+          }
+        )
+      end
+
+      it do
+        expect_any_instance_of(SupportsCollectionSelectSet)
+          .to receive(:od_select).with(%i[c id]).and_call_original
+        json_string = schema.execute('SupportsCollectionSelect',
+                                     context: Context.new,
+                                     query_options: { '$select' => 'c' })
+        response = Oj.load(json_string)
+        expect(response).to eq(
+          {
+            '@odata.context' => '$metadata#SupportsCollectionSelect',
+            'value' => [{ '@odata.id' => 'SupportsCollectionSelect(\'1\')',
+                          'c' => { 's' => '1' } },
+                        { '@odata.id' => 'SupportsCollectionSelect(\'2\')',
+                          'c' => { 's' => '2' } }]
+          }
+        )
+      end
+    end
+  end
+end

--- a/spec/odata_duty/schema_builder/entity_set/select_spec.rb
+++ b/spec/odata_duty/schema_builder/entity_set/select_spec.rb
@@ -1,0 +1,242 @@
+require 'spec_helper'
+
+class SupportsCollectionSelectResolver < OdataDuty::SetResolver
+  ALL_RECORDS = (1..2).map do |i|
+    { 'id' => i.to_s, 'i' => i, 't' => Time.at(i), 'c' => OpenStruct.new(s: i.to_s) }
+  end
+  SELECTED_RECORDS = (1..2).map do |i| # used to prove od_select is called
+    { 'id' => i.to_s, 'i' => i + 2, 't' => Time.at(i + 2), 'c' => OpenStruct.new(s: (i + 2).to_s) }
+  end
+
+  def od_after_init
+    @records = ALL_RECORDS
+  end
+
+  def od_select(select)
+    keys = select.map(&:to_s) + ['id']
+    @records = SELECTED_RECORDS.map { |r| r.slice(*keys) }
+  end
+
+  def collection
+    @records.map { |r| CamelSnakeStruct.new(r) }
+  end
+
+  def individual(id)
+    collection.find { |r| r.id == id }
+  end
+end
+
+class SelectlessCollectionResolver < OdataDuty::SetResolver
+  ALL_RECORDS = (1..2).map do |i|
+    CamelSnakeStruct.new('id' => i.to_s, 'i' => i, 't' => Time.at(i),
+                         'c' => CamelSnakeStruct.new('s' => i.to_s))
+  end
+
+  def od_after_init
+    @records = ALL_RECORDS
+  end
+
+  def collection
+    @records
+  end
+
+  def individual(id)
+    @records.find { |r| r.id == id }
+  end
+end
+
+module OdataDuty
+  RSpec.describe SchemaBuilder::EntitySet, 'Can select specific properties in the return result' do
+    subject(:schema) do
+      SchemaBuilder.build(namespace: 'SampleSpace', host: 'localhost') do |s|
+        complex = s.add_entity_type(name: 'CollectionSelectTestComplex') do |et|
+          et.property 's', String
+        end
+
+        entity = s.add_entity_type(name: 'CollectionSelectTest') do |et|
+          et.property_ref 'id', String
+          et.property 'i', Integer
+          et.property 't', Time
+          et.property 'c', complex
+        end
+
+        s.add_entity_set(entity_type: entity, resolver: 'SelectlessCollectionResolver')
+        s.add_entity_set(entity_type: entity, resolver: 'SupportsCollectionSelectResolver')
+      end
+    end
+
+    describe '#execute' do
+      describe 'individual' do
+        it do
+          json_string = schema.execute("SelectlessCollection('1')",
+                                       context: Context.new,
+                                       query_options: { '$select' => 'id,i' })
+          response = Oj.load(json_string)
+          expect(response).to eq(
+            {
+              '@odata.context' => '$metadata#SelectlessCollection/$entity',
+              '@odata.id' => 'SelectlessCollection(\'1\')',
+              'id' => '1', 'i' => 1
+            }
+          )
+        end
+
+        it do
+          json_string = schema.execute("SelectlessCollection('1')",
+                                       context: Context.new,
+                                       query_options: { '$select' => 'c' })
+          response = Oj.load(json_string)
+          expect(response).to eq(
+            {
+              '@odata.context' => '$metadata#SelectlessCollection/$entity',
+              '@odata.id' => 'SelectlessCollection(\'1\')',
+              'c' => { 's' => '1' }
+            }
+          )
+        end
+
+        it do
+          expect do
+            schema.execute("SelectlessCollection('1')",
+                           context: Context.new,
+                           query_options: { '$select' => 'id,a' })
+          end.to raise_error(OdataDuty::UnknownPropertyError)
+        end
+
+        it do
+          expect do
+            schema.execute("SelectlessCollection('1')",
+                           context: Context.new,
+                           query_options: { '$select' => 'id,c/s' })
+          end.to raise_error(OdataDuty::InvalidQueryOptionError)
+        end
+
+        it do
+          expect do
+            schema.execute("SelectlessCollection('1')",
+                           context: Context.new,
+                           query_options: { '$select' => '"id"' })
+          end.to raise_error(OdataDuty::InvalidQueryOptionError)
+        end
+
+        it do
+          json_string = schema.execute("SupportsCollectionSelect('1')",
+                                       context: Context.new,
+                                       query_options: { '$select' => 'id,i' })
+          response = Oj.load(json_string)
+          expect(response).to eq(
+            {
+              '@odata.context' => '$metadata#SupportsCollectionSelect/$entity',
+              '@odata.id' => 'SupportsCollectionSelect(\'1\')',
+              'id' => '1', 'i' => 3
+            }
+          )
+        end
+
+        it do
+          json_string = schema.execute("SupportsCollectionSelect('1')",
+                                       context: Context.new,
+                                       query_options: { '$select' => 'c' })
+          response = Oj.load(json_string)
+          expect(response).to eq(
+            {
+              '@odata.context' => '$metadata#SupportsCollectionSelect/$entity',
+              '@odata.id' => 'SupportsCollectionSelect(\'1\')',
+              'c' => { 's' => '3' }
+            }
+          )
+        end
+      end
+
+      describe 'collection' do
+        it do
+          json_string = schema.execute('SelectlessCollection',
+                                       context: Context.new,
+                                       query_options: { '$select' => 'id,i' })
+          response = Oj.load(json_string)
+          expect(response).to eq(
+            {
+              '@odata.context' => '$metadata#SelectlessCollection',
+              'value' => [{ '@odata.id' => 'SelectlessCollection(\'1\')',
+                            'id' => '1', 'i' => 1 },
+                          { '@odata.id' => 'SelectlessCollection(\'2\')',
+                            'id' => '2', 'i' => 2 }]
+            }
+          )
+        end
+
+        it do
+          json_string = schema.execute('SelectlessCollection',
+                                       context: Context.new,
+                                       query_options: { '$select' => 'c' })
+          response = Oj.load(json_string)
+          expect(response).to eq(
+            {
+              '@odata.context' => '$metadata#SelectlessCollection',
+              'value' => [{ '@odata.id' => 'SelectlessCollection(\'1\')',
+                            'c' => { 's' => '1' } },
+                          { '@odata.id' => 'SelectlessCollection(\'2\')',
+                            'c' => { 's' => '2' } }]
+            }
+          )
+        end
+
+        it do
+          expect do
+            schema.execute('SelectlessCollection',
+                           context: Context.new,
+                           query_options: { '$select' => 'id,a' })
+          end.to raise_error(OdataDuty::UnknownPropertyError)
+        end
+
+        it do
+          expect do
+            schema.execute('SelectlessCollection',
+                           context: Context.new,
+                           query_options: { '$select' => 'id,c/s' })
+          end.to raise_error(OdataDuty::InvalidQueryOptionError)
+        end
+
+        it do
+          expect do
+            schema.execute('SelectlessCollection',
+                           context: Context.new,
+                           query_options: { '$select' => '"id"' })
+          end.to raise_error(OdataDuty::InvalidQueryOptionError)
+        end
+
+        it do
+          json_string = schema.execute('SupportsCollectionSelect',
+                                       context: Context.new,
+                                       query_options: { '$select' => 'id,i' })
+          response = Oj.load(json_string)
+          expect(response).to eq(
+            {
+              '@odata.context' => '$metadata#SupportsCollectionSelect',
+              'value' => [{ '@odata.id' => 'SupportsCollectionSelect(\'1\')',
+                            'id' => '1', 'i' => 3 },
+                          { '@odata.id' => 'SupportsCollectionSelect(\'2\')',
+                            'id' => '2', 'i' => 4 }]
+            }
+          )
+        end
+
+        it do
+          json_string = schema.execute('SupportsCollectionSelect',
+                                       context: Context.new,
+                                       query_options: { '$select' => 'c' })
+          response = Oj.load(json_string)
+          expect(response).to eq(
+            {
+              '@odata.context' => '$metadata#SupportsCollectionSelect',
+              'value' => [{ '@odata.id' => 'SupportsCollectionSelect(\'1\')',
+                            'c' => { 's' => '3' } },
+                          { '@odata.id' => 'SupportsCollectionSelect(\'2\')',
+                            'c' => { 's' => '4' } }]
+            }
+          )
+        end
+      end
+    end
+  end
+end

--- a/spec/odata_duty/schema_builder/entity_type/entity_type_name_spec.rb
+++ b/spec/odata_duty/schema_builder/entity_type/entity_type_name_spec.rb
@@ -1,0 +1,23 @@
+require 'spec_helper'
+
+module OdataDuty
+  RSpec.describe SchemaBuilder::EntityType, 'Can setup property refs' do
+    describe 'name' do
+      it do
+        expect do
+          SchemaBuilder.build(namespace: 'SampleSpace', host: 'localhost') do |s|
+            s.add_entity_type(name: '0')
+          end
+        end.to raise_error(InvalidNCNamesError, '"0" is not a valid property name')
+      end
+
+      it do
+        expect do
+          SchemaBuilder.build(namespace: 'SampleSpace', host: 'localhost') do |s|
+            s.add_entity_type(name: 'a b')
+          end
+        end.to raise_error(InvalidNCNamesError, '"a b" is not a valid property name')
+      end
+    end
+  end
+end

--- a/spec/odata_duty/schema_builder/entity_type/property_spec.rb
+++ b/spec/odata_duty/schema_builder/entity_type/property_spec.rb
@@ -25,6 +25,28 @@ module OdataDuty
           end
         end.to raise_error(PropertyAlreadyDefinedError, 'another is already defined')
       end
+
+      it do
+        expect do
+          SchemaBuilder.build(namespace: 'SampleSpace', host: 'localhost') do |s|
+            s.add_entity_type(name: 'StringRef') do |et|
+              et.property_ref 'id', String
+              et.property '0', String
+            end
+          end
+        end.to raise_error(InvalidNCNamesError, '"0" is not a valid property name')
+      end
+
+      it do
+        expect do
+          SchemaBuilder.build(namespace: 'SampleSpace', host: 'localhost') do |s|
+            s.add_entity_type(name: 'StringRef') do |et|
+              et.property_ref 'id', String
+              et.property 'a b', String
+            end
+          end
+        end.to raise_error(InvalidNCNamesError, '"a b" is not a valid property name')
+      end
     end
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,6 +1,7 @@
 require 'byebug'
 require 'nokogiri'
 require 'odata_duty'
+require 'camel_snake_struct'
 
 class String
   def to_date
@@ -117,4 +118,5 @@ RSpec.configure do |config|
     # (e.g. via a command-line flag).
     config.default_formatter = 'doc'
   end
+  config.seed = srand % 0xFFFF
 end


### PR DESCRIPTION
This PR introduces support for the `$select` query option in `OdataDuty`. It enables developers to restrict returned properties by implementing an optional `od_select` method on custom `OdataDuty::EntitySet` classes. The change includes updates to internal record selection logic, validations for common error cases (such as unknown properties, nested selections, and quoted identifiers), corresponding tests, and documentation updates in `using_select.md`.

suggest viewing the doc first : https://github.com/NEXL-LTS/odata_duty-ruby/pull/15/files?short_path=0255d35#diff-0255d35464743bb745e76da5d2d1e5b4fb43a88873d0caa6fc94a5a16add940e 