### PR TITLE
POC: initial support for the MCP protocol

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,8 +192,8 @@ end
 ## 📚 Further Documentation
 
 - [OData Crash Course](doc/odata_crash_course.md)
+- [MCP Crash Course](doc/mcp_crash_course.md)
 - [Using `$select`](doc/using_select.md)
-- [MCP Integration (coming soon)](doc/mcp.md)
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,19 @@
 # OdataDuty
 
-Write OData compatible APIs in Ruby with the goal of easily connection your application to Microsoft PowerBI and PowerAutomate.
+**OdataDuty** is a Ruby gem that lets you define structured data and operations once using a simple DSL — and expose them seamlessly to analytics tools (like PowerBI), no-code platforms (like PowerAutomate), and AI systems (via JSON-RPC or the Model Context Protocol).
+
+It’s designed around the principle of _"define once, serve everywhere"_: you model your entities, properties, filters, and behaviors in Ruby, and OdataDuty takes care of transforming that into formats and protocols your tools and agents understand.
+
+---
+
+## ✨ Why use OdataDuty?
+
+- ✅ Define your data model and logic in plain Ruby
+- ✅ Support schema-based APIs (OpenAPI/Swagger)
+- ✅ Avoid repeating business logic in multiple layers or formats
+- ✅ Build for humans and works with reporting tools, automation tools, and LLMs (WIP) simultaneously
+
+---
 
 ## Installation
 
@@ -12,32 +25,38 @@ gem 'odata_duty'
 
 And then execute:
 
-    $ bundle install
+```bash
+bundle install
+```
 
-Or install it yourself as:
+Or install it manually:
 
-    $ gem install odata_duty
+```bash
+gem install odata_duty
+```
 
-## Usage
+---
 
-The gem assumes some familiarity with OData concepts. If you're new to OData, you may want to check out the [OData Crash Course](doc/odata_crash_course.md) to get a quick overview of the core concepts.
+## Getting Started
 
-### Key Features
+> The gem assumes basic familiarity with OData concepts.  
+> If you’re new, check out the [OData Crash Course](doc/odata_crash_course.md).
 
-- **Define Entities and Properties**: Easily define your OData entities and their properties using simple Ruby classes.
-- **Handle Collections**: Manage collections of entities with support for filtering, paging, and counting.
-- **Support for Complex Types and Enums**: Define and use complex types and enumerations within your entities.
-- **Retrieve Individual Items**: Implement methods to fetch individual entities by their keys.
-- **Schema Definition**: Organize and expose your OData entities using schemas.
+### 🔧 Key Features
 
-#### Quick Example
+- **Entity and property definition** using a simple DSL
+- **Filtering, paging, and count support**
+- **Complex types and enums**
+- **Individual item retrieval and creation**
+- **Schema introspection and OpenAPI generation**
 
-Here's a quick example demonstrating how to define entities, manage collections, and handle individual items.
+---
+
+## DSL Quick Example
 
 ```ruby
 require 'odata_duty'
 
-# Define an entity type
 class PersonEntity < OdataDuty::EntityType
   property_ref 'id', String
   property 'user_name', String, nullable: false
@@ -45,7 +64,6 @@ class PersonEntity < OdataDuty::EntityType
   property 'emails', [String], nullable: false
 end
 
-# Define a collection set
 class PeopleSet < OdataDuty::EntitySet
   entity_type PersonEntity
 
@@ -66,59 +84,41 @@ class PeopleSet < OdataDuty::EntitySet
   end
 end
 
-# Define the schema
 class SampleSchema < OdataDuty::Schema
   namespace 'SampleSpace'
   entity_sets [PeopleSet]
+  base_url Rails.application.routes.url_helpers.api_root_url
 end
-
-# Example usage
-schema = SampleSchema.new
-puts schema.execute('People')
-puts schema.execute("People('1')")
 ```
 
-#### Quick Dynamic Example with Rails
+---
+
+## Rails Integration Example
 
 ```ruby
-# add to routes.rb
-
+# config/routes.rb
 scope '/api' do
   root 'api#index'
-  get '$metadata' => 'api#metadata', as: 'metadata'
-  get '$oas2' => 'api#oas2', as: 'oas2'
-  get '*url' => 'api#show', as: 'show'
-  post '*url' => 'api#create', as: 'create'
+  get '$metadata' => 'api#metadata'
+  get '$oas2' => 'api#oas2'
+  get '*url' => 'api#show'
+  post '*url' => 'api#create'
 end
 ```
 
 ```ruby
-rescue_from OdataDuty::RequestError do |error|
-  render json: { error: { code: error.code, error: error.message, target: error.target } }, 
-         status: error.status
-end
+# app/controllers/api_controller.rb
 
-rescue_from ActiveRecord::StatementInvalid do |error|
-  render json: { error: { code: 'StatementInvalid', error: error.message } }, 
-         status: :bad_request
-end
-
-rescue_from ActiveRecord::RecordNotFound do |error|
-  render json: { error: { code: 'RecordNotFound', error: error.message } }, 
-         status: :not_found
-end
-
-# add to api_controller.rb
-def index # OData Service Index
+def index
   render json: OdataDuty::EdmxSchema.index_hash(schema)
 end
 
-def metadata # OData metadata
+def metadata
   render xml: OdataDuty::EdmxSchema.metadata_xml(schema)
 end
 
-def oas2 # OpenAPI 2.0 (Swagger) schema
-  render xml: OdataDuty::OAS2.build_json(schema)
+def oas2
+  render json: OdataDuty::OAS2.build_json(schema)
 end
 
 def show
@@ -151,41 +151,26 @@ end
 ```
 
 ```ruby
-# add to people_resolver.rb
+# app/models/people_resolver.rb
 class PeopleResolver < OdataDuty::SetResolver
   def od_after_init
     @records = Person.all
   end
 
-  # eq: Test whether a field is equal to
   def od_filter_eq(property_name, value)
     @records = @records.where(property_name.to_sym => value)
   end
 
-  # ne: Test whether a field is not equal to
   def od_filter_ne(property_name, value)
     @records = @records.where.not(property_name.to_sym => value)
   end
 
-  # gt: Test whether a field is greater than
   def od_filter_gt(property_name, value)
-    @records = @records.where("#{@records.table_name}.#{property_name} > ?", value)
+    @records = @records.where("#{property_name} > ?", value)
   end
 
-  # ge: Test whether a field is greater than or equal
-  def od_filter_ge(property_name, value)
-    @records = @records.where(property_name.to_sym => value..)
-  end
-
-  # lt: Test whether a field is less than
   def od_filter_lt(property_name, value)
-    @records = @records.where(property_name.to_sym => ...value)
-  end
-
-  # le: Test whether a field is less than or equal to
-  def od_filter_le(property_name, value)
-    assert_filterable_property(property_name)
-    @records = @records.where(property_name.to_sym => ..value)
+    @records = @records.where("#{property_name} < ?", value)
   end
 
   def count
@@ -202,21 +187,51 @@ class PeopleResolver < OdataDuty::SetResolver
 end
 ```
 
-## Further documentation
+---
 
+## 📚 Further Documentation
+
+- [OData Crash Course](doc/odata_crash_course.md)
 - [Using `$select`](doc/using_select.md)
+- [MCP Integration (coming soon)](doc/mcp.md)
+
+---
 
 ## TODO
 
-* add support for composite keys
-* add support for descriptions
+- Add support for composite keys
+- Add support for schema descriptions
+- Extend protocol adapters (MCP tools, resource reading)
+
+---
 
 ## Development
 
-After checking out the repo, run `bin/setup` to install dependencies. Then, run `rake spec` to run the tests. You can also run `bin/console` for an interactive prompt that will allow you to experiment.
+```bash
+bin/setup     # Install dependencies
+rake spec     # Run the test suite
+bin/console   # Open interactive console
+```
 
-To install this gem onto your local machine, run `bundle exec rake install`. To release a new version, update the version number in `version.rb`, and then run `bundle exec rake release`, which will create a git tag for the version, push git commits and the created tag, and push the `.gem` file to [rubygems.org](https://rubygems.org).
+To install this gem locally:
+
+```bash
+bundle exec rake install
+```
+
+To release a new version:
+
+```bash
+bundle exec rake release
+```
+
+---
 
 ## Contributing
 
-Bug reports and pull requests are welcome on GitHub at https://github.com/[USERNAME]/odata_duty.
+Bug reports and pull requests are welcome on GitHub at [github.com/[USERNAME]/odata_duty](https://github.com/[USERNAME]/odata_duty).
+
+If you're interested in extending the DSL to support new protocols or tool integrations, open an issue or start a discussion — the architecture is designed for extensibility.
+```
+
+---

--- a/benchmarks/flat.rb
+++ b/benchmarks/flat.rb
@@ -73,7 +73,7 @@ def simple_test(context = Context.new)
       'string_val' => data.string_val&.to_str, 'date_val' => data.date_val&.iso8601,
       'datetime_val' => data.datetime_val&.iso8601,
       'bool_val' => BOOLEANS.include?(data.bool_val) && data.bool_val,
-      '@odata.id' => "#{base_url}('#{data.id}')" }
+      '@odata.id' => "http://localhost/#{base_url}('#{data.id}')" }
   end
   Oj.dump('value' => result, mode: :compat)
 end

--- a/benchmarks/nested.rb
+++ b/benchmarks/nested.rb
@@ -89,7 +89,7 @@ def simple_test(context = Context.new)
     { 'id' => nested_data.id,
       'sample1' => build_sample(nested_data.sample1),
       'sample2' => build_sample(nested_data.sample2),
-      '@odata.id' => "#{base_url}('#{nested_data.id}')" }
+      '@odata.id' => "http://localhost/#{base_url}('#{nested_data.id}')" }
   end
   Oj.dump('value' => result, mode: :compat)
 end

--- a/doc/mcp_crash_course.md
+++ b/doc/mcp_crash_course.md
@@ -1,0 +1,59 @@
+# Model Context Protocol Crash Course: Key Concepts and Terminology
+
+The [Model Context Protocol](https://modelcontextprotocol.io) (MCP) is an open protocol that enables seamless integration between LLM applications and external data sources and tools. Here's a quick overview of the core concepts:
+
+## 1. Architecture Components
+
+- **Host:**  
+  The application that initiates connections and coordinates between clients and LLMs. Hosts manage multiple clients, enforce security policies, and handle user authorization.
+  
+- **Client:**  
+  A connector within the host application that maintains a 1:1 relationship with a server. Clients establish stateful sessions, handle protocol negotiation, and route messages.
+
+- **Server:**  
+  A service that provides context and capabilities to LLM applications. Servers expose resources, tools, and prompts while operating independently with focused responsibilities.
+
+## 2. Core Primitives
+
+- **Resources:**  
+  Structured data or content that provides additional context to the language model. Resources are application-controlled and represent contextual information like file contents, database records, or API results.
+  
+- **Prompts:**  
+  Pre-defined templates or instructions that guide language model interactions. Prompts are user-controlled and represent interactive elements like slash commands or menu options.
+  
+- **Tools:**  
+  Executable functions that allow models to perform actions or retrieve information. Tools are model-controlled and represent capabilities like API requests, data transformations, or file operations.
+
+- **Sampling:**  
+  A client-side feature that enables server-initiated agentic behaviors and recursive LLM interactions. Sampling allows servers to request LLM processing while maintaining appropriate security boundaries.
+
+## 3. Protocol Mechanics
+
+- **Base Protocol:**  
+  MCP uses [JSON-RPC](https://www.jsonrpc.org/) 2.0 as its message format, supporting three types of messages:
+  - **Requests:** Bidirectional messages expecting a response
+  - **Responses:** Successful results or errors matching specific request IDs
+  - **Notifications:** One-way messages requiring no response
+  
+- **Capability Negotiation:**  
+  Clients and servers explicitly declare their supported features during initialization. This determines which protocol primitives are available during a session.
+
+- **Lifecycle Management:**  
+  The protocol manages connection initialization, capability exchange, and session control to maintain a stateful connection between clients and servers.
+
+## 4. Key Design Principles
+
+- Servers should be extremely easy to build
+- Servers should be highly composable
+- Servers should not be able to read the whole conversation or "see into" other servers
+- Features can be added to servers and clients progressively
+
+## Summary
+
+- **Host Applications** create and manage multiple **Clients**, each connecting to a specific **Server**
+- **Resources**, **Prompts**, and **Tools** are the fundamental primitives servers expose
+- The protocol uses **JSON-RPC** messages for standardized communication
+- **Capability negotiation** ensures clients and servers understand supported functionality
+- Strong **security boundaries** protect user data and ensure appropriate consent
+- MCP enables powerful AI integrations while maintaining control and security
+

--- a/lib/odata_duty.rb
+++ b/lib/odata_duty.rb
@@ -5,6 +5,7 @@ require 'odata_duty/set_resolver'
 require 'odata_duty/schema_builder'
 require 'odata_duty/edmx_schema'
 require 'odata_duty/executor'
+require 'odata_duty/mcp_executor'
 require 'odata_duty/oas2'
 require 'odata_duty/property'
 require 'odata_duty/enum_type'
@@ -149,6 +150,20 @@ module OdataDuty
       @entity_sets
     end
 
+    def self.base_url(url = nil)
+      @base_url = url if url
+      @base_url
+    end
+
+    def self.host(host = nil)
+      @host = host if host
+      @host
+    end
+
+    def self.edmx_schema
+      EdmxSchema.new(self)
+    end
+
     class Metadata
       attr_reader :schema
 
@@ -236,11 +251,13 @@ module OdataDuty
     end
 
     def self.execute(url, context:, query_options: {})
-      Executor.execute(url: url, context: context, query_options: query_options, schema: self)
+      Executor.execute(url: url, context: context,
+                       query_options: query_options, schema: self)
     end
 
     def self.create(url, context:, query_options: {})
-      Executor.create(url: url, context: context, query_options: query_options, schema: self)
+      Executor.create(url: url, context: context,
+                      query_options: query_options, schema: self)
     end
   end
 end

--- a/lib/odata_duty.rb
+++ b/lib/odata_duty.rb
@@ -155,15 +155,6 @@ module OdataDuty
       @base_url
     end
 
-    def self.host(host = nil)
-      @host = host if host
-      @host
-    end
-
-    def self.edmx_schema
-      EdmxSchema.new(self)
-    end
-
     class Metadata
       attr_reader :schema
 

--- a/lib/odata_duty.rb
+++ b/lib/odata_duty.rb
@@ -242,13 +242,11 @@ module OdataDuty
     end
 
     def self.execute(url, context:, query_options: {})
-      Executor.execute(url: url, context: context,
-                       query_options: query_options, schema: self)
+      Executor.execute(url: url, context: context, query_options: query_options, schema: self)
     end
 
     def self.create(url, context:, query_options: {})
-      Executor.create(url: url, context: context,
-                      query_options: query_options, schema: self)
+      Executor.create(url: url, context: context, query_options: query_options, schema: self)
     end
   end
 end

--- a/lib/odata_duty/entity_type.rb
+++ b/lib/odata_duty/entity_type.rb
@@ -44,7 +44,7 @@ module OdataDuty
     end
 
     def self.mapper(context, selected:)
-      context.current['odata_url_base'] ||= context.url_for(url: context.endpoint.url)
+      context.current['odata_url_base'] ||= context.od_full_url(context.endpoint.url)
       if property_refs.first.raw_type == EdmInt64
         int_mapper(context, selected: selected)
       else

--- a/lib/odata_duty/mcp_executor.rb
+++ b/lib/odata_duty/mcp_executor.rb
@@ -1,0 +1,92 @@
+require 'uri'
+
+module OdataDuty
+  class MCPExecutor
+    def self.handle(**kwargs)
+      new(**kwargs).handle
+    end
+
+    attr_reader :request_hash, :schema, :context
+
+    def initialize(request_hash:, schema:, context:)
+      @request_hash = request_hash
+      @schema = schema
+      @context = context
+    end
+
+    def uri
+      @uri ||= URI.parse(request_hash['params']['uri'])
+    end
+
+    def handle
+      result = case request_hash['method']
+               when 'initialize' then handle_initialize
+               when 'resources/list' then handle_resources_list
+               when 'resources/templates/list' then handle_resources_templates_list
+               when 'resources/read'
+                 { 'contents' => [{
+                   'uri' => uri.path,
+                   'mimeType' => 'application/json',
+                   'text' => handle_resources_read.to_s
+                 }] }
+               end
+
+      return nil if result.nil?
+
+      Oj.dump('jsonrpc' => '2.0', 'id' => request_hash['id'], 'result' => result)
+    end
+
+    private
+
+    def handle_initialize
+      {
+        'protocolVersion' => '2024-11-05',
+        'capabilities' => {
+          'logging' => {},
+          'prompts' => { 'listChanged' => false },
+          'resources' => { 'subscribe' => false, 'listChanged' => false },
+          'tools' => { 'listChanged' => false }
+        },
+        'serverInfo' => {
+          'name' => schema.title,
+          'version' => schema.version
+        }
+        # "instructions": "Optional instructions for the client"
+      }
+    end
+
+    def handle_resources_read
+      query_options = CGI.parse(uri.query || '').transform_values(&:first)
+      Executor.execute(url: uri.path,
+                       context: @context,
+                       query_options: query_options,
+                       schema: schema)
+    end
+
+    def handle_resources_list
+      resources_list = schema.endpoints.flat_map { |endpoint| resources_for_endpoint(endpoint) }
+      { 'resources' => resources_list.select { |r| r.key?('uri') } }
+    end
+
+    def handle_resources_templates_list
+      resources_list = schema.endpoints.flat_map { |endpoint| resources_for_endpoint(endpoint) }
+      { 'resourceTemplates' => resources_list.select { |r| r.key?('uriTemplate') } }
+    end
+
+    def resources_for_endpoint(endpoint)
+      name = endpoint.name
+      [{ 'uriTemplate' => "#{endpoint.url}('{id}')",
+         'name' => endpoint.entity_type.name,
+         'description' => "Retrieve a specific #{endpoint.entity_type.name} record by ID",
+         'mimeType' => 'application/json' },
+       { 'uriTemplate' => "#{endpoint.url}?$top={top}&$skip={skip}",
+         'name' => "Paginated #{name} Collection",
+         'description' => "Retrieve paginated #{name} records",
+         'mimeType' => 'application/json' },
+       { 'uri' => "#{endpoint.url}/$count",
+         'name' => "#{name} Count",
+         'description' => "Get a count of #{name} records",
+         'mimeType' => 'text/plain' }]
+    end
+  end
+end

--- a/lib/odata_duty/schema_builder.rb
+++ b/lib/odata_duty/schema_builder.rb
@@ -98,13 +98,8 @@ module OdataDuty
         EdmxSchema.metadata_xml(self)
       end
 
-      def index_hash(metadata_url)
-        {
-          '@odata.context': metadata_url,
-          value: endpoints.map do |e|
-            { name: e.name, kind: e.kind, url: e.url }
-          end
-        }
+      def index_hash
+        EdmxSchema.index_hash(self)
       end
 
       private

--- a/lib/odata_duty/schema_builder.rb
+++ b/lib/odata_duty/schema_builder.rb
@@ -95,16 +95,7 @@ module OdataDuty
       end
 
       def metadata_xml
-        require 'erb'
-
-        # Create a metadata variable for the template
-        metadata = self
-
-        b = binding
-        # create and run templates, filling member data variables
-        erb = ERB.new(File.read("#{File.dirname(__FILE__)}/../metadata.xml.erb"), trim_mode: '<>')
-        erb.location = ["#{File.dirname(__FILE__)}/../metadata.xml.erb", 1]
-        erb.result b
+        EdmxSchema.metadata_xml(self)
       end
 
       def index_hash(metadata_url)

--- a/lib/odata_duty/schema_builder.rb
+++ b/lib/odata_duty/schema_builder.rb
@@ -90,6 +90,32 @@ module OdataDuty
         Executor.create(url: url, context: context, query_options: query_options, schema: self)
       end
 
+      def handle_jsonrpc(request_hash, context:)
+        MCPExecutor.handle(request_hash: request_hash, schema: self, context: context)
+      end
+
+      def metadata_xml
+        require 'erb'
+
+        # Create a metadata variable for the template
+        metadata = self
+
+        b = binding
+        # create and run templates, filling member data variables
+        erb = ERB.new(File.read("#{File.dirname(__FILE__)}/../metadata.xml.erb"), trim_mode: '<>')
+        erb.location = ["#{File.dirname(__FILE__)}/../metadata.xml.erb", 1]
+        erb.result b
+      end
+
+      def index_hash(metadata_url)
+        {
+          '@odata.context': metadata_url,
+          value: endpoints.map do |e|
+            { name: e.name, kind: e.kind, url: e.url }
+          end
+        }
+      end
+
       private
 
       def add_type(type)

--- a/lib/odata_duty/schema_builder/container.rb
+++ b/lib/odata_duty/schema_builder/container.rb
@@ -1,10 +1,15 @@
 module OdataDuty
   module SchemaBuilder
     class Container
-      attr_reader :name
+      attr_reader :name, :_defined_at_
 
       def initialize(name:)
         @name = name.to_str.clone.freeze
+        @_defined_at_ = caller.find { |line| !line.include?('/lib/odata_duty/') }
+
+        return if Property.valid_name?(@name)
+
+        raise InvalidNCNamesError, "\"#{@name}\" is not a valid property name"
       end
     end
   end

--- a/lib/odata_duty/schema_builder/entity_type.rb
+++ b/lib/odata_duty/schema_builder/entity_type.rb
@@ -23,7 +23,7 @@ module OdataDuty
       end
 
       def mapper(context, selected:)
-        context.current['odata_url_base'] ||= context.url_for(url: context.endpoint.url)
+        context.current['odata_url_base'] ||= context.od_full_url(context.endpoint.url)
         if integer_property_ref?
           int_mapper(context, selected: selected)
         else

--- a/odata_duty.gemspec
+++ b/odata_duty.gemspec
@@ -2,13 +2,13 @@
 
 Gem::Specification.new do |spec|
   spec.name          = 'odata_duty'
-  spec.version       = '0.9.0'
+  spec.version       = '0.10.0'
   spec.authors       = ['Grant Petersen-Speelman']
   spec.email         = ['grant@nexl.io']
 
-  spec.summary       = 'Write OData compatible APIs'
+  spec.summary       = 'A unified, intent-driven interface layer that serves automation, AI, and developer platforms with minimal duplication.' # rubocop:disable Layout/LineLength
   spec.description   =
-    'Write OData compatible APIs to easier connection to Microsoft PowerBI and PowerAutomate.'
+    'A unified DSL for exposing structured data and operations across analytics tools (PowerBI), no-code platforms (PowerAutomate), and AI agents (via MCP).' # rubocop:disable Layout/LineLength
   # spec.homepage      = "TODO: Put your gem's website or public repo URL here."
   spec.required_ruby_version = Gem::Requirement.new('>= 3.0.0')
 
@@ -23,6 +23,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
 
   spec.add_dependency 'oj', '>= 3.0.0', '< 5.0.0'
+  spec.add_dependency 'uri', '>= 1.0.0', '< 2.0.0'
   # spec.add_dependency 'securerandom', '>= 0.1.0', '< 2.0.0'
 
   # For more information and examples about making a new gem, checkout our

--- a/spec/odata_duty/entity_set/collection_spec.rb
+++ b/spec/odata_duty/entity_set/collection_spec.rb
@@ -54,6 +54,7 @@ class DoesNotSupportCollectionSet < OdataDuty::EntitySet
 end
 
 class CollectionTestSchema < OdataDuty::Schema
+  base_url 'http://localhost:3000/api'
   entity_sets [SupportsCollectionSet, DoesNotSupportCollectionSet, LargeCollectionSet]
 end
 
@@ -67,9 +68,9 @@ RSpec.describe OdataDuty::EntitySet, 'Can specific individual result' do
         response = Oj.load(json_string)
         expect(response).to eq(
           {
-            '@odata.context' => '$metadata#SupportsCollection',
+            '@odata.context' => 'http://localhost:3000/api/$metadata#SupportsCollection',
             'value' => [
-              '@odata.id' => 'SupportsCollection(\'1\')',
+              '@odata.id' => 'http://localhost:3000/api/SupportsCollection(\'1\')',
               'id' => '1'
             ]
           }
@@ -86,10 +87,10 @@ RSpec.describe OdataDuty::EntitySet, 'Can specific individual result' do
         json_string = schema.execute('LargeCollection', context: Context.new)
         response = Oj.load(json_string)
         context = response['@odata.context']
-        expect(context).to eq('$metadata#LargeCollection')
+        expect(context).to eq('http://localhost:3000/api/$metadata#LargeCollection')
         expect(response['value'].count).to eq(50)
         next_link = response['@odata.nextLink']
-        expect(next_link).to eq('LargeCollection?$skiptoken=50')
+        expect(next_link).to eq('http://localhost:3000/api/LargeCollection?%24skiptoken=50')
       end
 
       it do
@@ -110,10 +111,10 @@ RSpec.describe OdataDuty::EntitySet, 'Can specific individual result' do
                                                           query_options: { '$count' => 'true' })
           response = Oj.load(json_string)
           context = response['@odata.context']
-          expect(context).to eq('$metadata#LargeCollection')
+          expect(context).to eq('http://localhost:3000/api/$metadata#LargeCollection')
           expect(response['value'].count).to eq(50)
           next_link = response['@odata.nextLink']
-          expect(next_link).to eq('LargeCollection?$count=true&$skiptoken=50')
+          expect(next_link).to eq('http://localhost:3000/api/LargeCollection?%24count=true&%24skiptoken=50')
           count = response['@odata.count']
           expect(count).to eq(102)
         end
@@ -124,10 +125,10 @@ RSpec.describe OdataDuty::EntitySet, 'Can specific individual result' do
                                        query_options: { '$skiptoken' => '50' })
           response = Oj.load(json_string)
           context = response['@odata.context']
-          expect(context).to eq('$metadata#LargeCollection')
+          expect(context).to eq('http://localhost:3000/api/$metadata#LargeCollection')
           expect(response['value'].count).to eq(2)
           next_link = response['@odata.nextLink']
-          expect(next_link).to eq('LargeCollection?$skiptoken=100')
+          expect(next_link).to eq('http://localhost:3000/api/LargeCollection?%24skiptoken=50&%24skiptoken=100')
         end
 
         it do
@@ -136,7 +137,7 @@ RSpec.describe OdataDuty::EntitySet, 'Can specific individual result' do
                                        query_options: { '$skiptoken' => '100' })
           response = Oj.load(json_string)
           context = response['@odata.context']
-          expect(context).to eq('$metadata#LargeCollection')
+          expect(context).to eq('http://localhost:3000/api/$metadata#LargeCollection')
           expect(response['value'].count).to eq(2)
           next_link = response['@odata.nextLink']
           expect(next_link).to be_nil
@@ -150,10 +151,12 @@ RSpec.describe OdataDuty::EntitySet, 'Can specific individual result' do
                                                       '$top' => '100' })
         response = Oj.load(json_string)
         context = response['@odata.context']
-        expect(context).to eq('$metadata#LargeCollection')
+        expect(context).to eq('http://localhost:3000/api/$metadata#LargeCollection')
         expect(response['value'].count).to eq(50)
         next_link = response['@odata.nextLink']
-        expect(next_link).to eq("LargeCollection?$filter=id ne '1'&$top=100&$skiptoken=50")
+        expect(next_link).to eq(
+          'http://localhost:3000/api/LargeCollection?%24filter=id+ne+%271%27&%24top=100&%24skiptoken=50'
+        )
       end
     end
   end

--- a/spec/odata_duty/entity_set/create/with_complex_spec.rb
+++ b/spec/odata_duty/entity_set/create/with_complex_spec.rb
@@ -44,6 +44,7 @@ class InvalidPropertyTestSet < OdataDuty::EntitySet
 end
 
 class CreateComplexTestSchema < OdataDuty::Schema
+  base_url 'http://localhost:3000/api'
   entity_sets [CreateComplexTestSet, InvalidPropertyTestSet]
 end
 
@@ -60,8 +61,8 @@ RSpec.describe OdataDuty::EntitySet, 'Can create' do
 
     it do
       expect(response).to eq(
-        '@odata.context' => '$metadata#CreateComplexTest/$entity',
-        '@odata.id' => 'CreateComplexTest(\'1\')',
+        '@odata.context' => 'http://localhost:3000/api/$metadata#CreateComplexTest/$entity',
+        '@odata.id' => 'http://localhost:3000/api/CreateComplexTest(\'1\')',
         'id' => '1',
         'complex' => nil
       )

--- a/spec/odata_duty/entity_set/create/with_scalars_spec.rb
+++ b/spec/odata_duty/entity_set/create/with_scalars_spec.rb
@@ -31,6 +31,7 @@ class DoesNotSupportCreateSet < OdataDuty::EntitySet
 end
 
 class CreateTestSchema < OdataDuty::Schema
+  base_url 'http://localhost:3000/api'
   entity_sets [CreateScalarsTestSet, DoesNotSupportCreateSet]
 end
 
@@ -47,8 +48,8 @@ RSpec.describe OdataDuty::EntitySet, 'Can create' do
 
     it do
       expect(response).to eq(
-        '@odata.context' => '$metadata#CreateScalarsTest/$entity',
-        '@odata.id' => 'CreateScalarsTest(\'1\')',
+        '@odata.context' => 'http://localhost:3000/api/$metadata#CreateScalarsTest/$entity',
+        '@odata.id' => 'http://localhost:3000/api/CreateScalarsTest(\'1\')',
         'id' => '1',
         'string' => nil,
         'string_list' => nil,

--- a/spec/odata_duty/entity_set/individual_spec.rb
+++ b/spec/odata_duty/entity_set/individual_spec.rb
@@ -29,6 +29,7 @@ class IndividualIntegerSet < OdataDuty::EntitySet
 end
 
 class IndividualTestSchema < OdataDuty::Schema
+  base_url 'http://localhost:3000/api'
   entity_sets [SupportsIndividualSet, DoesNotSupportIndividualSet, IndividualIntegerSet]
 end
 
@@ -42,8 +43,8 @@ RSpec.describe OdataDuty::EntitySet, 'Can specific individual result' do
         response = Oj.load(json_string)
         expect(response).to eq(
           {
-            '@odata.context' => '$metadata#SupportsIndividual/$entity',
-            '@odata.id' => 'SupportsIndividual(\'1\')',
+            '@odata.context' => 'http://localhost:3000/api/$metadata#SupportsIndividual/$entity',
+            '@odata.id' => 'http://localhost:3000/api/SupportsIndividual(\'1\')',
             'id' => '1'
           }
         )
@@ -54,8 +55,8 @@ RSpec.describe OdataDuty::EntitySet, 'Can specific individual result' do
         response = Oj.load(json_string)
         expect(response).to eq(
           {
-            '@odata.context' => '$metadata#IndividualInteger/$entity',
-            '@odata.id' => 'IndividualInteger(1)',
+            '@odata.context' => 'http://localhost:3000/api/$metadata#IndividualInteger/$entity',
+            '@odata.id' => 'http://localhost:3000/api/IndividualInteger(1)',
             'id' => 1
           }
         )

--- a/spec/odata_duty/entity_set/method_override_spec.rb
+++ b/spec/odata_duty/entity_set/method_override_spec.rb
@@ -24,6 +24,7 @@ class MethodOverrideSet < OdataDuty::EntitySet
 end
 
 class MethodOverrideTestsSchema < OdataDuty::Schema
+  base_url 'http://localhost:3000/api'
   entity_sets [MethodOverrideSet]
 end
 
@@ -36,13 +37,13 @@ RSpec.describe OdataDuty::EntitySet, 'Can Override the default name and/or url' 
         response = Oj.load(schema.execute('MethodOverride', context: Context.new))
         expect(response).to eq(
           'value' => [{
-            '@odata.id' => 'MethodOverride(\'1\')',
+            '@odata.id' => 'http://localhost:3000/api/MethodOverride(\'1\')',
             'id' => '1',
             'second_id' => '1',
             'over' => 'overridden',
             'second_over' => 'overridden'
           }],
-          '@odata.context' => '$metadata#MethodOverride'
+          '@odata.context' => 'http://localhost:3000/api/$metadata#MethodOverride'
         )
       end
     end

--- a/spec/odata_duty/entity_set/select_spec.rb
+++ b/spec/odata_duty/entity_set/select_spec.rb
@@ -58,6 +58,7 @@ class SelectlessCollectionSet < OdataDuty::EntitySet
 end
 
 class CollectionSelectTestSchema < OdataDuty::Schema
+  base_url 'http://localhost:3000/api'
   entity_sets [SupportsCollectionSelectSet, SelectlessCollectionSet]
 end
 
@@ -73,8 +74,8 @@ RSpec.describe OdataDuty::EntitySet, 'Can specific individual result' do
         response = Oj.load(json_string)
         expect(response).to eq(
           {
-            '@odata.context' => '$metadata#SelectlessCollection/$entity',
-            '@odata.id' => 'SelectlessCollection(\'1\')',
+            '@odata.context' => 'http://localhost:3000/api/$metadata#SelectlessCollection/$entity',
+            '@odata.id' => 'http://localhost:3000/api/SelectlessCollection(\'1\')',
             'id' => '1', 'i' => 1
           }
         )
@@ -87,8 +88,8 @@ RSpec.describe OdataDuty::EntitySet, 'Can specific individual result' do
         response = Oj.load(json_string)
         expect(response).to eq(
           {
-            '@odata.context' => '$metadata#SelectlessCollection/$entity',
-            '@odata.id' => 'SelectlessCollection(\'1\')',
+            '@odata.context' => 'http://localhost:3000/api/$metadata#SelectlessCollection/$entity',
+            '@odata.id' => 'http://localhost:3000/api/SelectlessCollection(\'1\')',
             'c' => { 's' => '1' }
           }
         )
@@ -127,8 +128,8 @@ RSpec.describe OdataDuty::EntitySet, 'Can specific individual result' do
         response = Oj.load(json_string)
         expect(response).to eq(
           {
-            '@odata.context' => '$metadata#SupportsCollectionSelect/$entity',
-            '@odata.id' => 'SupportsCollectionSelect(\'1\')',
+            '@odata.context' => 'http://localhost:3000/api/$metadata#SupportsCollectionSelect/$entity',
+            '@odata.id' => 'http://localhost:3000/api/SupportsCollectionSelect(\'1\')',
             'id' => '1', 'i' => 1
           }
         )
@@ -143,8 +144,8 @@ RSpec.describe OdataDuty::EntitySet, 'Can specific individual result' do
         response = Oj.load(json_string)
         expect(response).to eq(
           {
-            '@odata.context' => '$metadata#SupportsCollectionSelect/$entity',
-            '@odata.id' => 'SupportsCollectionSelect(\'1\')',
+            '@odata.context' => 'http://localhost:3000/api/$metadata#SupportsCollectionSelect/$entity',
+            '@odata.id' => 'http://localhost:3000/api/SupportsCollectionSelect(\'1\')',
             'c' => { 's' => '1' }
           }
         )
@@ -159,10 +160,10 @@ RSpec.describe OdataDuty::EntitySet, 'Can specific individual result' do
         response = Oj.load(json_string)
         expect(response).to eq(
           {
-            '@odata.context' => '$metadata#SelectlessCollection',
-            'value' => [{ '@odata.id' => 'SelectlessCollection(\'1\')',
+            '@odata.context' => 'http://localhost:3000/api/$metadata#SelectlessCollection',
+            'value' => [{ '@odata.id' => 'http://localhost:3000/api/SelectlessCollection(\'1\')',
                           'id' => '1', 'i' => 1 },
-                        { '@odata.id' => 'SelectlessCollection(\'2\')',
+                        { '@odata.id' => 'http://localhost:3000/api/SelectlessCollection(\'2\')',
                           'id' => '2', 'i' => 2 }]
           }
         )
@@ -175,10 +176,10 @@ RSpec.describe OdataDuty::EntitySet, 'Can specific individual result' do
         response = Oj.load(json_string)
         expect(response).to eq(
           {
-            '@odata.context' => '$metadata#SelectlessCollection',
-            'value' => [{ '@odata.id' => 'SelectlessCollection(\'1\')',
+            '@odata.context' => 'http://localhost:3000/api/$metadata#SelectlessCollection',
+            'value' => [{ '@odata.id' => 'http://localhost:3000/api/SelectlessCollection(\'1\')',
                           'c' => { 's' => '1' } },
-                        { '@odata.id' => 'SelectlessCollection(\'2\')',
+                        { '@odata.id' => 'http://localhost:3000/api/SelectlessCollection(\'2\')',
                           'c' => { 's' => '2' } }]
           }
         )
@@ -217,10 +218,10 @@ RSpec.describe OdataDuty::EntitySet, 'Can specific individual result' do
         response = Oj.load(json_string)
         expect(response).to eq(
           {
-            '@odata.context' => '$metadata#SupportsCollectionSelect',
-            'value' => [{ '@odata.id' => 'SupportsCollectionSelect(\'1\')',
+            '@odata.context' => 'http://localhost:3000/api/$metadata#SupportsCollectionSelect',
+            'value' => [{ '@odata.id' => 'http://localhost:3000/api/SupportsCollectionSelect(\'1\')',
                           'id' => '1', 'i' => 1 },
-                        { '@odata.id' => 'SupportsCollectionSelect(\'2\')',
+                        { '@odata.id' => 'http://localhost:3000/api/SupportsCollectionSelect(\'2\')',
                           'id' => '2', 'i' => 2 }]
           }
         )
@@ -235,10 +236,10 @@ RSpec.describe OdataDuty::EntitySet, 'Can specific individual result' do
         response = Oj.load(json_string)
         expect(response).to eq(
           {
-            '@odata.context' => '$metadata#SupportsCollectionSelect',
-            'value' => [{ '@odata.id' => 'SupportsCollectionSelect(\'1\')',
+            '@odata.context' => 'http://localhost:3000/api/$metadata#SupportsCollectionSelect',
+            'value' => [{ '@odata.id' => 'http://localhost:3000/api/SupportsCollectionSelect(\'1\')',
                           'c' => { 's' => '1' } },
-                        { '@odata.id' => 'SupportsCollectionSelect(\'2\')',
+                        { '@odata.id' => 'http://localhost:3000/api/SupportsCollectionSelect(\'2\')',
                           'c' => { 's' => '2' } }]
           }
         )

--- a/spec/odata_duty/entity_set/set_name_and_url_spec.rb
+++ b/spec/odata_duty/entity_set/set_name_and_url_spec.rb
@@ -69,6 +69,7 @@ class SetDoesNotEnd < OdataDuty::EntitySet
 end
 
 class EntityTestsSchema < OdataDuty::Schema
+  base_url 'http://localhost:3000/api'
   entity_sets [NewNameSet, SetDoesNotEnd, RenamedSet, RenameBothWithSymbolSet,
                RenameUrlWithStringSet]
 end
@@ -95,10 +96,10 @@ RSpec.describe OdataDuty::EntitySet, 'Can Override the default name and/or url' 
         response = Oj.load(schema.execute('symbol_renamed', context: Context.new))
         expect(response).to eq(
           'value' => [{
-            '@odata.id' => 'symbol_renamed(\'1\')',
+            '@odata.id' => 'http://localhost:3000/api/symbol_renamed(\'1\')',
             'id' => '1'
           }],
-          '@odata.context' => '$metadata#RenameWithSymbol'
+          '@odata.context' => 'http://localhost:3000/api/$metadata#RenameWithSymbol'
         )
       end
 
@@ -106,10 +107,10 @@ RSpec.describe OdataDuty::EntitySet, 'Can Override the default name and/or url' 
         response = Oj.load(schema.execute('set_renamed', context: Context.new))
         expect(response).to eq(
           'value' => [{
-            '@odata.id' => 'set_renamed(\'2\')',
+            '@odata.id' => 'http://localhost:3000/api/set_renamed(\'2\')',
             'id' => '2'
           }],
-          '@odata.context' => '$metadata#set_renamed'
+          '@odata.context' => 'http://localhost:3000/api/$metadata#set_renamed'
         )
       end
 
@@ -117,10 +118,10 @@ RSpec.describe OdataDuty::EntitySet, 'Can Override the default name and/or url' 
         response = Oj.load(schema.execute('SetDoesNotEnd', context: Context.new))
         expect(response).to eq(
           'value' => [{
-            '@odata.id' => 'SetDoesNotEnd(\'3\')',
+            '@odata.id' => 'http://localhost:3000/api/SetDoesNotEnd(\'3\')',
             'id' => '3'
           }],
-          '@odata.context' => '$metadata#SetDoesNotEnd'
+          '@odata.context' => 'http://localhost:3000/api/$metadata#SetDoesNotEnd'
         )
       end
 
@@ -128,10 +129,10 @@ RSpec.describe OdataDuty::EntitySet, 'Can Override the default name and/or url' 
         response = Oj.load(schema.execute('NewName', context: Context.new))
         expect(response).to eq(
           'value' => [{
-            '@odata.id' => 'NewName(\'4\')',
+            '@odata.id' => 'http://localhost:3000/api/NewName(\'4\')',
             'id' => '4'
           }],
-          '@odata.context' => '$metadata#NewName'
+          '@odata.context' => 'http://localhost:3000/api/$metadata#NewName'
         )
       end
     end

--- a/spec/odata_duty/entity_type/boolean_type_spec.rb
+++ b/spec/odata_duty/entity_type/boolean_type_spec.rb
@@ -45,6 +45,7 @@ class BoolWithInvalidSet < OdataDuty::EntitySet
 end
 
 class BooleanTestSchema < OdataDuty::Schema
+  base_url 'http://localhost:3000/api'
   entity_sets [BoolSet, BoolWithInvalidSet]
 end
 
@@ -77,11 +78,13 @@ RSpec.describe OdataDuty::EntitySet, 'Can use boolean primitive type' do
         response = Oj.load(json_string)
         expect(response).to eq(
           {
-            '@odata.context' => '$metadata#Bool',
+            '@odata.context' => 'http://localhost:3000/api/$metadata#Bool',
             'value' => [
-              { '@odata.id' => 'Bool(\'1\')', 'id' => '1', 'boolean' => true, 'maybe' => nil },
-              { '@odata.id' => 'Bool(\'2\')', 'id' => '2', 'boolean' => false, 'maybe' => true },
-              { '@odata.id' => 'Bool(\'3\')', 'id' => '3', 'boolean' => true, 'maybe' => false }
+              { '@odata.id' => 'http://localhost:3000/api/Bool(\'1\')', 'id' => '1',
+                'boolean' => true, 'maybe' => nil },
+              { '@odata.id' => 'http://localhost:3000/api/Bool(\'2\')', 'id' => '2',
+                'boolean' => false, 'maybe' => true },
+              { '@odata.id' => 'http://localhost:3000/api/Bool(\'3\')', 'id' => '3', 'boolean' => true, 'maybe' => false }
             ]
           }
         )
@@ -93,10 +96,11 @@ RSpec.describe OdataDuty::EntitySet, 'Can use boolean primitive type' do
         response = Oj.load(json_string)
         expect(response).to eq(
           {
-            '@odata.context' => '$metadata#Bool',
+            '@odata.context' => 'http://localhost:3000/api/$metadata#Bool',
             'value' => [
-              { '@odata.id' => 'Bool(\'1\')', 'id' => '1', 'boolean' => true, 'maybe' => nil },
-              { '@odata.id' => 'Bool(\'3\')', 'id' => '3', 'boolean' => true, 'maybe' => false }
+              { '@odata.id' => 'http://localhost:3000/api/Bool(\'1\')', 'id' => '1',
+                'boolean' => true, 'maybe' => nil },
+              { '@odata.id' => 'http://localhost:3000/api/Bool(\'3\')', 'id' => '3', 'boolean' => true, 'maybe' => false }
             ]
           }
         )
@@ -108,9 +112,9 @@ RSpec.describe OdataDuty::EntitySet, 'Can use boolean primitive type' do
         response = Oj.load(json_string)
         expect(response).to eq(
           {
-            '@odata.context' => '$metadata#Bool',
+            '@odata.context' => 'http://localhost:3000/api/$metadata#Bool',
             'value' => [
-              { '@odata.id' => 'Bool(\'3\')', 'id' => '3', 'boolean' => true, 'maybe' => false }
+              { '@odata.id' => 'http://localhost:3000/api/Bool(\'3\')', 'id' => '3', 'boolean' => true, 'maybe' => false }
             ]
           }
         )

--- a/spec/odata_duty/schema_builder/entity_set/collection_spec.rb
+++ b/spec/odata_duty/schema_builder/entity_set/collection_spec.rb
@@ -68,9 +68,9 @@ module OdataDuty
           response = Oj.load(json_string)
           expect(response).to eq(
             {
-              '@odata.context' => '$metadata#SupportsCollection',
+              '@odata.context' => 'https://localhost/$metadata#SupportsCollection',
               'value' => [
-                '@odata.id' => 'SupportsCollection(\'1\')',
+                '@odata.id' => 'https://localhost/SupportsCollection(\'1\')',
                 'id' => '1'
               ]
             }
@@ -87,10 +87,10 @@ module OdataDuty
           json_string = schema.execute('LargeCollection', context: Context.new)
           response = Oj.load(json_string)
           context = response['@odata.context']
-          expect(context).to eq('$metadata#LargeCollection')
+          expect(context).to eq('https://localhost/$metadata#LargeCollection')
           expect(response['value'].count).to eq(50)
           next_link = response['@odata.nextLink']
-          expect(next_link).to eq('LargeCollection?$skiptoken=50')
+          expect(next_link).to eq('https://localhost/LargeCollection?%24skiptoken=50')
         end
 
         it do
@@ -111,10 +111,10 @@ module OdataDuty
                                                             query_options: { '$count' => 'true' })
             response = Oj.load(json_string)
             context = response['@odata.context']
-            expect(context).to eq('$metadata#LargeCollection')
+            expect(context).to eq('https://localhost/$metadata#LargeCollection')
             expect(response['value'].count).to eq(50)
             next_link = response['@odata.nextLink']
-            expect(next_link).to eq('LargeCollection?$count=true&$skiptoken=50')
+            expect(next_link).to eq('https://localhost/LargeCollection?%24count=true&%24skiptoken=50')
             count = response['@odata.count']
             expect(count).to eq(102)
           end
@@ -125,10 +125,10 @@ module OdataDuty
                                          query_options: { '$skiptoken' => '50' })
             response = Oj.load(json_string)
             context = response['@odata.context']
-            expect(context).to eq('$metadata#LargeCollection')
+            expect(context).to eq('https://localhost/$metadata#LargeCollection')
             expect(response['value'].count).to eq(2)
             next_link = response['@odata.nextLink']
-            expect(next_link).to eq('LargeCollection?$skiptoken=100')
+            expect(next_link).to eq('https://localhost/LargeCollection?%24skiptoken=50&%24skiptoken=100')
           end
 
           it do
@@ -137,7 +137,7 @@ module OdataDuty
                                          query_options: { '$skiptoken' => '100' })
             response = Oj.load(json_string)
             context = response['@odata.context']
-            expect(context).to eq('$metadata#LargeCollection')
+            expect(context).to eq('https://localhost/$metadata#LargeCollection')
             expect(response['value'].count).to eq(2)
             next_link = response['@odata.nextLink']
             expect(next_link).to be_nil
@@ -151,10 +151,12 @@ module OdataDuty
                                                         '$top' => '100' })
           response = Oj.load(json_string)
           context = response['@odata.context']
-          expect(context).to eq('$metadata#LargeCollection')
+          expect(context).to eq('https://localhost/$metadata#LargeCollection')
           expect(response['value'].count).to eq(50)
           next_link = response['@odata.nextLink']
-          expect(next_link).to eq("LargeCollection?$filter=id ne '1'&$top=100&$skiptoken=50")
+          expect(next_link).to eq(
+            'https://localhost/LargeCollection?%24filter=id+ne+%271%27&%24top=100&%24skiptoken=50'
+          )
         end
       end
     end

--- a/spec/odata_duty/schema_builder/entity_set/create/with_complex_spec.rb
+++ b/spec/odata_duty/schema_builder/entity_set/create/with_complex_spec.rb
@@ -24,7 +24,7 @@ end
 module OdataDuty
   RSpec.describe SchemaBuilder::EntitySet, 'Can create' do
     subject(:schema) do
-      SchemaBuilder.build(namespace: 'SampleSpace', host: 'localhost') do |s|
+      SchemaBuilder.build(namespace: 'SampleSpace', host: 'localhost', base_path: '') do |s|
         complex_type = s.add_complex_type(name: 'CreateTestComplex') do |et|
           et.property 'string', String
           et.property 'string_list', [String]
@@ -60,8 +60,8 @@ module OdataDuty
 
       it do
         expect(response).to eq(
-          '@odata.context' => '$metadata#CreateComplexTest/$entity',
-          '@odata.id' => 'CreateComplexTest(\'1\')',
+          '@odata.context' => 'https://localhost/$metadata#CreateComplexTest/$entity',
+          '@odata.id' => 'https://localhost/CreateComplexTest(\'1\')',
           'id' => '1',
           'complex' => nil
         )

--- a/spec/odata_duty/schema_builder/entity_set/create/with_scalars_spec.rb
+++ b/spec/odata_duty/schema_builder/entity_set/create/with_scalars_spec.rb
@@ -16,7 +16,7 @@ end
 module OdataDuty
   RSpec.describe SchemaBuilder::EntitySet, 'Can create' do
     subject(:schema) do
-      SchemaBuilder.build(namespace: 'SampleSpace', host: 'localhost') do |s|
+      SchemaBuilder.build(namespace: 'SampleSpace', host: 'localhost', base_path: '') do |s|
         collection_entity = s.add_entity_type(name: 'CreateScalarsTestEntity') do |et|
           et.property_ref 'id', String
           et.property 'string', String
@@ -48,8 +48,8 @@ module OdataDuty
 
       it do
         expect(response).to eq(
-          '@odata.context' => '$metadata#CreateScalarsTest/$entity',
-          '@odata.id' => 'CreateScalarsTest(\'1\')',
+          '@odata.context' => 'https://localhost/$metadata#CreateScalarsTest/$entity',
+          '@odata.id' => 'https://localhost/CreateScalarsTest(\'1\')',
           'id' => '1',
           'string' => nil,
           'string_list' => nil,

--- a/spec/odata_duty/schema_builder/entity_set/entity_set_name_spec.rb
+++ b/spec/odata_duty/schema_builder/entity_set/entity_set_name_spec.rb
@@ -1,0 +1,33 @@
+require 'spec_helper'
+
+module OdataDuty
+  RSpec.describe SchemaBuilder::EntityType, 'Can setup property refs' do
+    describe 'name' do
+      it do
+        expect do
+          SchemaBuilder.build(namespace: 'SampleSpace', host: 'localhost', base_path: '') do |s|
+            name_entity = s.add_entity_type(name: 'Name') do |et|
+              et.property_ref 'id', String
+            end
+
+            s.add_entity_set(entity_type: name_entity, resolver: 'RenamedResolver',
+                             name: '0')
+          end
+        end.to raise_error(InvalidNCNamesError, '"0" is not a valid property name')
+      end
+
+      it do
+        expect do
+          SchemaBuilder.build(namespace: 'SampleSpace', host: 'localhost', base_path: '') do |s|
+            name_entity = s.add_entity_type(name: 'Name') do |et|
+              et.property_ref 'id', String
+            end
+
+            s.add_entity_set(entity_type: name_entity, resolver: 'RenamedResolver',
+                             name: 'a b')
+          end
+        end.to raise_error(InvalidNCNamesError, '"a b" is not a valid property name')
+      end
+    end
+  end
+end

--- a/spec/odata_duty/schema_builder/entity_set/individual_spec.rb
+++ b/spec/odata_duty/schema_builder/entity_set/individual_spec.rb
@@ -18,7 +18,7 @@ end
 module OdataDuty
   RSpec.describe SchemaBuilder::EntitySet, 'Can specific individual result' do
     subject(:schema) do
-      SchemaBuilder.build(namespace: 'SampleSpace', host: 'localhost') do |s|
+      SchemaBuilder.build(namespace: 'SampleSpace', host: 'localhost', base_path: '') do |s|
         string_entity = s.add_entity_type(name: 'IndividualTest') do |et|
           et.property_ref 'id', String
         end
@@ -39,8 +39,8 @@ module OdataDuty
           response = Oj.load(json_string)
           expect(response).to eq(
             {
-              '@odata.context' => '$metadata#SupportsIndividual/$entity',
-              '@odata.id' => 'SupportsIndividual(\'1\')',
+              '@odata.context' => 'https://localhost/$metadata#SupportsIndividual/$entity',
+              '@odata.id' => 'https://localhost/SupportsIndividual(\'1\')',
               'id' => '1'
             }
           )
@@ -51,8 +51,8 @@ module OdataDuty
           response = Oj.load(json_string)
           expect(response).to eq(
             {
-              '@odata.context' => '$metadata#IndividualInteger/$entity',
-              '@odata.id' => 'IndividualInteger(1)',
+              '@odata.context' => 'https://localhost/$metadata#IndividualInteger/$entity',
+              '@odata.id' => 'https://localhost/IndividualInteger(1)',
               'id' => 1
             }
           )

--- a/spec/odata_duty/schema_builder/entity_set/select_spec.rb
+++ b/spec/odata_duty/schema_builder/entity_set/select_spec.rb
@@ -48,7 +48,7 @@ end
 module OdataDuty
   RSpec.describe SchemaBuilder::EntitySet, 'Can select specific properties in the return result' do
     subject(:schema) do
-      SchemaBuilder.build(namespace: 'SampleSpace', host: 'localhost') do |s|
+      SchemaBuilder.build(namespace: 'SampleSpace', host: 'localhost', base_path: '') do |s|
         complex = s.add_entity_type(name: 'CollectionSelectTestComplex') do |et|
           et.property 's', String
         end
@@ -74,8 +74,8 @@ module OdataDuty
           response = Oj.load(json_string)
           expect(response).to eq(
             {
-              '@odata.context' => '$metadata#SelectlessCollection/$entity',
-              '@odata.id' => 'SelectlessCollection(\'1\')',
+              '@odata.context' => 'https://localhost/$metadata#SelectlessCollection/$entity',
+              '@odata.id' => 'https://localhost/SelectlessCollection(\'1\')',
               'id' => '1', 'i' => 1
             }
           )
@@ -88,8 +88,8 @@ module OdataDuty
           response = Oj.load(json_string)
           expect(response).to eq(
             {
-              '@odata.context' => '$metadata#SelectlessCollection/$entity',
-              '@odata.id' => 'SelectlessCollection(\'1\')',
+              '@odata.context' => 'https://localhost/$metadata#SelectlessCollection/$entity',
+              '@odata.id' => 'https://localhost/SelectlessCollection(\'1\')',
               'c' => { 's' => '1' }
             }
           )
@@ -126,8 +126,8 @@ module OdataDuty
           response = Oj.load(json_string)
           expect(response).to eq(
             {
-              '@odata.context' => '$metadata#SupportsCollectionSelect/$entity',
-              '@odata.id' => 'SupportsCollectionSelect(\'1\')',
+              '@odata.context' => 'https://localhost/$metadata#SupportsCollectionSelect/$entity',
+              '@odata.id' => 'https://localhost/SupportsCollectionSelect(\'1\')',
               'id' => '1', 'i' => 3
             }
           )
@@ -140,8 +140,8 @@ module OdataDuty
           response = Oj.load(json_string)
           expect(response).to eq(
             {
-              '@odata.context' => '$metadata#SupportsCollectionSelect/$entity',
-              '@odata.id' => 'SupportsCollectionSelect(\'1\')',
+              '@odata.context' => 'https://localhost/$metadata#SupportsCollectionSelect/$entity',
+              '@odata.id' => 'https://localhost/SupportsCollectionSelect(\'1\')',
               'c' => { 's' => '3' }
             }
           )
@@ -156,10 +156,10 @@ module OdataDuty
           response = Oj.load(json_string)
           expect(response).to eq(
             {
-              '@odata.context' => '$metadata#SelectlessCollection',
-              'value' => [{ '@odata.id' => 'SelectlessCollection(\'1\')',
+              '@odata.context' => 'https://localhost/$metadata#SelectlessCollection',
+              'value' => [{ '@odata.id' => 'https://localhost/SelectlessCollection(\'1\')',
                             'id' => '1', 'i' => 1 },
-                          { '@odata.id' => 'SelectlessCollection(\'2\')',
+                          { '@odata.id' => 'https://localhost/SelectlessCollection(\'2\')',
                             'id' => '2', 'i' => 2 }]
             }
           )
@@ -172,10 +172,10 @@ module OdataDuty
           response = Oj.load(json_string)
           expect(response).to eq(
             {
-              '@odata.context' => '$metadata#SelectlessCollection',
-              'value' => [{ '@odata.id' => 'SelectlessCollection(\'1\')',
+              '@odata.context' => 'https://localhost/$metadata#SelectlessCollection',
+              'value' => [{ '@odata.id' => 'https://localhost/SelectlessCollection(\'1\')',
                             'c' => { 's' => '1' } },
-                          { '@odata.id' => 'SelectlessCollection(\'2\')',
+                          { '@odata.id' => 'https://localhost/SelectlessCollection(\'2\')',
                             'c' => { 's' => '2' } }]
             }
           )
@@ -212,10 +212,10 @@ module OdataDuty
           response = Oj.load(json_string)
           expect(response).to eq(
             {
-              '@odata.context' => '$metadata#SupportsCollectionSelect',
-              'value' => [{ '@odata.id' => 'SupportsCollectionSelect(\'1\')',
+              '@odata.context' => 'https://localhost/$metadata#SupportsCollectionSelect',
+              'value' => [{ '@odata.id' => 'https://localhost/SupportsCollectionSelect(\'1\')',
                             'id' => '1', 'i' => 3 },
-                          { '@odata.id' => 'SupportsCollectionSelect(\'2\')',
+                          { '@odata.id' => 'https://localhost/SupportsCollectionSelect(\'2\')',
                             'id' => '2', 'i' => 4 }]
             }
           )
@@ -228,10 +228,10 @@ module OdataDuty
           response = Oj.load(json_string)
           expect(response).to eq(
             {
-              '@odata.context' => '$metadata#SupportsCollectionSelect',
-              'value' => [{ '@odata.id' => 'SupportsCollectionSelect(\'1\')',
+              '@odata.context' => 'https://localhost/$metadata#SupportsCollectionSelect',
+              'value' => [{ '@odata.id' => 'https://localhost/SupportsCollectionSelect(\'1\')',
                             'c' => { 's' => '3' } },
-                          { '@odata.id' => 'SupportsCollectionSelect(\'2\')',
+                          { '@odata.id' => 'https://localhost/SupportsCollectionSelect(\'2\')',
                             'c' => { 's' => '4' } }]
             }
           )

--- a/spec/odata_duty/schema_builder/entity_set/set_name_and_url_spec.rb
+++ b/spec/odata_duty/schema_builder/entity_set/set_name_and_url_spec.rb
@@ -70,7 +70,7 @@ module OdataDuty
     end
 
     describe '#index_hash' do
-      let(:index_hash) { schema.index_hash('$metadata') }
+      let(:index_hash) { schema.index_hash }
       let(:index_values) { index_hash.fetch(:value) }
       let(:entity_set) { index_values.map { |x| x.slice(:name, :url) } }
 

--- a/spec/odata_duty/schema_builder/entity_set/set_name_and_url_spec.rb
+++ b/spec/odata_duty/schema_builder/entity_set/set_name_and_url_spec.rb
@@ -53,7 +53,7 @@ end
 module OdataDuty
   RSpec.describe SchemaBuilder::EntitySet, 'Can Override the default name and/or url' do
     subject(:schema) do
-      SchemaBuilder.build(namespace: 'SampleSpace', host: 'localhost') do |s|
+      SchemaBuilder.build(namespace: 'SampleSpace', host: 'localhost', base_path: '') do |s|
         name_entity = s.add_entity_type(name: 'Name') do |et|
           et.property_ref 'id', String
         end
@@ -70,7 +70,7 @@ module OdataDuty
     end
 
     describe '#index_hash' do
-      let(:index_hash) { EdmxSchema.index_hash(schema) }
+      let(:index_hash) { schema.index_hash('$metadata') }
       let(:index_values) { index_hash.fetch(:value) }
       let(:entity_set) { index_values.map { |x| x.slice(:name, :url) } }
 
@@ -88,10 +88,10 @@ module OdataDuty
           response = Oj.load(schema.execute('symbol_renamed', context: Context.new))
           expect(response).to eq(
             'value' => [{
-              '@odata.id' => 'symbol_renamed(\'1\')',
+              '@odata.id' => 'https://localhost/symbol_renamed(\'1\')',
               'id' => '1'
             }],
-            '@odata.context' => '$metadata#RenameWithSymbol'
+            '@odata.context' => 'https://localhost/$metadata#RenameWithSymbol'
           )
         end
 
@@ -99,10 +99,10 @@ module OdataDuty
           response = Oj.load(schema.execute('set_renamed', context: Context.new))
           expect(response).to eq(
             'value' => [{
-              '@odata.id' => 'set_renamed(\'2\')',
+              '@odata.id' => 'https://localhost/set_renamed(\'2\')',
               'id' => '2'
             }],
-            '@odata.context' => '$metadata#set_renamed'
+            '@odata.context' => 'https://localhost/$metadata#set_renamed'
           )
         end
 
@@ -110,10 +110,10 @@ module OdataDuty
           response = Oj.load(schema.execute('ResolverDoesNotEnd', context: Context.new))
           expect(response).to eq(
             'value' => [{
-              '@odata.id' => 'ResolverDoesNotEnd(\'3\')',
+              '@odata.id' => 'https://localhost/ResolverDoesNotEnd(\'3\')',
               'id' => '3'
             }],
-            '@odata.context' => '$metadata#ResolverDoesNotEnd'
+            '@odata.context' => 'https://localhost/$metadata#ResolverDoesNotEnd'
           )
         end
 
@@ -121,10 +121,10 @@ module OdataDuty
           response = Oj.load(schema.execute('NewName', context: Context.new))
           expect(response).to eq(
             'value' => [{
-              '@odata.id' => 'NewName(\'4\')',
+              '@odata.id' => 'https://localhost/NewName(\'4\')',
               'id' => '4'
             }],
-            '@odata.context' => '$metadata#NewName'
+            '@odata.context' => 'https://localhost/$metadata#NewName'
           )
         end
       end
@@ -132,7 +132,7 @@ module OdataDuty
 
     describe '#metadata_xml' do
       let(:parsed_xml) do
-        parse_xml_from_string(EdmxSchema.metadata_xml(schema))
+        parse_xml_from_string(schema.metadata_xml)
       end
       let(:entity_sets) { entity_sets_from_doc(parsed_xml) }
 

--- a/spec/odata_duty/schema_builder/entity_type/boolean_array_type_spec.rb
+++ b/spec/odata_duty/schema_builder/entity_type/boolean_array_type_spec.rb
@@ -29,7 +29,7 @@ end
 module OdataDuty
   RSpec.describe SchemaBuilder::EntityType, 'Can use array boolean primitive type' do
     subject(:schema) do
-      SchemaBuilder.build(namespace: 'SampleSpace', host: 'localhost') do |s|
+      SchemaBuilder.build(namespace: 'SampleSpace', host: 'localhost', base_path: '') do |s|
         bool_entity = s.add_entity_type(name: 'BoolValues') do |et|
           et.property_ref 'id', String
           et.property 'booleans', [TrueClass], nullable: false
@@ -44,7 +44,7 @@ module OdataDuty
 
     describe '#metadata_xml' do
       let(:parsed_xml) do
-        parse_xml_from_string(EdmxSchema.metadata_xml(schema))
+        parse_xml_from_string(schema.metadata_xml)
       end
       let(:entity_types) { entity_types_from_doc(parsed_xml) }
       let(:keys) { entity_type.fetch(:keys) }
@@ -71,11 +71,13 @@ module OdataDuty
           response = Oj.load(json_string)
           expect(response).to eq(
             {
-              '@odata.context' => '$metadata#Bool',
+              '@odata.context' => 'https://localhost/$metadata#Bool',
               'value' => [
-                { '@odata.id' => 'Bool(\'1\')', 'id' => '1', 'booleans' => [true] },
-                { '@odata.id' => 'Bool(\'2\')', 'id' => '2', 'booleans' => [false] },
-                { '@odata.id' => 'Bool(\'3\')', 'id' => '3', 'booleans' => [true] }
+                { '@odata.id' => 'https://localhost/Bool(\'1\')', 'id' => '1',
+                  'booleans' => [true] },
+                { '@odata.id' => 'https://localhost/Bool(\'2\')', 'id' => '2',
+                  'booleans' => [false] },
+                { '@odata.id' => 'https://localhost/Bool(\'3\')', 'id' => '3', 'booleans' => [true] }
               ]
             }
           )

--- a/spec/odata_duty/schema_builder/entity_type/boolean_type_spec.rb
+++ b/spec/odata_duty/schema_builder/entity_type/boolean_type_spec.rb
@@ -37,7 +37,7 @@ end
 module OdataDuty
   RSpec.describe SchemaBuilder::EntityType, 'Can use boolean primitive type' do
     subject(:schema) do
-      SchemaBuilder.build(namespace: 'SampleSpace', host: 'localhost') do |s|
+      SchemaBuilder.build(namespace: 'SampleSpace', host: 'localhost', base_path: '') do |s|
         bool_entity = s.add_entity_type(name: 'BoolValues') do |et|
           et.property_ref 'id', String
           et.property 'boolean', TrueClass, nullable: false
@@ -52,7 +52,7 @@ module OdataDuty
 
     describe '#metadata_xml' do
       let(:parsed_xml) do
-        parse_xml_from_string(EdmxSchema.metadata_xml(schema))
+        parse_xml_from_string(schema.metadata_xml)
       end
       let(:entity_types) { entity_types_from_doc(parsed_xml) }
       let(:keys) { entity_type.fetch(:keys) }
@@ -78,11 +78,13 @@ module OdataDuty
           response = Oj.load(json_string)
           expect(response).to eq(
             {
-              '@odata.context' => '$metadata#Bool',
+              '@odata.context' => 'https://localhost/$metadata#Bool',
               'value' => [
-                { '@odata.id' => 'Bool(\'1\')', 'id' => '1', 'boolean' => true, 'maybe' => nil },
-                { '@odata.id' => 'Bool(\'2\')', 'id' => '2', 'boolean' => false, 'maybe' => true },
-                { '@odata.id' => 'Bool(\'3\')', 'id' => '3', 'boolean' => true, 'maybe' => false }
+                { '@odata.id' => 'https://localhost/Bool(\'1\')', 'id' => '1', 'boolean' => true,
+                  'maybe' => nil },
+                { '@odata.id' => 'https://localhost/Bool(\'2\')', 'id' => '2', 'boolean' => false,
+                  'maybe' => true },
+                { '@odata.id' => 'https://localhost/Bool(\'3\')', 'id' => '3', 'boolean' => true, 'maybe' => false }
               ]
             }
           )
@@ -94,10 +96,11 @@ module OdataDuty
           response = Oj.load(json_string)
           expect(response).to eq(
             {
-              '@odata.context' => '$metadata#Bool',
+              '@odata.context' => 'https://localhost/$metadata#Bool',
               'value' => [
-                { '@odata.id' => 'Bool(\'1\')', 'id' => '1', 'boolean' => true, 'maybe' => nil },
-                { '@odata.id' => 'Bool(\'3\')', 'id' => '3', 'boolean' => true, 'maybe' => false }
+                { '@odata.id' => 'https://localhost/Bool(\'1\')', 'id' => '1', 'boolean' => true,
+                  'maybe' => nil },
+                { '@odata.id' => 'https://localhost/Bool(\'3\')', 'id' => '3', 'boolean' => true, 'maybe' => false }
               ]
             }
           )
@@ -109,9 +112,9 @@ module OdataDuty
           response = Oj.load(json_string)
           expect(response).to eq(
             {
-              '@odata.context' => '$metadata#Bool',
+              '@odata.context' => 'https://localhost/$metadata#Bool',
               'value' => [
-                { '@odata.id' => 'Bool(\'3\')', 'id' => '3', 'boolean' => true, 'maybe' => false }
+                { '@odata.id' => 'https://localhost/Bool(\'3\')', 'id' => '3', 'boolean' => true, 'maybe' => false }
               ]
             }
           )

--- a/spec/odata_duty/schema_builder/entity_type/enum_type_spec.rb
+++ b/spec/odata_duty/schema_builder/entity_type/enum_type_spec.rb
@@ -37,7 +37,7 @@ end
 module OdataDuty
   RSpec.describe SchemaBuilder::EntityType, 'Can use boolean primitive type' do
     subject(:schema) do
-      SchemaBuilder.build(namespace: 'SampleSpace', host: 'localhost') do |s|
+      SchemaBuilder.build(namespace: 'SampleSpace', host: 'localhost', base_path: '') do |s|
         enum_type = s.add_enum_type(name: 'BoolValues') do |en|
           en.member 'one'
           en.member 'two'
@@ -57,7 +57,7 @@ module OdataDuty
 
     describe '#metadata_xml' do
       let(:parsed_xml) do
-        parse_xml_from_string(EdmxSchema.metadata_xml(schema))
+        parse_xml_from_string(schema.metadata_xml)
       end
       let(:entity_types) { entity_types_from_doc(parsed_xml) }
       let(:keys) { entity_type.fetch(:keys) }
@@ -87,11 +87,13 @@ module OdataDuty
           response = Oj.load(json_string)
           expect(response).to eq(
             {
-              '@odata.context' => '$metadata#Enum',
+              '@odata.context' => 'https://localhost/$metadata#Enum',
               'value' => [
-                { '@odata.id' => 'Enum(\'1\')', 'id' => '1', 'enum' => 'one', 'maybe' => nil },
-                { '@odata.id' => 'Enum(\'2\')', 'id' => '2', 'enum' => 'two', 'maybe' => 'one' },
-                { '@odata.id' => 'Enum(\'3\')', 'id' => '3', 'enum' => 'one', 'maybe' => 'two' }
+                { '@odata.id' => 'https://localhost/Enum(\'1\')', 'id' => '1', 'enum' => 'one',
+                  'maybe' => nil },
+                { '@odata.id' => 'https://localhost/Enum(\'2\')', 'id' => '2', 'enum' => 'two',
+                  'maybe' => 'one' },
+                { '@odata.id' => 'https://localhost/Enum(\'3\')', 'id' => '3', 'enum' => 'one', 'maybe' => 'two' }
               ]
             }
           )
@@ -103,10 +105,11 @@ module OdataDuty
           response = Oj.load(json_string)
           expect(response).to eq(
             {
-              '@odata.context' => '$metadata#Enum',
+              '@odata.context' => 'https://localhost/$metadata#Enum',
               'value' => [
-                { '@odata.id' => 'Enum(\'1\')', 'id' => '1', 'enum' => 'one', 'maybe' => nil },
-                { '@odata.id' => 'Enum(\'3\')', 'id' => '3', 'enum' => 'one', 'maybe' => 'two' }
+                { '@odata.id' => 'https://localhost/Enum(\'1\')', 'id' => '1', 'enum' => 'one',
+                  'maybe' => nil },
+                { '@odata.id' => 'https://localhost/Enum(\'3\')', 'id' => '3', 'enum' => 'one', 'maybe' => 'two' }
               ]
             }
           )
@@ -118,9 +121,9 @@ module OdataDuty
           response = Oj.load(json_string)
           expect(response).to eq(
             {
-              '@odata.context' => '$metadata#Enum',
+              '@odata.context' => 'https://localhost/$metadata#Enum',
               'value' => [
-                { '@odata.id' => 'Enum(\'3\')', 'id' => '3', 'enum' => 'one', 'maybe' => 'two' }
+                { '@odata.id' => 'https://localhost/Enum(\'3\')', 'id' => '3', 'enum' => 'one', 'maybe' => 'two' }
               ]
             }
           )

--- a/spec/odata_duty/schema_builder/entity_type/property_method_spec.rb
+++ b/spec/odata_duty/schema_builder/entity_type/property_method_spec.rb
@@ -14,7 +14,7 @@ end
 module OdataDuty
   RSpec.describe SchemaBuilder::EntityType, 'Can suggest an alternative method' do
     subject(:schema) do
-      SchemaBuilder.build(namespace: 'SampleSpace', host: 'localhost') do |s|
+      SchemaBuilder.build(namespace: 'SampleSpace', host: 'localhost', base_path: '') do |s|
         a_complex_type = s.add_complex_type(name: 'SimpleComplex') do |et|
           et.property 'string', String
         end
@@ -37,9 +37,9 @@ module OdataDuty
         response = Oj.load(json_string)
         expect(response).to eq(
           {
-            '@odata.context' => '$metadata#AlternativeMethods',
+            '@odata.context' => 'https://localhost/$metadata#AlternativeMethods',
             'value' => [
-              { '@odata.id' => 'AlternativeMethods(\'1\')',
+              { '@odata.id' => 'https://localhost/AlternativeMethods(\'1\')',
                 'id' => '1',
                 'string' => 'alternative_string',
                 'combined' => '1-alternative_string',

--- a/spec/odata_duty/schema_builder_spec.rb
+++ b/spec/odata_duty/schema_builder_spec.rb
@@ -60,9 +60,9 @@ module OdataDuty
 
     describe '#index_hash' do
       it do
-        expect(EdmxSchema.index_hash(schema))
+        expect(schema.index_hash('$metadata'))
           .to eq({
-                   '@odata.context': 'http://localhost/$metadata',
+                   '@odata.context': '$metadata',
                    value: [{ kind: 'EntitySet', name: 'People', url: 'People' }]
                  })
       end
@@ -70,7 +70,7 @@ module OdataDuty
 
     describe '#metadata_xml' do
       it 'works' do
-        generated_xml = format_xml(EdmxSchema.metadata_xml(schema))
+        generated_xml = format_xml(schema.metadata_xml)
         expected_xml = format_xml(File.read("#{__dir__}/../metadata.xml"))
         expect(generated_xml).to eq(expected_xml)
       end
@@ -112,9 +112,9 @@ module OdataDuty
           response = Oj.load(
             schema.execute('People', context: Context.new)
           )
-          expect(response['@odata.context']).to eq('$metadata#People')
+          expect(response['@odata.context']).to eq('http://localhost/$metadata#People')
           expect(response['value'][0]).to eq(
-            '@odata.id' => 'People(\'1\')',
+            '@odata.id' => 'http://localhost/People(\'1\')',
             'id' => '1', 'user_name' => 'user1', 'name' => 'User',
             'emails' => ['user@email.com'],
             'address_info' => [
@@ -132,7 +132,7 @@ module OdataDuty
           response = Oj.load(
             schema.execute('People', context: Context.new, query_options: { 'none' => 'true' })
           )
-          expect(response['@odata.context']).to eq('$metadata#People')
+          expect(response['@odata.context']).to eq('http://localhost/$metadata#People')
           expect(response['value']).to be_empty
         end
       end
@@ -150,8 +150,8 @@ module OdataDuty
           json_string = schema.execute("People('1')", context: Context.new)
           response = Oj.load(json_string)
           expect(response).to eq(
-            '@odata.context' => '$metadata#People/$entity',
-            '@odata.id' => 'People(\'1\')',
+            '@odata.context' => 'http://localhost/$metadata#People/$entity',
+            '@odata.id' => 'http://localhost/People(\'1\')',
             'id' => '1',
             'user_name' => 'user1',
             'name' => 'User',
@@ -164,6 +164,298 @@ module OdataDuty
             }],
             'gender' => 'Male',
             'concurrency' => 11
+          )
+        end
+      end
+    end
+
+    describe 'mcp' do
+      let(:mcp_server) do
+        schema # reuses existing OData schema setup
+      end
+
+      describe 'initialize' do
+        let(:context)      { Context.new }
+        let(:client_caps)  { { 'roots' => {}, 'sampling' => {} } }
+        let(:server_caps)  do
+          {
+            'logging' => {},
+            'prompts' => { 'listChanged' => false },
+            'resources' => { 'subscribe' => false, 'listChanged' => false },
+            'tools' => { 'listChanged' => false }
+          }
+        end
+
+        describe 'successful initialize' do
+          let(:request_payload) do
+            {
+              'jsonrpc' => '2.0',
+              'id' => 'init‑444',
+              'method' => 'initialize',
+              'params' => {
+                'protocolVersion' => '2024-11-05',
+                'capabilities' => client_caps,
+                'clientInfo' => { 'name' => 'RSpecClient', 'version' => '0.0.1' }
+              }
+            }
+          end
+
+          it 'it returns the version' do
+            raw = schema.handle_jsonrpc(request_payload, context: context)
+            response = Oj.load(raw)
+
+            expect(response).to eq(
+              'jsonrpc' => '2.0',
+              'id' => 'init‑444',
+              'result' => {
+                'protocolVersion' => '2024-11-05',
+                'capabilities' => server_caps,
+                'serverInfo' => { 'name' => 'This is a sample OData service.',
+                                  'version' => '1.2.3' }
+              }
+            )
+          end
+        end
+      end
+
+      describe 'notifications/initialized' do
+        let(:request_payload) do
+          {
+            'jsonrpc' => '2.0',
+            'method' => 'notifications/initialized',
+            'params' => {},
+            'id' => 'req-4'
+          }
+        end
+
+        it 'returns an empty response' do
+          actual = mcp_server.handle_jsonrpc(request_payload, context: Context.new)
+          expect(actual).to be_nil
+        end
+      end
+
+      describe 'resources/list' do
+        let(:request_payload) do
+          {
+            'jsonrpc' => '2.0',
+            'method' => 'resources/list',
+            'params' => {},
+            'id' => 'req-5'
+          }
+        end
+
+        let(:expected) do
+          {
+            'jsonrpc' => '2.0',
+            'id' => 'req-5',
+            'result' => {
+              'resources' => [
+                {
+                  'uri' => 'People/$count',
+                  'name' => 'People Count',
+                  'description' => 'Get a count of People records',
+                  'mimeType' => 'text/plain'
+                }
+              ]
+            }
+          }
+        end
+
+        it 'returns direct resources' do
+          actual = Oj.load(mcp_server.handle_jsonrpc(request_payload, context: Context.new))
+          actual_indexed = actual['result']['resources'].to_h { |r| [r['uri'], r] }
+          expected_indexed = expected['result']['resources'].to_h { |r| [r['uri'], r] }
+          expect(actual_indexed.keys).to match_array(expected_indexed.keys)
+          actual_indexed.each_key do |key|
+            expect(actual_indexed[key]).to eq(expected_indexed[key])
+          end
+        end
+      end
+
+      describe 'resources/templates/list' do
+        let(:request_payload) do
+          {
+            'jsonrpc' => '2.0',
+            'method' => 'resources/templates/list',
+            'params' => {},
+            'id' => 'req-5'
+          }
+        end
+
+        let(:expected) do
+          {
+            'jsonrpc' => '2.0',
+            'id' => 'req-5',
+            'result' => {
+              'resourceTemplates' => [
+                {
+                  'uriTemplate' => 'People(\'{id}\')',
+                  'name' => 'Person',
+                  'description' => 'Retrieve a specific Person record by ID',
+                  'mimeType' => 'application/json'
+                },
+                {
+                  'uriTemplate' => 'People?$top={top}&$skip={skip}',
+                  'name' => 'Paginated People Collection',
+                  'description' => 'Retrieve paginated People records',
+                  'mimeType' => 'application/json'
+                }
+              ]
+            }
+          }
+        end
+
+        it 'returns resource templates' do
+          actual = Oj.load(mcp_server.handle_jsonrpc(request_payload, context: Context.new))
+
+          actual_indexed = actual['result']['resourceTemplates'].to_h { |r| [r['uriTemplate'], r] }
+          expected_indexed = expected['result']['resourceTemplates'].to_h do |r|
+            [r['uriTemplate'], r]
+          end
+          expect(actual_indexed.keys).to match_array(expected_indexed.keys)
+          actual_indexed.each_key do |key|
+            expect(actual_indexed[key]).to eq(expected_indexed[key])
+          end
+        end
+      end
+
+      describe 'resources/read' do
+        let(:request_payload) do
+          {
+            'jsonrpc' => '2.0',
+            'method' => 'resources/read',
+            'params' => { 'uri' => "People('1')" },
+            'id' => 'req-6'
+          }
+        end
+
+        let(:expected_response) do
+          {
+            'jsonrpc' => '2.0',
+            'id' => 'req-6',
+            'result' => {
+              'contents' => [
+                {
+                  'uri' => "People('1')",
+                  'mimeType' => 'application/json',
+                  'text' => Oj.dump(
+                    'id' => '1',
+                    'user_name' => 'user1',
+                    'name' => 'User',
+                    'emails' => ['user@email.com'],
+                    'address_info' => [
+                      {
+                        'address' => 'address',
+                        'city' => {
+                          'country_region' => 'country',
+                          'name' => 'name',
+                          'region' => 'region'
+                        }
+                      }
+                    ],
+                    'gender' => 'Male',
+                    'concurrency' => 11,
+                    '@odata.id' => 'http://localhost/People(\'1\')',
+                    '@odata.context' => 'http://localhost/$metadata#People/$entity'
+                  )
+                }
+              ]
+            }
+          }
+        end
+
+        it 'retrieves a specific resource successfully' do
+          result = mcp_server.handle_jsonrpc(request_payload, context: Context.new)
+          actual_response = Oj.load(result)
+          expect(actual_response.keys).to match_array(expected_response.keys)
+          actual_contents = actual_response['result']['contents'][0]
+          expected_contents = expected_response['result']['contents'][0]
+          expect(actual_contents.keys).to match_array(expected_contents.keys)
+          expect(Oj.load(actual_contents['text'])).to eq(Oj.load(expected_contents['text']))
+          expect(actual_contents).to eq(expected_contents)
+        end
+      end
+
+      describe 'tool.invoke (createPerson)' do
+        let(:request_payload) do
+          {
+            'jsonrpc' => '2.0',
+            'method' => 'tool.invoke',
+            'params' => {
+              'name' => 'createPerson',
+              'arguments' => {
+                'user_name' => 'janedoe',
+                'name' => 'Jane Doe',
+                'emails' => ['jane@example.com'],
+                'gender' => 'Female',
+                'concurrency' => 1,
+                'address_info' => [{
+                  'address' => '123 Lane',
+                  'city' => {
+                    'country_region' => 'CountryX',
+                    'name' => 'CityX',
+                    'region' => 'RegionX'
+                  }
+                }]
+              }
+            },
+            'id' => 'req-2'
+          }
+        end
+
+        let(:expected_response) do
+          {
+            'jsonrpc' => '2.0',
+            'id' => 'req-2',
+            'result' => hash_including(
+              'id' => kind_of(String), # id generated by server
+              'user_name' => 'janedoe',
+              'name' => 'Jane Doe',
+              'emails' => ['jane@example.com'],
+              'gender' => 'Female',
+              'concurrency' => 1,
+              'address_info' => [{
+                'address' => '123 Lane',
+                'city' => {
+                  'country_region' => 'CountryX',
+                  'name' => 'CityX',
+                  'region' => 'RegionX'
+                }
+              }]
+            )
+          }
+        end
+
+        it 'creates a new person resource' do
+          skip
+          actual_response = Oj.load(
+            mcp_server.handle_jsonrpc(Oj.dump(request_payload))
+          )
+          expect(actual_response).to match(expected_response)
+        end
+      end
+
+      describe 'tool.invoke (errors)' do
+        let(:request_payload_invalid_method) do
+          {
+            'jsonrpc' => '2.0',
+            'method' => 'tool.invoke',
+            'params' => {
+              'name' => 'nonExistentTool',
+              'arguments' => {}
+            },
+            'id' => 'req-3'
+          }
+        end
+
+        it 'handles invalid tool errors' do
+          skip
+          actual_response = Oj.load(
+            mcp_server.handle_jsonrpc(Oj.dump(request_payload_invalid_method))
+          )
+          expect(actual_response['error']).to include(
+            'code' => -32_601, # JSON-RPC method not found
+            'message' => 'Method nonExistentTool not found.'
           )
         end
       end

--- a/spec/odata_duty/schema_builder_spec.rb
+++ b/spec/odata_duty/schema_builder_spec.rb
@@ -60,9 +60,9 @@ module OdataDuty
 
     describe '#index_hash' do
       it do
-        expect(schema.index_hash('$metadata'))
+        expect(schema.index_hash)
           .to eq({
-                   '@odata.context': '$metadata',
+                   '@odata.context': 'http://localhost/$metadata',
                    value: [{ kind: 'EntitySet', name: 'People', url: 'People' }]
                  })
       end

--- a/spec/odata_duty_spec.rb
+++ b/spec/odata_duty_spec.rb
@@ -62,6 +62,7 @@ class SampleSchema < OdataDuty::Schema
   namespace 'SampleSpace'
   version '1.2.3'
   title 'This is a sample OData service.'
+  base_url 'http://localhost'
   entity_sets [PeopleSet]
 end
 
@@ -93,7 +94,7 @@ RSpec.describe OdataDuty do
         expect(response).to eq(
           {
             'value' => [{
-              '@odata.id' => 'People(\'1\')',
+              '@odata.id' => 'http://localhost/People(\'1\')',
               'id' => '1', 'user_name' => 'user1', 'name' => 'User',
               'emails' => ['user@email.com'],
               'address_info' => [
@@ -104,7 +105,7 @@ RSpec.describe OdataDuty do
               ],
               'gender' => 'Male', 'concurrency' => 11
             }],
-            '@odata.context' => '$metadata#People'
+            '@odata.context' => 'http://localhost/$metadata#People'
           }
         )
       end
@@ -122,8 +123,8 @@ RSpec.describe OdataDuty do
         json_string = SampleSchema.execute("People('1')", context: Context.new)
         response = Oj.load(json_string)
         expect(response).to eq(
-          { '@odata.context' => '$metadata#People/$entity',
-            '@odata.id' => 'People(\'1\')',
+          { '@odata.context' => 'http://localhost/$metadata#People/$entity',
+            '@odata.id' => 'http://localhost/People(\'1\')',
             'id' => '1',
             'user_name' => 'user1',
             'name' => 'User',
@@ -160,8 +161,8 @@ RSpec.describe OdataDuty do
                                                   query_options: attributes)
       response = Oj.load(json_string)
       expect(response).to eq(
-        { '@odata.context' => '$metadata#People/$entity',
-          '@odata.id' => 'People(\'111\')',
+        { '@odata.context' => 'http://localhost/$metadata#People/$entity',
+          '@odata.id' => 'http://localhost/People(\'111\')',
           'id' => '111',
           'user_name' => 'user2',
           'name' => 'User2',

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -71,12 +71,11 @@ module TestHelpers
   end
 end
 
-Context = Struct.new(:endpoint) do
-  def url_for(url:, anchor: nil, **params)
-    params_joined = params.transform_keys(&:to_s).map { |k, v| "#{k}=#{v}" }.join('&')
-    "#{url}#{params_joined == '' ? '' : "?#{params_joined}"}#{anchor ? "##{anchor}" : ''}"
-  end
-end
+Context = Struct.new(:endpoint)
+# def url_for(url:, anchor: nil, **params)
+#   params_joined = params.transform_keys(&:to_s).map { |k, v| "#{k}=#{v}" }.join('&')
+#   "#{url}#{params_joined == '' ? '' : "?#{params_joined}"}#{anchor ? "##{anchor}" : ''}"
+# end
 
 CountryCity = Struct.new(:country_region, :name, :region) do
   def self.all

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -72,10 +72,6 @@ module TestHelpers
 end
 
 Context = Struct.new(:endpoint)
-# def url_for(url:, anchor: nil, **params)
-#   params_joined = params.transform_keys(&:to_s).map { |k, v| "#{k}=#{v}" }.join('&')
-#   "#{url}#{params_joined == '' ? '' : "?#{params_joined}"}#{anchor ? "##{anchor}" : ''}"
-# end
 
 CountryCity = Struct.new(:country_region, :name, :region) do
   def self.all


### PR DESCRIPTION
This is initial work to support the 2024-11-05 Model Context Protocol : https://modelcontextprotocol.io/specification/2024-11-05/server
This change is first step towards supporting reporting tools, no automation tools and LLMs with the same ruby DSL
This is not the final solution but only the first step.

Initial support for the following methods:
* initialize
* resources/list
* resources/templates/list
* resources/read