### PR TITLE
Handle `nil` in array types

### DIFF
--- a/lib/odata_duty/dynamic_object_wrapper.rb.erb
+++ b/lib/odata_duty/dynamic_object_wrapper.rb.erb
@@ -10,20 +10,25 @@ Class.new(MapperBuilder) do
     <% end %>
 
   <% if property.collection? %>
-    <% if property.scalar? %> 
+    <% if property.scalar? %>
+      begin 
       <% if property.boolean? %>
         <%= property.name %>_value&.map{ |rw| confirm_boolean("<%= property.name %>", rw) }
       <% elsif property.string? %>
-        <%= property.name %>_value = <%= property.name %>_value&.map(&:to_str)
+        <%= property.name %>_value = <%= property.name %>_value&.map{ |v| v&.to_str }
       <% elsif property.int? %>
-        <%= property.name %>_value = <%= property.name %>_value&.map(&:to_int)
+        <%= property.name %>_value = <%= property.name %>_value&.map{ |v| v&.to_int }
       <% elsif property.date? %>
-        <%= property.name %>_value = <%= property.name %>_value&.map(&:to_date)&.map(&:iso8601)
+        <%= property.name %>_value = <%= property.name %>_value&.map{ |v| v&.to_date&.iso8601 }
       <% elsif property.datetime? %>
-        <%= property.name %>_value = <%= property.name %>_value&.map(&:to_datetime)&.map(&:iso8601)
+        <%= property.name %>_value = <%= property.name %>_value&.map{ |v| v&.to_datetime&.iso8601 }
       <% else %>
         raise('<%= property.type %> Coming soon')
       <% end %>
+      rescue NoMethodError => e
+        e.backtrace.unshift "<%= property.line__defined__at %>"
+        raise InvalidValue.new(e)
+      end
     <% else %>
       <%= property.name %>_value = <%= property.name %>_value&.map{ |rw| @<%= property.name %>_mapper.obj_to_base_hash(rw) }
     <% end %>

--- a/odata_duty.gemspec
+++ b/odata_duty.gemspec
@@ -2,7 +2,7 @@
 
 Gem::Specification.new do |spec|
   spec.name          = 'odata_duty'
-  spec.version       = '0.10.0'
+  spec.version       = '0.10.1'
   spec.authors       = ['Grant Petersen-Speelman']
   spec.email         = ['grant@nexl.io']
 

--- a/spec/odata_duty/schema_builder/entity_type/date_array_type_spec.rb
+++ b/spec/odata_duty/schema_builder/entity_type/date_array_type_spec.rb
@@ -1,0 +1,107 @@
+require 'spec_helper'
+
+class ForceDate
+  def initialize(value)
+    @value = value
+  end
+
+  def to_date
+    Date.parse(@value.to_s)
+  end
+end
+
+class DateArrayResolver < OdataDuty::SetResolver
+  def od_after_init
+    @records = [
+      OpenStruct.new(id: 1, dates: [Date.new(2023, 1, 1), Date.new(2023, 1, 2)]),
+      OpenStruct.new(id: 2, dates: []),
+      OpenStruct.new(id: 3, dates: [ForceDate.new('2023-01-03')]),
+      OpenStruct.new(id: 4, dates: nil),
+      OpenStruct.new(id: 5, dates: [nil])
+    ]
+  end
+
+  def collection
+    @records
+  end
+
+  def count
+    @records.count
+  end
+end
+
+class DateArrayInvalidResolver < OdataDuty::SetResolver
+  def collection
+    [
+      OpenStruct.new(id: 1, dates: [:invalid_date])
+    ]
+  end
+end
+
+module OdataDuty
+  RSpec.describe SchemaBuilder::EntityType, 'Can use array date primitive type' do
+    subject(:schema) do
+      SchemaBuilder.build(namespace: 'SampleSpace', host: 'localhost', base_path: '') do |s|
+        date_entity = s.add_entity_type(name: 'DateValues') do |et|
+          et.property_ref 'id', Integer
+          et.property 'dates', [Date], nullable: true
+        end
+
+        s.add_entity_set(name: 'DateInvalid', entity_type: date_entity,
+                         resolver: 'DateArrayInvalidResolver')
+        s.add_entity_set(name: 'Date', entity_type: date_entity,
+                         resolver: 'DateArrayResolver')
+      end
+    end
+
+    describe '#metadata_xml' do
+      let(:parsed_xml) do
+        parse_xml_from_string(schema.metadata_xml)
+      end
+      let(:entity_types) { entity_types_from_doc(parsed_xml) }
+      let(:keys) { entity_type.fetch(:keys) }
+      let(:properties) { entity_type.fetch(:properties) }
+
+      it { expect(entity_types.keys).to contain_exactly('DateValues') }
+
+      describe 'DateValues' do
+        let(:entity_type) { entity_types['DateValues'] }
+
+        it { expect(keys).to eq(['id']) }
+        it do
+          expect(properties).to include(name: 'dates',
+                                        type: 'Collection(Edm.Date)',
+                                        nullable: 'true')
+        end
+      end
+    end
+
+    describe '#collection' do
+      describe 'DateArrayResolver' do
+        it do
+          json_string = schema.execute('Date', context: Context.new)
+          response = Oj.load(json_string)
+          expect(response).to eq(
+            'value' => [
+              { '@odata.id' => 'https://localhost/Date(1)', 'id' => 1,
+                'dates' => %w[2023-01-01 2023-01-02] },
+              { '@odata.id' => 'https://localhost/Date(2)', 'id' => 2, 'dates' => [] },
+              { '@odata.id' => 'https://localhost/Date(3)', 'id' => 3, 'dates' => ['2023-01-03'] },
+              { '@odata.id' => 'https://localhost/Date(4)', 'id' => 4, 'dates' => nil },
+              { '@odata.id' => 'https://localhost/Date(5)', 'id' => 5, 'dates' => [nil] }
+            ],
+            '@odata.context' => 'https://localhost/$metadata#Date'
+          )
+        end
+      end
+
+      describe 'DateArrayInvalidResolver' do
+        it do
+          expect do
+            schema.execute('DateInvalid', context: Context.new)
+          end.to raise_error(OdataDuty::InvalidValue)
+        end
+      end
+    end
+  end
+end

--- a/spec/odata_duty/schema_builder/entity_type/datetime_array_type_spec.rb
+++ b/spec/odata_duty/schema_builder/entity_type/datetime_array_type_spec.rb
@@ -1,0 +1,109 @@
+require 'spec_helper'
+
+class ForceDateTime
+  def initialize(value)
+    @value = value
+  end
+
+  def to_datetime
+    DateTime.parse(@value.to_s)
+  end
+end
+
+class DateTimeArrayResolver < OdataDuty::SetResolver
+  def od_after_init
+    @records = [
+      OpenStruct.new(id: 1, datetimes: [DateTime.new(2023, 1, 1, 12, 0, 0),
+                                        DateTime.new(2023, 1, 2, 12, 0, 0)]),
+      OpenStruct.new(id: 2, datetimes: []),
+      OpenStruct.new(id: 3, datetimes: [ForceDateTime.new('2023-01-03T12:00:00')]),
+      OpenStruct.new(id: 4, datetimes: nil),
+      OpenStruct.new(id: 5, datetimes: [nil])
+    ]
+  end
+
+  def collection
+    @records
+  end
+
+  def count
+    @records.count
+  end
+end
+
+class DateTimeArrayInvalidResolver < OdataDuty::SetResolver
+  def collection
+    [
+      OpenStruct.new(id: 1, datetimes: [:invalid_datetime])
+    ]
+  end
+end
+
+module OdataDuty
+  RSpec.describe SchemaBuilder::EntityType, 'Can use array datetime primitive type' do
+    subject(:schema) do
+      SchemaBuilder.build(namespace: 'SampleSpace', host: 'localhost', base_path: '') do |s|
+        datetime_entity = s.add_entity_type(name: 'DateTimeValues') do |et|
+          et.property_ref 'id', Integer
+          et.property 'datetimes', [DateTime], nullable: true
+        end
+
+        s.add_entity_set(name: 'DateTimeInvalid', entity_type: datetime_entity,
+                         resolver: 'DateTimeArrayInvalidResolver')
+        s.add_entity_set(name: 'DateTime', entity_type: datetime_entity,
+                         resolver: 'DateTimeArrayResolver')
+      end
+    end
+
+    describe '#metadata_xml' do
+      let(:parsed_xml) do
+        parse_xml_from_string(schema.metadata_xml)
+      end
+      let(:entity_types) { entity_types_from_doc(parsed_xml) }
+      let(:keys) { entity_type.fetch(:keys) }
+      let(:properties) { entity_type.fetch(:properties) }
+
+      it { expect(entity_types.keys).to contain_exactly('DateTimeValues') }
+
+      describe 'DateTimeValues' do
+        let(:entity_type) { entity_types['DateTimeValues'] }
+
+        it { expect(keys).to eq(['id']) }
+        it do
+          expect(properties).to include(name: 'datetimes',
+                                        type: 'Collection(Edm.DateTimeOffset)',
+                                        nullable: 'true')
+        end
+      end
+    end
+
+    describe '#collection' do
+      describe 'DateTimeArrayResolver' do
+        it do
+          json_string = schema.execute('DateTime', context: Context.new)
+          response = Oj.load(json_string)
+          expect(response).to eq(
+            'value' => [
+              { '@odata.id' => 'https://localhost/DateTime(1)', 'id' => 1,
+                'datetimes' => ['2023-01-01T12:00:00+00:00', '2023-01-02T12:00:00+00:00'] },
+              { '@odata.id' => 'https://localhost/DateTime(2)', 'id' => 2, 'datetimes' => [] },
+              { '@odata.id' => 'https://localhost/DateTime(3)', 'id' => 3,
+                'datetimes' => ['2023-01-03T12:00:00+00:00'] },
+              { '@odata.id' => 'https://localhost/DateTime(4)', 'id' => 4, 'datetimes' => nil },
+              { '@odata.id' => 'https://localhost/DateTime(5)', 'id' => 5, 'datetimes' => [nil] }
+            ],
+            '@odata.context' => 'https://localhost/$metadata#DateTime'
+          )
+        end
+      end
+
+      describe 'DateTimeArrayInvalidResolver' do
+        it do
+          expect do
+            schema.execute('DateTimeInvalid', context: Context.new)
+          end.to raise_error(OdataDuty::InvalidValue)
+        end
+      end
+    end
+  end
+end

--- a/spec/odata_duty/schema_builder/entity_type/integer_array_type_spec.rb
+++ b/spec/odata_duty/schema_builder/entity_type/integer_array_type_spec.rb
@@ -1,0 +1,106 @@
+require 'spec_helper'
+
+class ForceInt
+  def initialize(value)
+    @value = value
+  end
+
+  def to_int
+    @value.to_i
+  end
+end
+
+class IntegerArrayResolver < OdataDuty::SetResolver
+  def od_after_init
+    @records = [
+      OpenStruct.new(id: 1, integers: [1, 2]),
+      OpenStruct.new(id: 2, integers: []),
+      OpenStruct.new(id: 3, integers: [ForceInt.new('101')]),
+      OpenStruct.new(id: 4, integers: nil),
+      OpenStruct.new(id: 5, integers: [nil])
+    ]
+  end
+
+  def collection
+    @records
+  end
+
+  def count
+    @records.count
+  end
+end
+
+class IntegerArraySymbolInvalidResolver < OdataDuty::SetResolver
+  def collection
+    [
+      OpenStruct.new(id: 1, integers: [:sym])
+    ]
+  end
+end
+
+module OdataDuty
+  RSpec.describe SchemaBuilder::EntityType, 'Can use array integer primitive type' do
+    subject(:schema) do
+      SchemaBuilder.build(namespace: 'SampleSpace', host: 'localhost', base_path: '') do |s|
+        bool_entity = s.add_entity_type(name: 'IntegerValues') do |et|
+          et.property_ref 'id', Integer
+          et.property 'integers', [Integer], nullable: true
+        end
+
+        s.add_entity_set(name: 'IntInvalid', entity_type: bool_entity,
+                         resolver: 'IntegerArraySymbolInvalidResolver')
+        s.add_entity_set(name: 'Int', entity_type: bool_entity,
+                         resolver: 'IntegerArrayResolver')
+      end
+    end
+
+    describe '#metadata_xml' do
+      let(:parsed_xml) do
+        parse_xml_from_string(schema.metadata_xml)
+      end
+      let(:entity_types) { entity_types_from_doc(parsed_xml) }
+      let(:keys) { entity_type.fetch(:keys) }
+      let(:properties) { entity_type.fetch(:properties) }
+
+      it { expect(entity_types.keys).to contain_exactly('IntegerValues') }
+
+      describe 'IntegerValues' do
+        let(:entity_type) { entity_types['IntegerValues'] }
+
+        it { expect(keys).to eq(['id']) }
+        it do
+          expect(properties).to include(name: 'integers',
+                                        type: 'Collection(Edm.Int64)',
+                                        nullable: 'true')
+        end
+      end
+    end
+
+    describe '#collection' do
+      describe 'IntegerArrayResolver' do
+        it do
+          json_string = schema.execute('Int', context: Context.new)
+          response = Oj.load(json_string)
+          expect(response).to eq(
+            'value' => [
+              { '@odata.id' => 'https://localhost/Int(1)', 'id' => 1, 'integers' => [1, 2] },
+              { '@odata.id' => 'https://localhost/Int(2)', 'id' => 2, 'integers' => [] },
+              { '@odata.id' => 'https://localhost/Int(3)', 'id' => 3, 'integers' => [101] },
+              { '@odata.id' => 'https://localhost/Int(4)', 'id' => 4, 'integers' => nil },
+              { '@odata.id' => 'https://localhost/Int(5)', 'id' => 5, 'integers' => [nil] }
+            ],
+            '@odata.context' => 'https://localhost/$metadata#Int'
+          )
+        end
+      end
+
+      describe 'IntegerArraySymbolInvalidResolver' do
+        it do
+          expect do
+            schema.execute('IntInvalid', context: Context.new)
+          end.to raise_error(OdataDuty::InvalidValue)
+        end
+      end
+    end
+  end
+end

--- a/spec/odata_duty/schema_builder/entity_type/string_array_type_spec.rb
+++ b/spec/odata_duty/schema_builder/entity_type/string_array_type_spec.rb
@@ -1,0 +1,106 @@
+require 'spec_helper'
+
+class ForceStr
+  def initialize(value)
+    @value = value
+  end
+
+  def to_str
+    @value.to_s
+  end
+end
+
+class StringArrayResolver < OdataDuty::SetResolver
+  def od_after_init
+    @records = [
+      OpenStruct.new(id: 1, strings: %w[t r]),
+      OpenStruct.new(id: 2, strings: []),
+      OpenStruct.new(id: 3, strings: [ForceStr.new(:sym)]),
+      OpenStruct.new(id: 4, strings: nil),
+      OpenStruct.new(id: 5, strings: [nil])
+    ]
+  end
+
+  def collection
+    @records
+  end
+
+  def count
+    @records.count
+  end
+end
+
+class StringArraySymbolInvalidResolver < OdataDuty::SetResolver
+  def collection
+    [
+      OpenStruct.new(id: 1, strings: [:sym])
+    ]
+  end
+end
+
+module OdataDuty
+  RSpec.describe SchemaBuilder::EntityType, 'Can use array string primitive type' do
+    subject(:schema) do
+      SchemaBuilder.build(namespace: 'SampleSpace', host: 'localhost', base_path: '') do |s|
+        bool_entity = s.add_entity_type(name: 'StringValues') do |et|
+          et.property_ref 'id', Integer
+          et.property 'strings', [String], nullable: true
+        end
+
+        s.add_entity_set(name: 'StrInvalid', entity_type: bool_entity,
+                         resolver: 'StringArraySymbolInvalidResolver')
+        s.add_entity_set(name: 'Str', entity_type: bool_entity,
+                         resolver: 'StringArrayResolver')
+      end
+    end
+
+    describe '#metadata_xml' do
+      let(:parsed_xml) do
+        parse_xml_from_string(schema.metadata_xml)
+      end
+      let(:entity_types) { entity_types_from_doc(parsed_xml) }
+      let(:keys) { entity_type.fetch(:keys) }
+      let(:properties) { entity_type.fetch(:properties) }
+
+      it { expect(entity_types.keys).to contain_exactly('StringValues') }
+
+      describe 'StringValues' do
+        let(:entity_type) { entity_types['StringValues'] }
+
+        it { expect(keys).to eq(['id']) }
+        it do
+          expect(properties).to include(name: 'strings',
+                                        type: 'Collection(Edm.String)',
+                                        nullable: 'true')
+        end
+      end
+    end
+
+    describe '#collection' do
+      describe 'StringArrayResolver' do
+        it do
+          json_string = schema.execute('Str', context: Context.new)
+          response = Oj.load(json_string)
+          expect(response).to eq(
+            'value' => [
+              { '@odata.id' => 'https://localhost/Str(1)', 'id' => 1, 'strings' => %w[t r] },
+              { '@odata.id' => 'https://localhost/Str(2)', 'id' => 2, 'strings' => [] },
+              { '@odata.id' => 'https://localhost/Str(3)', 'id' => 3, 'strings' => ['sym'] },
+              { '@odata.id' => 'https://localhost/Str(4)', 'id' => 4, 'strings' => nil },
+              { '@odata.id' => 'https://localhost/Str(5)', 'id' => 5, 'strings' => [nil] }
+            ],
+            '@odata.context' => 'https://localhost/$metadata#Str'
+          )
+        end
+      end
+
+      describe 'StringArraySymbolInvalidResolver' do
+        it do
+          expect do
+            schema.execute('StrInvalid', context: Context.new)
+          end.to raise_error(OdataDuty::InvalidValue)
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Error is raised if any of the values inside an array is nil.
This PR updates the code to be able to handle `nil` inside of an array