### PR TITLE
add support for the OData `$search` query parameter

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,0 +1,2 @@
+inspector: npx @modelcontextprotocol/inspector@0.14.3 -e PORT=9292
+rackup: bundle exec rerun -- bundle exec rackup spec/config.ru

--- a/README.md
+++ b/README.md
@@ -216,6 +216,7 @@ end
 - [OData Crash Course](doc/odata_crash_course.md)
 - [MCP Crash Course](doc/mcp_crash_course.md)
 - [Using `$select`](doc/using_select.md)
+- [Using `$search`](doc/using_search.md)
 
 ---
 

--- a/doc/using_search.md
+++ b/doc/using_search.md
@@ -1,0 +1,147 @@
+# Using `$search` with OdataDuty
+
+The `$search` query option in OData allows clients to perform free-text searches across entity contents. This provides a flexible way to find entities that match search terms without requiring specific property-based filtering.  
+OdataDuty will call the `od_search` method on your entity set—if defined—to allow you to implement custom search logic optimized for your data store. if your `OdataDuty::EntitySet` does not implement `od_search` it will raise an `InvalidQueryOptionError`.
+
+This guide explains how to implement `od_search` in your custom `OdataDuty::EntitySet` class.
+
+## Overview
+
+- **Purpose:** Search across entity contents using free-text queries, providing flexible matching capabilities.
+- **Mechanism:** When a `$search` query option is provided, OdataDuty parses the search expression and passes it to your `od_search` method.
+- **Flexibility:** The exact matching criteria depend on your implementation, allowing for full-text search, partial matching, or other search strategies.
+
+## Implementing `od_search`
+
+To support `$search`, you implement the `od_search` method on your `OdataDuty::EntitySet` subclass. This method should:
+- Accept a search expression string.
+- Filter your internal record collection to include only entities matching the search criteria.
+- Return the filtered collection for further processing.
+
+### Example Implementation
+
+Below is a sample implementation for an entity set that uses ActiveRecord:
+
+```ruby
+class MyCustomEntitySet < OdataDuty::EntitySet
+  # Associate the entity type with this set
+  entity_type MyEntity
+
+  def od_after_init
+    # Assume People.active returns an ActiveRecord collection
+    @records = People.active
+  end
+
+  # Implements the $search logic.
+  # Receives a search expression string (e.g., 'Boise')
+  def od_search(search_expression)
+    # Perform a case-insensitive search across multiple columns
+    @records = @records.where(
+      "LOWER(name) LIKE ? OR LOWER(email) LIKE ? OR LOWER(address) LIKE ?",
+      "%#{search_expression.downcase}%",
+      "%#{search_expression.downcase}%",
+      "%#{search_expression.downcase}%"
+    )
+  end
+
+  # Return a collection of records
+  def collection
+    @records
+  end
+
+  # Return a single record based on its id
+  def individual(id)
+    collection.find(id)
+  end
+end
+```
+
+### Advanced Search Implementation
+
+For more sophisticated search capabilities, you might implement full-text search:
+
+```ruby
+class MyCustomEntitySet < OdataDuty::EntitySet
+  entity_type MyEntity
+
+  def od_after_init
+    @records = People.active
+  end
+
+  def od_search(search_expression)
+    # Use PostgreSQL full-text search
+    @records = @records.where(
+      "to_tsvector('english', name || ' ' || email || ' ' || address) @@ plainto_tsquery('english', ?)",
+      search_expression
+    )
+  end
+
+  def collection
+    @records
+  end
+
+  def individual(id)
+    collection.find(id)
+  end
+end
+```
+
+### How It Works
+
+1. **Parsing `$search`:**  
+   When a client makes a request such as:  
+   ```
+   GET /MyEntitySet?$search=Boise
+   ```  
+   OdataDuty extracts the search expression `"Boise"` and passes it to your `od_search` method.
+
+2. **Invoking `od_search`:**  
+   The framework calls your `od_search` method with the search expression. In the example above, it searches across the `name`, `email`, and `address` columns for entities containing "Boise".
+
+3. **Flexible Matching:**  
+   Unlike `$filter`, `$search` allows for implementation-specific matching logic. You can implement exact matching, partial matching, full-text search, or other search strategies based on your needs.
+
+## Common Error Cases
+
+While implementing `$search`, note the following error scenarios that your service should handle:
+
+- **Invalid Search Expression:**  
+  If the search expression contains invalid characters or syntax, an `InvalidQueryOptionError` should be raised.
+
+- **Search Not Supported:**  
+  If your entity set doesn't implement `od_search`, the framework may return an error or perform a default search implementation.
+
+- **Performance Considerations:**  
+  Large datasets may require indexing or optimized search implementations to maintain acceptable response times.
+
+## Combining with Other Query Options
+
+`$search` can be combined with other OData query options:
+
+```
+GET /MyEntitySet?$search=Boise&$select=name,email
+GET /MyEntitySet?$search=John&$top=10
+GET /MyEntitySet?$search=developer&$orderby=name
+```
+
+When combined with `$filter`, both conditions must be satisfied:
+
+```
+GET /MyEntitySet?$search=Boise&$filter=age gt 25
+```
+
+## Summary
+
+- **Custom Entity Set:**  
+  Subclass `OdataDuty::EntitySet` and implement the required methods (`od_after_init`, `collection`, `individual`), along with your custom `od_search`.
+
+- **Implementing `od_search`:**  
+  Filter your internal records based on the search expression—the exact matching logic is implementation-specific and can range from simple text matching to sophisticated full-text search.
+
+- **Usage:**  
+  When clients pass a `$search` parameter, OdataDuty routes it to your `od_search` implementation to return filtered results.
+
+- **Flexibility:**  
+  Unlike the strict comparison logic of `$filter`, `$search` allows for flexible, implementation-defined matching strategies.
+
+By following these guidelines, you'll provide robust support for the `$search` option in your OData API, enabling powerful search capabilities for your clients.

--- a/doc/using_search.md
+++ b/doc/using_search.md
@@ -213,4 +213,46 @@ GET /MyEntitySet?$search="senior developer" AND NOT intern&$filter=age gt 25
 - **Flexibility:**  
   Unlike the strict comparison logic of `$filter`, `$search` allows for flexible, implementation-defined matching strategies with support for complex boolean logic.
 
-By following these guidelines, you'll provide robust support for the `$search` option in your OData API, enabling powerful search capabilities with AND, OR, and NOT operators for your clients.
+## OData Metadata Integration
+
+When you implement `od_search`, OdataDuty automatically includes the appropriate search capabilities in your OData metadata (`$metadata` endpoint). This ensures that clients can discover search functionality through standard OData metadata inspection.
+
+### Automatic Metadata Generation
+
+The system automatically adds OData Capabilities vocabulary annotations to your metadata:
+
+```xml
+<EntitySet Name="YourEntitySet" EntityType="YourNamespace.YourEntityType">
+    <Annotation Term="Capabilities.SearchRestrictions">
+        <Record>
+            <PropertyValue Property="Searchable" Bool="true" />
+            <PropertyValue Property="UnsupportedExpressions" EnumMember="Capabilities.SearchExpressions/group" />
+        </Record>
+    </Annotation>
+</EntitySet>
+```
+
+### Supported Search Expressions
+
+The metadata indicates that your entity set supports:
+- **Basic search terms** (single words and quoted phrases)
+- **AND operations** (explicit `AND` and implicit)
+- **OR operations** (explicit `OR`)
+- **NOT operations** (negation with `NOT`)
+
+### Unsupported Features
+
+The metadata also indicates that the following are **not supported**:
+- **Grouping with parentheses** (indicated by `SearchExpressions/group`)
+- **Mixed AND/OR operations** in the same expression
+
+### Client Discovery
+
+OData clients can inspect the metadata to determine:
+1. Whether an entity set supports search (`Searchable` property)
+2. Which search expression types are supported
+3. Which search features are restricted
+
+This allows clients to provide appropriate user interfaces and validation for search functionality.
+
+By following these guidelines, you'll provide robust support for the `$search` option in your OData API, enabling powerful search capabilities with AND, OR, and NOT operators for your clients, complete with proper metadata annotations for client discovery.

--- a/doc/using_search.md
+++ b/doc/using_search.md
@@ -7,14 +7,16 @@ This guide explains how to implement `od_search` in your custom `OdataDuty::Enti
 
 ## Overview
 
-- **Purpose:** Search across entity contents using free-text queries, providing flexible matching capabilities.
-- **Mechanism:** When a `$search` query option is provided, OdataDuty parses the search expression and passes it to your `od_search` method.
+- **Purpose:** Search across entity contents using structured search expressions with support for AND, OR, and NOT operators.
+- **Mechanism:** When a `$search` query option is provided, OdataDuty parses the search expression into a `SearchExpression` object and passes it to your `od_search` method.
+- **Operators:** Supports AND (explicit or implicit), OR, and NOT operators following OData v4.01 specification.
 - **Flexibility:** The exact matching criteria depend on your implementation, allowing for full-text search, partial matching, or other search strategies.
 
 ## Implementing `od_search`
 
 To support `$search`, you implement the `od_search` method on your `OdataDuty::EntitySet` subclass. This method should:
-- Accept a search expression string.
+- Accept a `SearchExpression` object containing parsed terms and operators.
+- Handle AND, OR, and NOT operators according to your search strategy.
 - Filter your internal record collection to include only entities matching the search criteria.
 - Return the filtered collection for further processing.
 
@@ -33,16 +35,42 @@ class MyCustomEntitySet < OdataDuty::EntitySet
   end
 
   # Implements the $search logic.
-  # Receives a search expression string (e.g., 'Boise')
+  # Receives a SearchExpression object with parsed terms and operators
   def od_search(search_expression)
-    # Perform a case-insensitive search across multiple columns
-    @records = @records.where(
-      "LOWER(name) LIKE ? OR LOWER(email) LIKE ? OR LOWER(address) LIKE ?",
-      "%#{search_expression.downcase}%",
-      "%#{search_expression.downcase}%",
-      "%#{search_expression.downcase}%"
-    )
+    if search_expression.or?
+      # Handle OR expressions: find records matching any term
+      found_records = []
+      search_expression.terms.each do |term|
+        condition = build_search_condition(term)
+        matches = @records.where(condition)
+        found_records += matches
+      end
+      @records = found_records.uniq
+    else
+      # Handle AND expressions: apply each term sequentially
+      search_expression.terms.each do |term|
+        condition = build_search_condition(term)
+        @records = @records.where(condition)
+      end
+    end
   end
+
+  private
+
+  def build_search_condition(term)
+    # Build search condition based on whether term is negated
+    search_pattern = "%#{term.value.downcase}%"
+    base_condition = "LOWER(name) LIKE ? OR LOWER(email) LIKE ? OR LOWER(address) LIKE ?"
+    
+    if term.not?
+      # Negate the condition
+      "NOT (#{base_condition})"
+    else
+      base_condition
+    end
+  end
+
+  public
 
   # Return a collection of records
   def collection
@@ -91,25 +119,63 @@ end
 1. **Parsing `$search`:**  
    When a client makes a request such as:  
    ```
-   GET /MyEntitySet?$search=Boise
+   GET /MyEntitySet?$search=name AND NOT "old data"
    ```  
-   OdataDuty extracts the search expression `"Boise"` and passes it to your `od_search` method.
+   OdataDuty parses the search expression into a `SearchExpression` object containing:
+   - `terms`: Array of `SearchTerm` objects (e.g., `[{value: "name", negated: false}, {value: "old data", negated: true}]`)
+   - `operator`: `:and` or `:or` indicating how terms should be combined
 
 2. **Invoking `od_search`:**  
-   The framework calls your `od_search` method with the search expression. In the example above, it searches across the `name`, `email`, and `address` columns for entities containing "Boise".
+   The framework calls your `od_search` method with the parsed `SearchExpression`. Your implementation can:
+   - Check `search_expression.or?` or `search_expression.and?` to determine the operator
+   - Iterate through `search_expression.terms` to access each term
+   - Use `term.not?` to check if a term is negated
+   - Access `term.value` to get the actual search text
 
 3. **Flexible Matching:**  
    Unlike `$filter`, `$search` allows for implementation-specific matching logic. You can implement exact matching, partial matching, full-text search, or other search strategies based on your needs.
+
+## Search Syntax Examples
+
+The `$search` query option supports the following syntax:
+
+### Basic Terms
+- `hello` - Single word search
+- `"hello world"` - Quoted phrase search (exact phrase)
+
+### Logical Operators
+- `hello world` - Implicit AND (both terms must match)
+- `hello AND world` - Explicit AND (both terms must match)
+- `hello OR world` - OR operator (either term can match)
+- `NOT hello` - Negation (must not contain "hello")
+
+### Complex Expressions
+- `hello AND NOT world` - AND with negation
+- `"exact phrase" OR word` - Quoted phrases with OR
+- `term1 term2 term3` - Multiple terms with implicit AND
+
+### Important Notes
+- **Operator precedence:** NOT has higher precedence than AND/OR
+- **Mixed operators:** You cannot mix AND and OR in the same expression (raises `NoImplementationError`)
+- **Parentheses:** Not supported and will raise `NoImplementationError` 
+- **Quoted phrases:** Use double quotes for exact phrase matching
+- **Case sensitivity:** Search matching is implementation-dependent
 
 ## Common Error Cases
 
 While implementing `$search`, note the following error scenarios that your service should handle:
 
 - **Invalid Search Expression:**  
-  If the search expression contains invalid characters or syntax, an `InvalidQueryOptionError` should be raised.
+  If the search expression contains invalid characters or syntax, an `InvalidQueryOptionError` will be raised.
+
+- **Mixed Operators:**  
+  Expressions like `apple AND orange OR peach` will raise `NoImplementationError` because mixing AND/OR is not supported.
+
+- **Parentheses:**  
+  Expressions like `(apple OR orange) AND peach` will raise `NoImplementationError` because parentheses are not supported.
 
 - **Search Not Supported:**  
-  If your entity set doesn't implement `od_search`, the framework may return an error or perform a default search implementation.
+  If your entity set doesn't implement `od_search`, the framework will raise `NoImplementationError`.
 
 - **Performance Considerations:**  
   Large datasets may require indexing or optimized search implementations to maintain acceptable response times.
@@ -119,15 +185,15 @@ While implementing `$search`, note the following error scenarios that your servi
 `$search` can be combined with other OData query options:
 
 ```
-GET /MyEntitySet?$search=Boise&$select=name,email
-GET /MyEntitySet?$search=John&$top=10
-GET /MyEntitySet?$search=developer&$orderby=name
+GET /MyEntitySet?$search="John Doe"&$select=name,email
+GET /MyEntitySet?$search=manager OR developer&$top=10
+GET /MyEntitySet?$search=active AND NOT archived&$orderby=name
 ```
 
 When combined with `$filter`, both conditions must be satisfied:
 
 ```
-GET /MyEntitySet?$search=Boise&$filter=age gt 25
+GET /MyEntitySet?$search="senior developer" AND NOT intern&$filter=age gt 25
 ```
 
 ## Summary
@@ -136,12 +202,15 @@ GET /MyEntitySet?$search=Boise&$filter=age gt 25
   Subclass `OdataDuty::EntitySet` and implement the required methods (`od_after_init`, `collection`, `individual`), along with your custom `od_search`.
 
 - **Implementing `od_search`:**  
-  Filter your internal records based on the search expression—the exact matching logic is implementation-specific and can range from simple text matching to sophisticated full-text search.
+  Handle `SearchExpression` objects containing parsed terms with AND, OR, and NOT operators. The exact matching logic is implementation-specific and can range from simple text matching to sophisticated full-text search.
+
+- **Search Expression Structure:**  
+  Access `search_expression.terms` for individual search terms, `search_expression.or?`/`search_expression.and?` for operator type, and `term.not?`/`term.value` for term details.
 
 - **Usage:**  
-  When clients pass a `$search` parameter, OdataDuty routes it to your `od_search` implementation to return filtered results.
+  When clients pass a `$search` parameter, OdataDuty parses it into a structured expression and routes it to your `od_search` implementation to return filtered results.
 
 - **Flexibility:**  
-  Unlike the strict comparison logic of `$filter`, `$search` allows for flexible, implementation-defined matching strategies.
+  Unlike the strict comparison logic of `$filter`, `$search` allows for flexible, implementation-defined matching strategies with support for complex boolean logic.
 
-By following these guidelines, you'll provide robust support for the `$search` option in your OData API, enabling powerful search capabilities for your clients.
+By following these guidelines, you'll provide robust support for the `$search` option in your OData API, enabling powerful search capabilities with AND, OR, and NOT operators for your clients.

--- a/lib/metadata.xml.erb
+++ b/lib/metadata.xml.erb
@@ -1,5 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <edmx:Edmx Version="4.0" xmlns:edmx="http://docs.oasis-open.org/odata/ns/edmx" edmx:schemaLocation="https://docs.oasis-open.org/odata/odata-csdl-xml/v4.01/os/schemas/edm.xsd https://docs.oasis-open.org/odata/odata-csdl-xml/v4.01/os/schemas/edmx.xsd">
+    <edmx:Reference Uri="https://docs.oasis-open.org/odata/odata-vocabularies/v4.0/vocabularies/Org.OData.Capabilities.V1.xml">
+        <edmx:Include Namespace="Org.OData.Capabilities.V1" Alias="Capabilities" />
+    </edmx:Reference>
     <edmx:DataServices>
         <Schema Namespace="<%= metadata.namespace %>" xmlns="http://docs.oasis-open.org/odata/ns/edm">
              <% if metadata.version %><Annotation Term="<%= metadata.namespace %>.Version" String="<%= metadata.version %>" /><% end %>
@@ -33,7 +36,16 @@
             <% end %>
             <EntityContainer Name="Container">
                 <% metadata.entity_sets.each do |entity_set| %>
-                    <EntitySet Name="<%= entity_set.name %>" EntityType="<%= metadata.namespace %>.<%= entity_set.entity_type_name %>" />
+                    <EntitySet Name="<%= entity_set.name %>" EntityType="<%= metadata.namespace %>.<%= entity_set.entity_type_name %>">
+                        <% if entity_set.supports_search? %>
+                            <Annotation Term="Capabilities.SearchRestrictions">
+                                <Record>
+                                    <PropertyValue Property="Searchable" Bool="true" />
+                                    <PropertyValue Property="UnsupportedExpressions" EnumMember="Capabilities.SearchExpressions/group" />
+                                </Record>
+                            </Annotation>
+                        <% end %>
+                    </EntitySet>
                 <% end %>
             </EntityContainer>
         </Schema>

--- a/lib/odata_duty.rb
+++ b/lib/odata_duty.rb
@@ -102,6 +102,11 @@ module OdataDuty
         mapper.obj_to_hash(result, context)
       end
 
+      def supports_search?
+        # Check if the entity set class supports search by looking for the od_search method
+        entity_set.method_defined?(:od_search)
+      end
+
       private
 
       def converted_id(id, context)

--- a/lib/odata_duty.rb
+++ b/lib/odata_duty.rb
@@ -254,5 +254,9 @@ module OdataDuty
     def self.create(url, context:, query_options: {})
       Executor.create(url: url, context: context, query_options: query_options, schema: self)
     end
+
+    def self.handle_jsonrpc(request_hash, context:)
+      MCPExecutor.handle(request_hash: request_hash, schema: self, context: context)
+    end
   end
 end

--- a/lib/odata_duty/executor.rb
+++ b/lib/odata_duty/executor.rb
@@ -176,6 +176,14 @@ module OdataDuty
       set_builder.od_skiptoken(skiptoken) if skiptoken
     end
 
+    def apply_search(set_builder, search_expression)
+      if !set_builder.respond_to?(:od_search) && search_expression
+        raise NoImplementationError, "$search not implemented for #{set_builder.class}"
+      end
+
+      set_builder.od_search(search_expression) if search_expression
+    end
+
     def add_next_link(data, endpoint, set_builder, query_options, context)
       return unless set_builder.od_next_link_skiptoken
 
@@ -197,6 +205,7 @@ module OdataDuty
 
     def individual(set_builder, endpoint, context, props)
       entity_id = extract_value_from_brackets(url)
+      apply_remaining(query_options, set_builder)
 
       Oj.dump(
         endpoint

--- a/lib/odata_duty/executor.rb
+++ b/lib/odata_duty/executor.rb
@@ -1,4 +1,5 @@
 require_relative 'context_wrapper'
+require_relative 'parslet_search_expression'
 
 module OdataDuty
   class Executor # rubocop:disable Metrics/ClassLength
@@ -176,12 +177,15 @@ module OdataDuty
       set_builder.od_skiptoken(skiptoken) if skiptoken
     end
 
-    def apply_search(set_builder, search_expression)
-      if !set_builder.respond_to?(:od_search) && search_expression
+    def apply_search(set_builder, search_string)
+      if !set_builder.respond_to?(:od_search) && search_string
         raise NoImplementationError, "$search not implemented for #{set_builder.class}"
       end
 
-      set_builder.od_search(search_expression) if search_expression
+      return unless search_string
+
+      search_expression = SearchExpression.parse(search_string)
+      set_builder.od_search(search_expression)
     end
 
     def add_next_link(data, endpoint, set_builder, query_options, context)

--- a/lib/odata_duty/mcp_executor.rb
+++ b/lib/odata_duty/mcp_executor.rb
@@ -20,17 +20,8 @@ module OdataDuty
     end
 
     def handle
-      result = case request_hash['method']
-               when 'initialize' then handle_initialize
-               when 'resources/list' then handle_resources_list
-               when 'resources/templates/list' then handle_resources_templates_list
-               when 'resources/read'
-                 { 'contents' => [{
-                   'uri' => uri.path,
-                   'mimeType' => 'application/json',
-                   'text' => handle_resources_read.to_s
-                 }] }
-               end
+      method_name = :"handle_#{request_hash['method'].to_s.tr('/', '_')}"
+      result = send(method_name)
 
       return nil if result.nil?
 
@@ -39,29 +30,30 @@ module OdataDuty
 
     private
 
+    def handle_notifications_initialized; end
+
+    def handle_resources_read
+      { 'contents' => [{ 'uri' => uri.path, 'mimeType' => 'application/json',
+                         'text' => run_resources_read.to_s }] }
+    end
+
     def handle_initialize
       {
         'protocolVersion' => '2024-11-05',
         'capabilities' => {
-          'logging' => {},
-          'prompts' => { 'listChanged' => false },
+          'logging' => {}, 'prompts' => { 'listChanged' => false },
           'resources' => { 'subscribe' => false, 'listChanged' => false },
           'tools' => { 'listChanged' => false }
         },
-        'serverInfo' => {
-          'name' => schema.title,
-          'version' => schema.version
-        }
+        'serverInfo' => { 'name' => schema.title, 'version' => schema.version }
         # "instructions": "Optional instructions for the client"
       }
     end
 
-    def handle_resources_read
+    def run_resources_read
       query_options = CGI.parse(uri.query || '').transform_values(&:first)
-      Executor.execute(url: uri.path,
-                       context: @context,
-                       query_options: query_options,
-                       schema: schema)
+      Executor.execute(url: uri.path, context: @context,
+                       query_options: query_options, schema: schema)
     end
 
     def handle_resources_list
@@ -72,6 +64,47 @@ module OdataDuty
     def handle_resources_templates_list
       resources_list = schema.endpoints.flat_map { |endpoint| resources_for_endpoint(endpoint) }
       { 'resourceTemplates' => resources_list.select { |r| r.key?('uriTemplate') } }
+    end
+
+    def handle_tools_list
+      # Add search tool for each entity set that supports search
+      tools = schema.endpoints.select(&:supports_search?).map do |endpoint|
+        build_tool(endpoint)
+      end
+
+      { 'tools' => tools }
+    end
+
+    def build_tool(endpoint)
+      { 'name' => "search_#{endpoint.name}",
+        'description' => "Search #{endpoint.name} using expressions with AND, OR, NOT operators",
+        'inputSchema' => {
+          'type' => 'object',
+          'properties' => {
+            '$search' => {
+              'type' => 'string',
+              'description' => 'Search query using expressions with AND, OR, NOT operators'
+            }
+          },
+          'required' => ['$search']
+        } }
+    end
+
+    def handle_tools_call
+      tool_name = request_hash['params']['name']
+      query_options = request_hash['params']['arguments'] || {}
+
+      # Parse tool name to extract entity set
+      raise "Unknown tool: #{tool_name}" unless tool_name.start_with?('search_')
+
+      endpoint_name = tool_name[7..] # Remove 'search_' prefix
+      endpoint = schema.endpoints.find { |ep| ep.name == endpoint_name }
+
+      result = Executor.execute(url: endpoint.url, context: context,
+                                query_options: query_options, schema: schema)
+
+      # Parse the JSON result to return it as structured data
+      Oj.load(result)
     end
 
     def resources_for_endpoint(endpoint)

--- a/lib/odata_duty/oas2/collection_get_path.rb
+++ b/lib/odata_duty/oas2/collection_get_path.rb
@@ -9,6 +9,12 @@ module OdataDuty
           'description' => 'Filter the results'
         },
         {
+          'name' => '$search',
+          'in' => 'query',
+          'type' => 'string',
+          'description' => 'Search across entity contents using structured expressions with AND, OR, NOT operators'
+        },
+        {
           'name' => '$select',
           'in' => 'query',
           'type' => 'array',
@@ -59,7 +65,8 @@ module OdataDuty
         '$top' => :od_top,
         '$count' => :count,
         '$skip' => :od_skip,
-        '$skiptoken' => :od_skiptoken
+        '$skiptoken' => :od_skiptoken,
+        '$search' => :od_search
       }.freeze
 
       def to_oas2

--- a/lib/odata_duty/oas2/collection_get_path.rb
+++ b/lib/odata_duty/oas2/collection_get_path.rb
@@ -12,7 +12,7 @@ module OdataDuty
           'name' => '$search',
           'in' => 'query',
           'type' => 'string',
-          'description' => 'Search across entity contents using structured expressions with AND, OR, NOT operators'
+          'description' => 'Search using structured expressions with AND, OR, NOT operators'
         },
         {
           'name' => '$select',
@@ -47,7 +47,6 @@ module OdataDuty
           'description' => 'Token for next page of results'
         }
       ].freeze
-
       COLLECTION_RESPONSE_DEFAULTS = {
         '@odata.nextLink' => {
           'type' => 'string',

--- a/lib/odata_duty/parslet_search_expression.rb
+++ b/lib/odata_duty/parslet_search_expression.rb
@@ -1,0 +1,163 @@
+require 'parslet'
+
+module OdataDuty
+  class SearchExpression
+    attr_reader :terms, :operator
+
+    def initialize(terms, operator = :and)
+      @terms = Array(terms)
+      @operator = operator
+    end
+
+    def or?
+      @operator == :or
+    end
+
+    def and?
+      @operator == :and
+    end
+
+    def self.parse(search_string)
+      return SearchExpression.new([]) if search_string.nil? || search_string.strip.empty?
+
+      parse_tree = build_parse_tree(search_string.strip)
+      validate_parse_tree(parse_tree)
+      transform(parse_tree)
+    end
+
+    def self.build_parse_tree(search_string)
+      parser = ParsletSearchExpressionParser.new
+      parser.parse(search_string)
+    rescue Parslet::ParseFailed => e
+      if search_string.include?('(') || search_string.include?(')')
+        raise NoImplementationError, 'Parentheses are not supported'
+      end
+      if search_string.include?(' AND ') && search_string.include?(' OR ')
+        raise NoImplementationError, 'Mixed AND/OR operators are not supported'
+      end
+
+      raise InvalidQueryOptionError, "Invalid search expression: #{e.message}"
+    end
+
+    def self.validate_parse_tree(parse_tree)
+      and_sub_tree = parse_tree[:explicit_and_expr] || parse_tree[:implicit_and_expr]
+      return unless and_sub_tree
+
+      contains_or = and_sub_tree.any? { |t| t.dig(:term, :word).to_s == 'OR' }
+      raise NoImplementationError, 'Mixed AND/OR operators are not supported' if contains_or
+    end
+
+    def self.transform(parse_tree)
+      transformer = ParsletSearchExpressionTransformer.new
+      transformer.apply(parse_tree)
+    end
+  end
+
+  class SearchTerm
+    attr_reader :value, :negated
+
+    def initialize(value, negated: false)
+      @value = value
+      @negated = negated
+    end
+
+    def not?
+      @negated
+    end
+
+    def to_s
+      prefix = @negated ? 'NOT ' : ''
+      quoted = @value.include?(' ') ? "\"#{@value}\"" : @value
+      "#{prefix}#{quoted}"
+    end
+  end
+
+  class ParsletSearchExpressionParser < Parslet::Parser
+    # Basic elements
+    rule(:space) { match('\s').repeat(1) }
+    rule(:space?) { space.maybe }
+
+    # Word characters - alphanumeric, dots, commas, hyphens, underscores
+    rule(:word_char) { match('[a-zA-Z0-9,.\-_]') }
+    rule(:word) { word_char.repeat(1).as(:word) }
+
+    # Quoted phrases
+    rule(:quoted_phrase) do
+      str('"') >>
+        (str('"').absent? >> any).repeat.as(:phrase) >>
+        str('"')
+    end
+
+    # NOT operator
+    rule(:not_operator) { str('NOT') >> space }
+
+    # Basic term (word or quoted phrase)
+    rule(:basic_term) { quoted_phrase | word }
+
+    # Term with optional negation
+    rule(:term) do
+      (not_operator >> basic_term).as(:negated_term) |
+        basic_term.as(:term)
+    end
+
+    # Operators
+    rule(:and_operator) { space >> str('AND') >> space }
+    rule(:or_operator) { space >> str('OR') >> space }
+    rule(:implicit_and) { space }
+
+    # Simplified expression rules
+    rule(:or_expression) { term >> (or_operator >> term).repeat(1) }
+    rule(:explicit_and_expression) { term >> (and_operator >> term).repeat(1) }
+    rule(:implicit_and_expression) { term >> (implicit_and >> term).repeat(1) }
+    rule(:single_term_expression) { term }
+
+    # Main expression - try each pattern
+    rule(:expression) do
+      or_expression.as(:or_expr) |
+        explicit_and_expression.as(:explicit_and_expr) |
+        implicit_and_expression.as(:implicit_and_expr) |
+        single_term_expression.as(:single_term)
+    end
+
+    # Root rule
+    rule(:search_expression) { space? >> expression >> space? }
+
+    root(:search_expression)
+  end
+
+  class ParsletSearchExpressionTransformer < Parslet::Transform
+    rule(word: simple(:word)) { word.to_s }
+    rule(phrase: simple(:phrase)) { phrase.to_s }
+
+    rule(term: simple(:term)) do
+      SearchTerm.new(term.to_s, negated: false)
+    end
+
+    rule(negated_term: simple(:term)) do
+      SearchTerm.new(term.to_s, negated: true)
+    end
+
+    # Single term expressions
+    rule(single_term: simple(:term)) do
+      SearchExpression.new([term], :and)
+    end
+
+    # OR expressions
+    rule(or_expr: sequence(:terms)) do
+      # Multiple terms in OR expression
+      SearchExpression.new(terms, :or)
+    end
+
+    # Explicit AND expressions
+    rule(explicit_and_expr: sequence(:terms)) do
+      # Multiple terms in explicit AND expression
+      SearchExpression.new(terms, :and)
+    end
+
+    # Implicit AND expressions
+    rule(implicit_and_expr: sequence(:terms)) do
+      # Multiple terms in implicit AND expression
+      SearchExpression.new(terms, :and)
+    end
+  end
+end

--- a/lib/odata_duty/schema_builder/endpoint.rb
+++ b/lib/odata_duty/schema_builder/endpoint.rb
@@ -49,6 +49,10 @@ module OdataDuty
         mapper.obj_to_hash(result, context)
       end
 
+      def supports_search?
+        entity_set.supports_search?
+      end
+
       private
 
       def extend_error(err, set_builder, method_name)

--- a/lib/odata_duty/schema_builder/entity_set.rb
+++ b/lib/odata_duty/schema_builder/entity_set.rb
@@ -18,6 +18,11 @@ module OdataDuty
       def entity_type_name = entity_type.name
 
       def resolver_class = Module.const_get(resolver)
+
+      def supports_search?
+        # Check if the resolver class supports search by looking for the od_search method
+        resolver_class.method_defined?(:od_search)
+      end
     end
   end
 end

--- a/odata_duty.gemspec
+++ b/odata_duty.gemspec
@@ -2,7 +2,7 @@
 
 Gem::Specification.new do |spec|
   spec.name          = 'odata_duty'
-  spec.version       = '0.13.0'
+  spec.version       = '0.14.0'
   spec.authors       = ['Grant Petersen-Speelman']
   spec.email         = ['grant@nexl.io']
 

--- a/odata_duty.gemspec
+++ b/odata_duty.gemspec
@@ -23,6 +23,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
 
   spec.add_dependency 'oj', '>= 3.0.0', '< 5.0.0'
+  spec.add_dependency 'parslet', '~> 2.0'
   spec.add_dependency 'uri', '>= 1.0.0', '< 2.0.0'
   # spec.add_dependency 'securerandom', '>= 0.1.0', '< 2.0.0'
 

--- a/spec/config.ru
+++ b/spec/config.ru
@@ -45,25 +45,31 @@ class TestPersonResolver < OdataDuty::SetResolver
 
   private
 
-  def od_search_or(search_expression)
-    found_records = []
+  def filter_records_by_terms(search_expression, accumulate: false)
+    result_records = accumulate ? [] : @records
+
     search_expression.terms.each do |term|
       matches = @records.select do |record|
         match_found = record.to_h.values.any? { |v| v.to_s.downcase.include?(term.value.downcase) }
         term.not? ? !match_found : match_found
       end
-      found_records += matches
+
+      if accumulate
+        result_records += matches
+      else
+        result_records &= matches
+      end
     end
-    @records = found_records.uniq { |r| r['id'] }
+
+    accumulate ? result_records.uniq { |r| r['id'] } : result_records
+  end
+
+  def od_search_or(search_expression)
+    @records = filter_records_by_terms(search_expression, accumulate: true)
   end
 
   def od_search_and(search_expression)
-    search_expression.terms.each do |term|
-      @records = @records.select do |record|
-        match_found = record.to_h.values.any? { |v| v.to_s.downcase.include?(term.value.downcase) }
-        term.not? ? !match_found : match_found
-      end
-    end
+    @records = filter_records_by_terms(search_expression, accumulate: false)
   end
 end
 

--- a/spec/config.ru
+++ b/spec/config.ru
@@ -45,6 +45,7 @@ class TestPersonResolver < OdataDuty::SetResolver
 
   private
 
+  # rubocop:disable Metrics/PerceivedComplexity,Metrics/CyclomaticComplexity
   def filter_records_by_terms(search_expression, accumulate: false)
     result_records = accumulate ? [] : @records
 
@@ -63,6 +64,7 @@ class TestPersonResolver < OdataDuty::SetResolver
 
     accumulate ? result_records.uniq { |r| r['id'] } : result_records
   end
+  # rubocop:enable Metrics/PerceivedComplexity,Metrics/CyclomaticComplexity
 
   def od_search_or(search_expression)
     @records = filter_records_by_terms(search_expression, accumulate: true)

--- a/spec/config.ru
+++ b/spec/config.ru
@@ -15,6 +15,14 @@ class TestPersonResolver < OdataDuty::SetResolver
     ]
   end
 
+  def od_search(search_expression)
+    if search_expression.or?
+      od_search_or(search_expression)
+    else
+      od_search_and(search_expression)
+    end
+  end
+
   def od_filter_eq(property_name, value)
     @records = @records.select { |record| record.send(property_name) == value }
   end
@@ -34,6 +42,29 @@ class TestPersonResolver < OdataDuty::SetResolver
   def individual(id)
     @records.find { |record| record.id == id.to_i }
   end
+
+  private
+
+  def od_search_or(search_expression)
+    found_records = []
+    search_expression.terms.each do |term|
+      matches = @records.select do |record|
+        match_found = record.to_h.values.any? { |v| v.to_s.downcase.include?(term.value.downcase) }
+        term.not? ? !match_found : match_found
+      end
+      found_records += matches
+    end
+    @records = found_records.uniq { |r| r['id'] }
+  end
+
+  def od_search_and(search_expression)
+    search_expression.terms.each do |term|
+      @records = @records.select do |record|
+        match_found = record.to_h.values.any? { |v| v.to_s.downcase.include?(term.value.downcase) }
+        term.not? ? !match_found : match_found
+      end
+    end
+  end
 end
 
 # rubocop:disable Metrics/MethodLength,Metrics/AbcSize,Metrics/CyclomaticComplexity,Layout/LineLength
@@ -44,7 +75,7 @@ class TestApiApp
       s.title = 'Test OData API'
       s.version = '1.0.0'
       person_entity = s.add_entity_type(name: 'Person') do |et|
-        et.property_ref 'id', String
+        et.property_ref 'id', Integer
         et.property 'user_name', String, nullable: false
         et.property 'name', String
         et.property 'emails', [String], nullable: false

--- a/spec/metadata.xml
+++ b/spec/metadata.xml
@@ -1,6 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 <edmx:Edmx Version="4.0" xmlns:edmx="http://docs.oasis-open.org/odata/ns/edmx"
     edmx:schemaLocation="https://docs.oasis-open.org/odata/odata-csdl-xml/v4.01/os/schemas/edm.xsd https://docs.oasis-open.org/odata/odata-csdl-xml/v4.01/os/schemas/edmx.xsd">
+    <edmx:Reference Uri="https://docs.oasis-open.org/odata/odata-vocabularies/v4.0/vocabularies/Org.OData.Capabilities.V1.xml">
+        <edmx:Include Namespace="Org.OData.Capabilities.V1" Alias="Capabilities" />
+    </edmx:Reference>
     <edmx:DataServices>
         <Schema Namespace="SampleSpace" xmlns="http://docs.oasis-open.org/odata/ns/edm">
             <Annotation Term="SampleSpace.Version" String="1.2.3" />
@@ -35,7 +38,9 @@
             </EntityType>
 
             <EntityContainer Name="Container">
-                <EntitySet Name="People" EntityType="SampleSpace.Person" />
+                <EntitySet Name="People" EntityType="SampleSpace.Person">
+                        
+                    </EntitySet>
             </EntityContainer>
         </Schema>
     </edmx:DataServices>

--- a/spec/odata_duty/entity_set/search_spec.rb
+++ b/spec/odata_duty/entity_set/search_spec.rb
@@ -1,5 +1,22 @@
 require 'spec_helper'
 
+# OAS2 test resolver classes
+class SupportsCollectionSearchResolver < OdataDuty::SetResolver
+  def od_search(search_expression)
+    # This method indicates search support for OAS2
+  end
+  
+  def collection
+    []
+  end
+end
+
+class SearchlessCollectionResolver < OdataDuty::SetResolver
+  def collection
+    []
+  end
+end
+
 class CollectionSearchTestComplexEntity < OdataDuty::ComplexType
   property 's', String
 end
@@ -327,6 +344,61 @@ RSpec.describe OdataDuty::EntitySet, 'Can search through collection results' do
                          context: Context.new,
                          query_options: { '$search' => '(apple)' })
         end.to raise_error(OdataDuty::NoImplementationError, /Parentheses are not supported/)
+      end
+    end
+  end
+
+  describe '#oas_2' do
+    # Use SchemaBuilder pattern for OAS2 tests since the legacy EntitySet approach doesn't work with OAS2
+    let(:oas2_schema) do
+      OdataDuty::SchemaBuilder.build(namespace: 'SampleSpace', host: 'localhost', base_path: '/api') do |s|
+        entity = s.add_entity_type(name: 'CollectionSearchTestEntity') do |et|
+          et.property_ref 'id', String
+          et.property 'name', String
+          et.property 'email', String
+          et.property 'address', String
+        end
+
+        s.add_entity_set(name: 'SupportsCollectionSearch', entity_type: entity,
+                         resolver: 'SupportsCollectionSearchResolver')
+        s.add_entity_set(name: 'SearchlessCollection', entity_type: entity,
+                         resolver: 'SearchlessCollectionResolver')
+      end
+    end
+
+    let(:json) { OdataDuty::OAS2.build_json(oas2_schema, context: Context.new) }
+    let(:get_parameters) { json['paths'][path]['get']['parameters'] }
+    let(:hashed_parameters) do
+      get_parameters.to_h do |p|
+        [p['name'], p.slice('type', 'in', 'description')]
+      end
+    end
+
+    describe '/SupportsCollectionSearch' do
+      let(:path) { '/SupportsCollectionSearch' }
+
+      it 'includes $search parameter when od_search is supported' do
+        expect(hashed_parameters['$search']).to eq(
+          'type' => 'string',
+          'in' => 'query',
+          'description' => 'Search across entity contents using structured expressions with AND, OR, NOT operators'
+        )
+      end
+
+      it 'includes other standard parameters' do
+        expect(hashed_parameters.keys).to include('$filter', '$select', '$search')
+      end
+    end
+
+    describe '/SearchlessCollection' do
+      let(:path) { '/SearchlessCollection' }
+
+      it 'does not include $search parameter when od_search is not supported' do
+        expect(hashed_parameters.keys).not_to include('$search')
+      end
+
+      it 'includes other standard parameters' do
+        expect(hashed_parameters.keys).to include('$filter', '$select')
       end
     end
   end

--- a/spec/odata_duty/entity_set/search_spec.rb
+++ b/spec/odata_duty/entity_set/search_spec.rb
@@ -5,7 +5,7 @@ class SupportsCollectionSearchResolver < OdataDuty::SetResolver
   def od_search(search_expression)
     # This method indicates search support for OAS2
   end
-  
+
   def collection
     []
   end
@@ -349,9 +349,9 @@ RSpec.describe OdataDuty::EntitySet, 'Can search through collection results' do
   end
 
   describe '#oas_2' do
-    # Use SchemaBuilder pattern for OAS2 tests since the legacy EntitySet approach doesn't work with OAS2
     let(:oas2_schema) do
-      OdataDuty::SchemaBuilder.build(namespace: 'SampleSpace', host: 'localhost', base_path: '/api') do |s|
+      OdataDuty::SchemaBuilder.build(namespace: 'SampleSpace', host: 'localhost',
+                                     base_path: '/api') do |s|
         entity = s.add_entity_type(name: 'CollectionSearchTestEntity') do |et|
           et.property_ref 'id', String
           et.property 'name', String
@@ -381,7 +381,7 @@ RSpec.describe OdataDuty::EntitySet, 'Can search through collection results' do
         expect(hashed_parameters['$search']).to eq(
           'type' => 'string',
           'in' => 'query',
-          'description' => 'Search across entity contents using structured expressions with AND, OR, NOT operators'
+          'description' => 'Search using structured expressions with AND, OR, NOT operators'
         )
       end
 
@@ -400,6 +400,46 @@ RSpec.describe OdataDuty::EntitySet, 'Can search through collection results' do
       it 'includes other standard parameters' do
         expect(hashed_parameters.keys).to include('$filter', '$select')
       end
+    end
+  end
+
+  describe '#metadata' do
+    let(:metadata_xml) do
+      OdataDuty::SchemaBuilder.build(namespace: 'SampleSpace', host: 'localhost',
+                                     base_path: '/api') do |s|
+        entity = s.add_entity_type(name: 'CollectionSearchTestEntity') do |et|
+          et.property_ref 'id', String
+          et.property 'name', String
+          et.property 'email', String
+          et.property 'address', String
+        end
+
+        s.add_entity_set(name: 'SupportsCollectionSearch', entity_type: entity,
+                         resolver: 'SupportsCollectionSearchResolver')
+        s.add_entity_set(name: 'SearchlessCollection', entity_type: entity,
+                         resolver: 'SearchlessCollectionResolver')
+      end.metadata_xml
+    end
+
+    it 'includes OData Capabilities vocabulary reference' do
+      expect(metadata_xml).to include('Org.OData.Capabilities.V1')
+      expect(metadata_xml).to include('Alias="Capabilities"')
+    end
+
+    it 'includes SearchRestrictions annotation for search-enabled entity sets' do
+      expect(metadata_xml).to include('<EntitySet Name="SupportsCollectionSearch"')
+      expect(metadata_xml).to include('Term="Capabilities.SearchRestrictions"')
+      expect(metadata_xml).to include('Property="Searchable" Bool="true"')
+      expect(metadata_xml).to include(
+        'Property="UnsupportedExpressions" EnumMember="Capabilities.SearchExpressions/group"'
+      )
+    end
+
+    it 'does not include SearchRestrictions annotation for non-search entity sets' do
+      searchless_entity_set_xml = metadata_xml.split(
+        '<EntitySet Name="SearchlessCollection"'
+      )[1].split('</EntitySet>')[0]
+      expect(searchless_entity_set_xml).not_to include('Capabilities.SearchRestrictions')
     end
   end
 end

--- a/spec/odata_duty/entity_set/search_spec.rb
+++ b/spec/odata_duty/entity_set/search_spec.rb
@@ -442,4 +442,108 @@ RSpec.describe OdataDuty::EntitySet, 'Can search through collection results' do
       expect(searchless_entity_set_xml).not_to include('Capabilities.SearchRestrictions')
     end
   end
+
+  describe 'mcp' do
+    let(:mcp_server) { schema }
+
+    describe 'tools/list' do
+      let(:request_payload) do
+        {
+          'jsonrpc' => '2.0',
+          'method' => 'tools/list',
+          'params' => {},
+          'id' => 'tools-list-1'
+        }
+      end
+
+      it 'returns search tools for entity sets that support search' do
+        actual = Oj.load(mcp_server.handle_jsonrpc(request_payload, context: Context.new))
+
+        expect(actual['result']['tools']).to include(
+          {
+            'name' => 'search_SupportsCollectionSearch',
+            'description' =>
+            'Search SupportsCollectionSearch using expressions with AND, OR, NOT operators',
+            'inputSchema' => {
+              'type' => 'object',
+              'properties' => {
+                '$search' => {
+                  'type' => 'string',
+                  'description' => 'Search query using expressions with AND, OR, NOT operators'
+                }
+              },
+              'required' => ['$search']
+            }
+          }
+        )
+      end
+
+      it 'does not return search tools for entity sets that do not support search' do
+        actual = Oj.load(mcp_server.handle_jsonrpc(request_payload, context: Context.new))
+
+        tool_names = actual['result']['tools'].map { |tool| tool['name'] }
+        expect(tool_names).not_to include('search_SearchlessCollection')
+      end
+    end
+
+    describe 'tools/call for search' do
+      let(:request_payload) do
+        {
+          'jsonrpc' => '2.0',
+          'method' => 'tools/call',
+          'params' => {
+            'name' => 'search_SupportsCollectionSearch',
+            'arguments' => {
+              '$search' => 'Doe'
+            }
+          },
+          'id' => 'tools-call-1'
+        }
+      end
+
+      it 'executes search on entity set that supports search' do
+        actual = Oj.load(mcp_server.handle_jsonrpc(request_payload, context: Context.new))
+
+        expect(actual['result']['value']).to be_an(Array)
+        expect(actual['result']['value'].length).to eq(1)
+        expect(actual['result']['value'].first['name']).to eq('John Doe')
+        expect(actual['result']['@odata.context']).to include('SupportsCollectionSearch')
+      end
+
+      it 'supports complex search expressions' do
+        request_payload['params']['arguments']['$search'] = 'Doe OR Jane'
+
+        actual = Oj.load(mcp_server.handle_jsonrpc(request_payload, context: Context.new))
+
+        expect(actual['result']['value']).to be_an(Array)
+        expect(actual['result']['value'].length).to eq(2)
+        names = actual['result']['value'].map { |v| v['name'] }
+        expect(names).to contain_exactly('John Doe', 'Jane Smith')
+      end
+
+      it 'raises error for entity set that does not support search' do
+        request_payload['params']['name'] = 'search_SearchlessCollection'
+
+        expect do
+          mcp_server.handle_jsonrpc(request_payload, context: Context.new)
+        end.to raise_error(OdataDuty::NoImplementationError)
+      end
+
+      it 'raises error for unknown tool' do
+        request_payload['params']['name'] = 'unknown_tool'
+
+        expect do
+          mcp_server.handle_jsonrpc(request_payload, context: Context.new)
+        end.to raise_error(/Unknown tool/)
+      end
+
+      it 'handles search expression parsing errors' do
+        request_payload['params']['arguments']['$search'] = 'apple AND orange OR peach'
+
+        expect do
+          mcp_server.handle_jsonrpc(request_payload, context: Context.new)
+        end.to raise_error(%r{Mixed AND/OR operators are not supported})
+      end
+    end
+  end
 end

--- a/spec/odata_duty/entity_set/search_spec.rb
+++ b/spec/odata_duty/entity_set/search_spec.rb
@@ -1,0 +1,138 @@
+require 'spec_helper'
+
+class CollectionSearchTestComplexEntity < OdataDuty::ComplexType
+  property 's', String
+end
+
+class CollectionSearchTestEntity < OdataDuty::EntityType
+  property_ref 'id', String
+  property 'name', String
+  property 'email', String
+  property 'address', String
+  property 'c', CollectionSearchTestComplexEntity
+end
+
+class SupportsCollectionSearchSet < OdataDuty::EntitySet
+  entity_type CollectionSearchTestEntity
+
+  ALL_RECORDS = [
+    { 'id' => '1', 'name' => 'John Doe', 'email' => 'john@example.com',
+      'address' => '123 Main St, Boise, ID', 'c' => CamelSnakeStruct.new('s' => 'value1') },
+    { 'id' => '2', 'name' => 'Jane Smith', 'email' => 'jane@example.com',
+      'address' => '456 Oak Ave, Seattle, WA', 'c' => CamelSnakeStruct.new('s' => 'value2') },
+    { 'id' => '3', 'name' => 'Bob Johnson', 'email' => 'bob@portland.com',
+      'address' => '789 Pine Rd, Portland, OR', 'c' => CamelSnakeStruct.new('s' => 'value3') }
+  ].freeze
+
+  def od_after_init
+    @records = ALL_RECORDS
+  end
+
+  def od_search(search_expression)
+    @records = @records.select do |key_val|
+      key_val.values.any? do |v|
+        v.to_s.include?(search_expression)
+      end
+    end
+  end
+
+  def collection
+    @records.map { |r| CamelSnakeStruct.new(r) }
+  end
+end
+
+class SearchlessCollectionSet < OdataDuty::EntitySet
+  entity_type CollectionSearchTestEntity
+
+  ALL_RECORDS = [
+    CamelSnakeStruct.new('id' => '1', 'name' => 'John Doe', 'email' => 'john@example.com',
+                         'address' => 'Main St, Boise, ID', 'c' => OpenStruct.new(s: 'value1')),
+    CamelSnakeStruct.new('id' => '2', 'name' => 'Jane Smith', 'email' => 'jane@example.com',
+                         'address' => 'Oak Ave, Seattle, WA', 'c' => OpenStruct.new(s: 'value2')),
+    CamelSnakeStruct.new('id' => '3', 'name' => 'Bob Johnson', 'email' => 'bob@portland.com',
+                         'address' => 'Pine Rd, Portland, OR', 'c' => OpenStruct.new(s: 'value3'))
+  ].freeze
+
+  def od_after_init
+    @records = ALL_RECORDS
+  end
+
+  def collection
+    @records
+  end
+end
+
+class CollectionSearchTestSchema < OdataDuty::Schema
+  base_url 'http://localhost:3000/api'
+  entity_sets [SupportsCollectionSearchSet, SearchlessCollectionSet]
+end
+
+RSpec.describe OdataDuty::EntitySet, 'Can search through collection results' do
+  subject(:schema) { CollectionSearchTestSchema }
+
+  describe '#execute' do
+    describe 'collection' do
+      it 'searches collection with matching term' do
+        json_string = schema.execute('SupportsCollectionSearch',
+                                     context: Context.new,
+                                     query_options: { '$search' => 'Doe' })
+        response = Oj.load(json_string)
+        expect(response).to eq(
+          {
+            '@odata.context' => 'http://localhost:3000/api/$metadata#SupportsCollectionSearch',
+            'value' => [
+              {
+                '@odata.id' => 'http://localhost:3000/api/SupportsCollectionSearch(\'1\')',
+                'id' => '1',
+                'name' => 'John Doe',
+                'email' => 'john@example.com',
+                'address' => '123 Main St, Boise, ID',
+                'c' => { 's' => 'value1' }
+              }
+            ]
+          }
+        )
+      end
+
+      it 'returns empty results when no matches found' do
+        json_string = schema.execute('SupportsCollectionSearch',
+                                     context: Context.new,
+                                     query_options: { '$search' => 'nonexistent' })
+        response = Oj.load(json_string)
+        expect(response).to eq(
+          {
+            '@odata.context' => 'http://localhost:3000/api/$metadata#SupportsCollectionSearch',
+            'value' => []
+          }
+        )
+      end
+
+      it 'calls od_search method when implemented' do
+        expect_any_instance_of(SupportsCollectionSearchSet)
+          .to receive(:od_search).with('Boise').and_call_original
+        schema.execute('SupportsCollectionSearch',
+                       context: Context.new,
+                       query_options: { '$search' => 'Boise' })
+      end
+
+      it 'raises error when od_search not implemented' do
+        expect do
+          schema.execute('SearchlessCollection',
+                         context: Context.new,
+                         query_options: { '$search' => 'Boise' })
+        end.to raise_error(OdataDuty::NoImplementationError, /\$search not implemented/)
+      end
+
+      it 'combines search with other query options' do
+        json_string = schema.execute('SupportsCollectionSearch',
+                                     context: Context.new,
+                                     query_options: { '$search' => 'example.com',
+                                                      '$select' => 'id,name,email' })
+        response = Oj.load(json_string)
+        expect(response['value'].length).to eq(2)
+        expect(response['value'].first).to include('id', 'name', 'email')
+        expect(response['value'].first).not_to include('address')
+      end
+    end
+  end
+end

--- a/spec/odata_duty/entity_set/search_spec.rb
+++ b/spec/odata_duty/entity_set/search_spec.rb
@@ -29,15 +29,38 @@ class SupportsCollectionSearchSet < OdataDuty::EntitySet
   end
 
   def od_search(search_expression)
-    @records = @records.select do |key_val|
-      key_val.values.any? do |v|
-        v.to_s.include?(search_expression)
-      end
+    if search_expression.or?
+      od_search_or(search_expression)
+    else
+      od_search_and(search_expression)
     end
   end
 
   def collection
     @records.map { |r| CamelSnakeStruct.new(r) }
+  end
+
+  private
+
+  def od_search_or(search_expression)
+    found_records = []
+    search_expression.terms.each do |term|
+      matches = @records.select do |record|
+        match_found = record.values.any? { |v| v.to_s.downcase.include?(term.value.downcase) }
+        term.not? ? !match_found : match_found
+      end
+      found_records += matches
+    end
+    @records = found_records.uniq { |r| r['id'] }
+  end
+
+  def od_search_and(search_expression)
+    search_expression.terms.each do |term|
+      @records = @records.select do |record|
+        match_found = record.values.any? { |v| v.to_s.downcase.include?(term.value.downcase) }
+        term.not? ? !match_found : match_found
+      end
+    end
   end
 end
 
@@ -109,7 +132,7 @@ RSpec.describe OdataDuty::EntitySet, 'Can search through collection results' do
 
       it 'calls od_search method when implemented' do
         expect_any_instance_of(SupportsCollectionSearchSet)
-          .to receive(:od_search).with('Boise').and_call_original
+          .to receive(:od_search).with(instance_of(OdataDuty::SearchExpression)).and_call_original
         schema.execute('SupportsCollectionSearch',
                        context: Context.new,
                        query_options: { '$search' => 'Boise' })
@@ -132,6 +155,178 @@ RSpec.describe OdataDuty::EntitySet, 'Can search through collection results' do
         expect(response['value'].length).to eq(2)
         expect(response['value'].first).to include('id', 'name', 'email')
         expect(response['value'].first).not_to include('address')
+      end
+
+      it 'supports AND search expressions' do
+        json_string = schema.execute('SupportsCollectionSearch',
+                                     context: Context.new,
+                                     query_options: { '$search' => 'John AND Doe' })
+        response = Oj.load(json_string)
+        expect(response['value'].length).to eq(1)
+        expect(response['value'].first['name']).to eq('John Doe')
+      end
+
+      it 'supports OR search expressions' do
+        json_string = schema.execute('SupportsCollectionSearch',
+                                     context: Context.new,
+                                     query_options: { '$search' => 'John OR Portland' })
+        response = Oj.load(json_string)
+        expect(response['value'].length).to eq(2)
+        names = response['value'].map { |v| v['name'] }
+        expect(names).to contain_exactly('John Doe', 'Bob Johnson')
+      end
+
+      it 'supports NOT search expressions' do
+        json_string = schema.execute('SupportsCollectionSearch',
+                                     context: Context.new,
+                                     query_options: { '$search' => 'example.com AND NOT John' })
+        response = Oj.load(json_string)
+        expect(response['value'].length).to eq(1)
+        expect(response['value'].first['name']).to eq('Jane Smith')
+      end
+
+      it 'supports quoted phrases' do
+        json_string = schema.execute('SupportsCollectionSearch',
+                                     context: Context.new,
+                                     query_options: { '$search' => '"Jane Smith"' })
+        response = Oj.load(json_string)
+        expect(response['value'].length).to eq(1)
+        expect(response['value'].first['name']).to eq('Jane Smith')
+      end
+
+      it 'raises error for mixed AND/OR operators' do
+        expect do
+          schema.execute('SupportsCollectionSearch',
+                         context: Context.new,
+                         query_options: { '$search' => 'apple AND orange OR peach' })
+        end.to raise_error(OdataDuty::NoImplementationError,
+                           %r{Mixed AND/OR operators are not supported})
+      end
+
+      it 'raises error for parentheses' do
+        expect do
+          schema.execute('SupportsCollectionSearch',
+                         context: Context.new,
+                         query_options: { '$search' => '(apple AND orange) AND peach' })
+        end.to raise_error(OdataDuty::NoImplementationError, /Parentheses are not supported/)
+      end
+
+      it 'raises error for implicit AND mixed with OR' do
+        expect do
+          schema.execute('SupportsCollectionSearch',
+                         context: Context.new,
+                         query_options: { '$search' => 'apple orange OR peach' })
+        end.to raise_error(OdataDuty::NoImplementationError,
+                           %r{Mixed AND/OR operators are not supported})
+      end
+
+      # Test comprehensive search expression parsing functionality
+      it 'parses single word search' do
+        json_string = schema.execute('SupportsCollectionSearch',
+                                     context: Context.new,
+                                     query_options: { '$search' => 'Doe' })
+        response = Oj.load(json_string)
+        expect(response['value'].length).to eq(1)
+        expect(response['value'].first['name']).to eq('John Doe')
+      end
+
+      it 'parses negated single term' do
+        json_string = schema.execute('SupportsCollectionSearch',
+                                     context: Context.new,
+                                     query_options: { '$search' => 'NOT Doe' })
+        response = Oj.load(json_string)
+        expect(response['value'].length).to eq(2)
+        names = response['value'].map { |v| v['name'] }
+        expect(names).to contain_exactly('Jane Smith', 'Bob Johnson')
+      end
+
+      it 'parses negated quoted phrase' do
+        json_string = schema.execute('SupportsCollectionSearch',
+                                     context: Context.new,
+                                     query_options: { '$search' => 'NOT "Jane Smith"' })
+        response = Oj.load(json_string)
+        expect(response['value'].length).to eq(2)
+        names = response['value'].map { |v| v['name'] }
+        expect(names).to contain_exactly('John Doe', 'Bob Johnson')
+      end
+
+      it 'parses implicit AND with multiple terms' do
+        json_string = schema.execute('SupportsCollectionSearch',
+                                     context: Context.new,
+                                     query_options: { '$search' => 'John Doe' })
+        response = Oj.load(json_string)
+        expect(response['value'].length).to eq(1)
+        expect(response['value'].first['name']).to eq('John Doe')
+      end
+
+      it 'parses explicit AND with multiple terms' do
+        json_string = schema.execute('SupportsCollectionSearch',
+                                     context: Context.new,
+                                     query_options: { '$search' => 'John AND Doe' })
+        response = Oj.load(json_string)
+        expect(response['value'].length).to eq(1)
+        expect(response['value'].first['name']).to eq('John Doe')
+      end
+
+      it 'parses OR with quoted phrases' do
+        json_string = schema.execute('SupportsCollectionSearch',
+                                     context: Context.new,
+                                     query_options: { '$search' => '"John Doe" OR "Jane Smith"' })
+        response = Oj.load(json_string)
+        expect(response['value'].length).to eq(2)
+        names = response['value'].map { |v| v['name'] }
+        expect(names).to contain_exactly('John Doe', 'Jane Smith')
+      end
+
+      it 'parses OR with negation' do
+        json_string = schema.execute('SupportsCollectionSearch',
+                                     context: Context.new,
+                                     query_options: { '$search' => 'John OR NOT example.com' })
+        response = Oj.load(json_string)
+        expect(response['value'].length).to eq(2)
+        names = response['value'].map { |v| v['name'] }
+        expect(names).to contain_exactly('John Doe', 'Bob Johnson')
+      end
+
+      it 'handles empty search string' do
+        json_string = schema.execute('SupportsCollectionSearch',
+                                     context: Context.new,
+                                     query_options: { '$search' => '' })
+        response = Oj.load(json_string)
+        expect(response['value'].length).to eq(3)
+      end
+
+      it 'handles whitespace only search' do
+        json_string = schema.execute('SupportsCollectionSearch',
+                                     context: Context.new,
+                                     query_options: { '$search' => '   ' })
+        response = Oj.load(json_string)
+        expect(response['value'].length).to eq(3)
+      end
+
+      it 'raises error for unterminated quote' do
+        expect do
+          schema.execute('SupportsCollectionSearch',
+                         context: Context.new,
+                         query_options: { '$search' => '"hello world' })
+        end.to raise_error(OdataDuty::InvalidQueryOptionError)
+      end
+
+      it 'raises error for complex mixed operators' do
+        expect do
+          schema.execute('SupportsCollectionSearch',
+                         context: Context.new,
+                         query_options: { '$search' => 'hello OR world AND test' })
+        end.to raise_error(OdataDuty::NoImplementationError,
+                           %r{Mixed AND/OR operators are not supported})
+      end
+
+      it 'raises error for simple parentheses' do
+        expect do
+          schema.execute('SupportsCollectionSearch',
+                         context: Context.new,
+                         query_options: { '$search' => '(apple)' })
+        end.to raise_error(OdataDuty::NoImplementationError, /Parentheses are not supported/)
       end
     end
   end

--- a/spec/odata_duty/schema_builder/entity_set/search_spec.rb
+++ b/spec/odata_duty/schema_builder/entity_set/search_spec.rb
@@ -260,5 +260,43 @@ module OdataDuty
         end
       end
     end
+
+    describe '#oas_2' do
+      let(:json) { OdataDuty::OAS2.build_json(schema, context: Context.new) }
+      let(:get_parameters) { json['paths'][path]['get']['parameters'] }
+      let(:hashed_parameters) do
+        get_parameters.to_h do |p|
+          [p['name'], p.slice('type', 'in', 'description')]
+        end
+      end
+
+      describe '/SupportsCollectionSearch' do
+        let(:path) { '/SupportsCollectionSearch' }
+
+        it 'includes $search parameter when od_search is supported' do
+          expect(hashed_parameters['$search']).to eq(
+            'type' => 'string',
+            'in' => 'query',
+            'description' => 'Search across entity contents using structured expressions with AND, OR, NOT operators'
+          )
+        end
+
+        it 'includes other standard parameters' do
+          expect(hashed_parameters.keys).to include('$filter', '$select', '$search')
+        end
+      end
+
+      describe '/SearchlessCollection' do
+        let(:path) { '/SearchlessCollection' }
+
+        it 'does not include $search parameter when od_search is not supported' do
+          expect(hashed_parameters.keys).not_to include('$search')
+        end
+
+        it 'includes other standard parameters' do
+          expect(hashed_parameters.keys).to include('$filter', '$select')
+        end
+      end
+    end
   end
 end

--- a/spec/odata_duty/schema_builder/entity_set/search_spec.rb
+++ b/spec/odata_duty/schema_builder/entity_set/search_spec.rb
@@ -2,14 +2,14 @@ require 'spec_helper'
 
 class SupportsCollectionSearchResolver < OdataDuty::SetResolver
   ALL_RECORDS = [
-    { 'id' => '1', 'name' => 'John Doe', 'email' => 'john@example.com',
-      'address' => '123 Main St, John, ID', 'c' => OpenStruct.new(s: 'value1') },
-    { 'id' => '2', 'name' => 'Jane Smith', 'email' => 'jane@example.com',
+    { 'id' => '1', 'name' => 'Alice Brown', 'email' => 'alice@example.com',
+      'address' => '123 Main St, Boise, ID', 'c' => OpenStruct.new(s: 'value1') },
+    { 'id' => '2', 'name' => 'Bob Smith', 'email' => 'bob@example.com',
       'address' => '456 Oak Ave, Seattle, WA', 'c' => OpenStruct.new(s: 'value2') },
-    { 'id' => '3', 'name' => 'Bob Johnson', 'email' => 'bob@bob.com',
-      'address' => '789 Pine Rd, Portland, OR', 'c' => OpenStruct.new(s: 'bob') },
-    { 'id' => '4', 'name' => 'John Doe', 'email' => 'john@example.com',
-      'address' => '123 Main St, Boise, ID', 'c' => OpenStruct.new(s: 'searched') }
+    { 'id' => '3', 'name' => 'Charlie Johnson', 'email' => 'charlie@portland.com',
+      'address' => '789 Pine Rd, Portland, OR', 'c' => OpenStruct.new(s: 'value3') },
+    { 'id' => '4', 'name' => 'Dave Wilson', 'email' => 'dave@example.com',
+      'address' => '321 Elm St, Denver, CO', 'c' => OpenStruct.new(s: 'searched') }
   ].freeze
 
   def od_after_init
@@ -17,15 +17,38 @@ class SupportsCollectionSearchResolver < OdataDuty::SetResolver
   end
 
   def od_search(search_expression)
-    @records = @records.select do |key_val|
-      key_val.values.any? do |v|
-        v.to_s.include?(search_expression)
-      end
+    if search_expression.or?
+      od_search_or(search_expression)
+    else
+      od_search_and(search_expression)
     end
   end
 
   def collection
     @records.map { |r| CamelSnakeStruct.new(r) }
+  end
+
+  private
+
+  def od_search_or(search_expression)
+    found_records = []
+    search_expression.terms.each do |term|
+      matches = @records.select do |record|
+        match_found = record.values.any? { |v| v.to_s.downcase.include?(term.value.downcase) }
+        term.not? ? !match_found : match_found
+      end
+      found_records += matches
+    end
+    @records = found_records.uniq { |r| r['id'] }
+  end
+
+  def od_search_and(search_expression)
+    search_expression.terms.each do |term|
+      @records = @records.select do |record|
+        match_found = record.values.any? { |v| v.to_s.downcase.include?(term.value.downcase) }
+        term.not? ? !match_found : match_found
+      end
+    end
   end
 end
 
@@ -88,12 +111,12 @@ module OdataDuty
               '@odata.context' => 'https://localhost/$metadata#SupportsCollectionSearch',
               'value' => [
                 {
-                  '@odata.id' => 'https://localhost/SupportsCollectionSearch(\'4\')',
-                  'id' => '4',
-                  'name' => 'John Doe',
-                  'email' => 'john@example.com',
+                  '@odata.id' => 'https://localhost/SupportsCollectionSearch(\'1\')',
+                  'id' => '1',
+                  'name' => 'Alice Brown',
+                  'email' => 'alice@example.com',
                   'address' => '123 Main St, Boise, ID',
-                  'c' => { 's' => 'searched' }
+                  'c' => { 's' => 'value1' }
                 }
               ]
             }
@@ -117,6 +140,123 @@ module OdataDuty
           expect(response['value'].length).to eq(1)
           expect(response['value'].first).to include('id', 'name')
           expect(response['value'].first).not_to include('address', 'email')
+        end
+
+        # Test comprehensive search expression parsing functionality
+        it 'parses single word search' do
+          json_string = schema.execute('SupportsCollectionSearch',
+                                       context: Context.new,
+                                       query_options: { '$search' => 'Alice' })
+          response = Oj.load(json_string)
+          expect(response['value'].length).to eq(1)
+          expect(response['value'].first['name']).to eq('Alice Brown')
+        end
+
+        it 'parses quoted phrase search' do
+          json_string = schema.execute('SupportsCollectionSearch',
+                                       context: Context.new,
+                                       query_options: { '$search' => '"Alice Brown"' })
+          response = Oj.load(json_string)
+          expect(response['value'].length).to eq(1)
+          expect(response['value'].first['name']).to eq('Alice Brown')
+        end
+
+        it 'parses negated term search' do
+          json_string = schema.execute('SupportsCollectionSearch',
+                                       context: Context.new,
+                                       query_options: { '$search' => 'NOT Alice' })
+          response = Oj.load(json_string)
+          expect(response['value'].length).to eq(3)
+          names = response['value'].map { |v| v['name'] }
+          expect(names).to contain_exactly('Bob Smith', 'Charlie Johnson', 'Dave Wilson')
+        end
+
+        it 'parses implicit AND search' do
+          json_string = schema.execute('SupportsCollectionSearch',
+                                       context: Context.new,
+                                       query_options: { '$search' => 'Alice Brown' })
+          response = Oj.load(json_string)
+          expect(response['value'].length).to eq(1)
+          expect(response['value'].first['name']).to eq('Alice Brown')
+        end
+
+        it 'parses explicit AND search' do
+          json_string = schema.execute('SupportsCollectionSearch',
+                                       context: Context.new,
+                                       query_options: { '$search' => 'Alice AND Brown' })
+          response = Oj.load(json_string)
+          expect(response['value'].length).to eq(1)
+          expect(response['value'].first['name']).to eq('Alice Brown')
+        end
+
+        it 'parses OR expression search' do
+          json_string = schema.execute('SupportsCollectionSearch',
+                                       context: Context.new,
+                                       query_options: { '$search' => 'Alice OR Bob' })
+          response = Oj.load(json_string)
+          expect(response['value'].length).to eq(2)
+          names = response['value'].map { |v| v['name'] }
+          expect(names).to contain_exactly('Alice Brown', 'Bob Smith')
+        end
+
+        it 'parses OR with negation' do
+          json_string = schema.execute('SupportsCollectionSearch',
+                                       context: Context.new,
+                                       query_options: { '$search' => 'Alice OR NOT example.com' })
+          response = Oj.load(json_string)
+          expect(response['value'].length).to eq(2)
+          names = response['value'].map { |v| v['name'] }
+          expect(names).to contain_exactly('Alice Brown', 'Charlie Johnson')
+        end
+
+        it 'handles empty search string' do
+          json_string = schema.execute('SupportsCollectionSearch',
+                                       context: Context.new,
+                                       query_options: { '$search' => '' })
+          response = Oj.load(json_string)
+          expect(response['value'].length).to eq(4)
+        end
+
+        it 'handles whitespace only search' do
+          json_string = schema.execute('SupportsCollectionSearch',
+                                       context: Context.new,
+                                       query_options: { '$search' => '   ' })
+          response = Oj.load(json_string)
+          expect(response['value'].length).to eq(4)
+        end
+
+        it 'raises error for mixed AND/OR operators' do
+          expect do
+            schema.execute('SupportsCollectionSearch',
+                           context: Context.new,
+                           query_options: { '$search' => 'apple AND orange OR peach' })
+          end.to raise_error(OdataDuty::NoImplementationError,
+                             %r{Mixed AND/OR operators are not supported})
+        end
+
+        it 'raises error for parentheses' do
+          expect do
+            schema.execute('SupportsCollectionSearch',
+                           context: Context.new,
+                           query_options: { '$search' => '(apple AND orange) AND peach' })
+          end.to raise_error(OdataDuty::NoImplementationError)
+        end
+
+        it 'raises error for unterminated quote' do
+          expect do
+            schema.execute('SupportsCollectionSearch',
+                           context: Context.new,
+                           query_options: { '$search' => '"hello world' })
+          end.to raise_error(OdataDuty::InvalidQueryOptionError)
+        end
+
+        it 'raises error for implicit AND mixed with OR' do
+          expect do
+            schema.execute('SupportsCollectionSearch',
+                           context: Context.new,
+                           query_options: { '$search' => 'apple orange OR peach' })
+          end.to raise_error(OdataDuty::NoImplementationError,
+                             %r{Mixed AND/OR operators are not supported})
         end
       end
     end

--- a/spec/odata_duty/schema_builder/entity_set/search_spec.rb
+++ b/spec/odata_duty/schema_builder/entity_set/search_spec.rb
@@ -1,0 +1,124 @@
+require 'spec_helper'
+
+class SupportsCollectionSearchResolver < OdataDuty::SetResolver
+  ALL_RECORDS = [
+    { 'id' => '1', 'name' => 'John Doe', 'email' => 'john@example.com',
+      'address' => '123 Main St, John, ID', 'c' => OpenStruct.new(s: 'value1') },
+    { 'id' => '2', 'name' => 'Jane Smith', 'email' => 'jane@example.com',
+      'address' => '456 Oak Ave, Seattle, WA', 'c' => OpenStruct.new(s: 'value2') },
+    { 'id' => '3', 'name' => 'Bob Johnson', 'email' => 'bob@bob.com',
+      'address' => '789 Pine Rd, Portland, OR', 'c' => OpenStruct.new(s: 'bob') },
+    { 'id' => '4', 'name' => 'John Doe', 'email' => 'john@example.com',
+      'address' => '123 Main St, Boise, ID', 'c' => OpenStruct.new(s: 'searched') }
+  ].freeze
+
+  def od_after_init
+    @records = ALL_RECORDS
+  end
+
+  def od_search(search_expression)
+    @records = @records.select do |key_val|
+      key_val.values.any? do |v|
+        v.to_s.include?(search_expression)
+      end
+    end
+  end
+
+  def collection
+    @records.map { |r| CamelSnakeStruct.new(r) }
+  end
+end
+
+class SearchlessCollectionResolver < OdataDuty::SetResolver
+  ALL_RECORDS = [
+    CamelSnakeStruct.new('id' => '1', 'name' => 'John Doe', 'email' => 'john@example.com',
+                         'address' => 'Main St, Boise, ID',
+                         'c' => CamelSnakeStruct.new('s' => 'value1')),
+    CamelSnakeStruct.new('id' => '2', 'name' => 'Jane Smith', 'email' => 'jane@example.com',
+                         'address' => 'Oak Ave, Seattle, WA',
+                         'c' => CamelSnakeStruct.new('s' => 'value2')),
+    CamelSnakeStruct.new('id' => '3', 'name' => 'Bob Johnson', 'email' => 'bob@boise.com',
+                         'address' => 'Pine Rd, Portland, OR',
+                         'c' => CamelSnakeStruct.new('s' => 'boise'))
+  ].freeze
+
+  def od_after_init
+    @records = ALL_RECORDS
+  end
+
+  def collection
+    @records
+  end
+
+  def individual(id)
+    @records.find { |r| r.id == id }
+  end
+end
+
+module OdataDuty
+  RSpec.describe SchemaBuilder::EntitySet, 'Can search through collection results' do
+    subject(:schema) do
+      SchemaBuilder.build(namespace: 'SampleSpace', host: 'localhost', base_path: '') do |s|
+        complex = s.add_entity_type(name: 'CollectionSearchTestComplex') do |et|
+          et.property 's', String
+        end
+
+        entity = s.add_entity_type(name: 'CollectionSearchTest') do |et|
+          et.property_ref 'id', String
+          et.property 'name', String
+          et.property 'email', String
+          et.property 'address', String
+          et.property 'c', complex
+        end
+
+        s.add_entity_set(entity_type: entity, resolver: 'SearchlessCollectionResolver')
+        s.add_entity_set(entity_type: entity, resolver: 'SupportsCollectionSearchResolver')
+      end
+    end
+
+    describe '#execute' do
+      describe 'collection' do
+        it 'searches collection with matching term' do
+          json_string = schema.execute('SupportsCollectionSearch',
+                                       context: Context.new,
+                                       query_options: { '$search' => 'Boise' })
+          response = Oj.load(json_string)
+          expect(response).to eq(
+            {
+              '@odata.context' => 'https://localhost/$metadata#SupportsCollectionSearch',
+              'value' => [
+                {
+                  '@odata.id' => 'https://localhost/SupportsCollectionSearch(\'4\')',
+                  'id' => '4',
+                  'name' => 'John Doe',
+                  'email' => 'john@example.com',
+                  'address' => '123 Main St, Boise, ID',
+                  'c' => { 's' => 'searched' }
+                }
+              ]
+            }
+          )
+        end
+
+        it 'raises error when od_search not implemented' do
+          expect do
+            schema.execute('SearchlessCollection',
+                           context: Context.new,
+                           query_options: { '$search' => 'Boise' })
+          end.to raise_error(OdataDuty::NoImplementationError, /\$search not implemented/)
+        end
+
+        it 'combines search with other query options' do
+          json_string = schema.execute('SupportsCollectionSearch',
+                                       context: Context.new,
+                                       query_options: { '$search' => 'Boise',
+                                                        '$select' => 'id,name' })
+          response = Oj.load(json_string)
+          expect(response['value'].length).to eq(1)
+          expect(response['value'].first).to include('id', 'name')
+          expect(response['value'].first).not_to include('address', 'email')
+        end
+      end
+    end
+  end
+end

--- a/spec/odata_duty/schema_builder/entity_set/search_spec.rb
+++ b/spec/odata_duty/schema_builder/entity_set/search_spec.rb
@@ -323,5 +323,109 @@ module OdataDuty
         expect(searchless_entity_set_xml).not_to include('Capabilities.SearchRestrictions')
       end
     end
+
+    describe 'mcp' do
+      let(:mcp_server) { schema }
+
+      describe 'tools/list' do
+        let(:request_payload) do
+          {
+            'jsonrpc' => '2.0',
+            'method' => 'tools/list',
+            'params' => {},
+            'id' => 'tools-list-1'
+          }
+        end
+
+        it 'returns search tools for entity sets that support search' do
+          actual = Oj.load(mcp_server.handle_jsonrpc(request_payload, context: Context.new))
+
+          expect(actual['result']['tools']).to include(
+            {
+              'name' => 'search_SupportsCollectionSearch',
+              'description' =>
+              'Search SupportsCollectionSearch using expressions with AND, OR, NOT operators',
+              'inputSchema' => {
+                'type' => 'object',
+                'properties' => {
+                  '$search' => {
+                    'type' => 'string',
+                    'description' => 'Search query using expressions with AND, OR, NOT operators'
+                  }
+                },
+                'required' => ['$search']
+              }
+            }
+          )
+        end
+
+        it 'does not return search tools for entity sets that do not support search' do
+          actual = Oj.load(mcp_server.handle_jsonrpc(request_payload, context: Context.new))
+
+          tool_names = actual['result']['tools'].map { |tool| tool['name'] }
+          expect(tool_names).not_to include('search_SearchlessCollection')
+        end
+      end
+
+      describe 'tools/call for search' do
+        let(:request_payload) do
+          {
+            'jsonrpc' => '2.0',
+            'method' => 'tools/call',
+            'params' => {
+              'name' => 'search_SupportsCollectionSearch',
+              'arguments' => {
+                '$search' => 'Alice'
+              }
+            },
+            'id' => 'tools-call-1'
+          }
+        end
+
+        it 'executes search on entity set that supports search' do
+          actual = Oj.load(mcp_server.handle_jsonrpc(request_payload, context: Context.new))
+
+          expect(actual['result']['value']).to be_an(Array)
+          expect(actual['result']['value'].length).to eq(1)
+          expect(actual['result']['value'].first['name']).to eq('Alice Brown')
+          expect(actual['result']['@odata.context']).to include('SupportsCollectionSearch')
+        end
+
+        it 'supports complex search expressions' do
+          request_payload['params']['arguments']['$search'] = 'Alice OR Bob'
+
+          actual = Oj.load(mcp_server.handle_jsonrpc(request_payload, context: Context.new))
+
+          expect(actual['result']['value']).to be_an(Array)
+          expect(actual['result']['value'].length).to eq(2)
+          names = actual['result']['value'].map { |v| v['name'] }
+          expect(names).to contain_exactly('Alice Brown', 'Bob Smith')
+        end
+
+        it 'raises error for entity set that does not support search' do
+          request_payload['params']['name'] = 'search_SearchlessCollection'
+
+          expect do
+            mcp_server.handle_jsonrpc(request_payload, context: Context.new)
+          end.to raise_error(OdataDuty::NoImplementationError)
+        end
+
+        it 'raises error for unknown tool' do
+          request_payload['params']['name'] = 'unknown_tool'
+
+          expect do
+            mcp_server.handle_jsonrpc(request_payload, context: Context.new)
+          end.to raise_error(/Unknown tool/)
+        end
+
+        it 'handles search expression parsing errors' do
+          request_payload['params']['arguments']['$search'] = 'apple AND orange OR peach'
+
+          expect do
+            mcp_server.handle_jsonrpc(request_payload, context: Context.new)
+          end.to raise_error(%r{Mixed AND/OR operators are not supported})
+        end
+      end
+    end
   end
 end

--- a/spec/odata_duty/schema_builder/entity_set/search_spec.rb
+++ b/spec/odata_duty/schema_builder/entity_set/search_spec.rb
@@ -277,7 +277,7 @@ module OdataDuty
           expect(hashed_parameters['$search']).to eq(
             'type' => 'string',
             'in' => 'query',
-            'description' => 'Search across entity contents using structured expressions with AND, OR, NOT operators'
+            'description' => 'Search using structured expressions with AND, OR, NOT operators'
           )
         end
 
@@ -296,6 +296,31 @@ module OdataDuty
         it 'includes other standard parameters' do
           expect(hashed_parameters.keys).to include('$filter', '$select')
         end
+      end
+    end
+
+    describe '#metadata' do
+      let(:metadata_xml) { schema.metadata_xml }
+
+      it 'includes OData Capabilities vocabulary reference' do
+        expect(metadata_xml).to include('Org.OData.Capabilities.V1')
+        expect(metadata_xml).to include('Alias="Capabilities"')
+      end
+
+      it 'includes SearchRestrictions annotation for search-enabled entity sets' do
+        expect(metadata_xml).to include('<EntitySet Name="SupportsCollectionSearch"')
+        expect(metadata_xml).to include('Term="Capabilities.SearchRestrictions"')
+        expect(metadata_xml).to include('Property="Searchable" Bool="true"')
+        expect(metadata_xml).to include(
+          'Property="UnsupportedExpressions" EnumMember="Capabilities.SearchExpressions/group"'
+        )
+      end
+
+      it 'does not include SearchRestrictions annotation for non-search entity sets' do
+        searchless_entity_set_xml = metadata_xml
+                                    .split('<EntitySet Name="SearchlessCollection"')[1]
+                                    .split('</EntitySet>')[0]
+        expect(searchless_entity_set_xml).not_to include('Capabilities.SearchRestrictions')
       end
     end
   end


### PR DESCRIPTION
Add comprehensive support for the OData `$search` query parameter, enabling structured search functionality across OData entity sets following OData v4.01 specification.

## Key Features

  - **Structured Search Expressions**: Support for AND, OR, NOT operators (`apple AND orange`, `apple OR banana`, `NOT apple`)
  - **Parslet-based Parser**: Robust parsing with proper error handling for invalid syntax
  - **OpenAPI Integration**: Automatic `$search` parameter inclusion in OAS2 definitions
  - **OData Metadata Support**: Proper `SearchRestrictions` annotations using Capabilities vocabulary
  - **MCP Tool Integration**: Exposes search as MCP tools for AI model interaction
  - **Comprehensive Testing**: 68 test examples covering all functionality

## Usage

  Entity sets can opt-in to search by implementing the `od_search` method:

  ```ruby
  def od_search(search_expression)
    if search_expression.or?
      # Handle OR expressions
    else
      # Handle AND expressions (default)
    end
  end

  Limitations

  - No parentheses: (apple AND orange) OR banana ❌
  - No mixed operators: apple AND orange OR banana ❌

  Breaking Changes

  None. Purely additive feature with full backward compatibility.

  Dependencies

  - Added parslet ~> 2.0 for search expression parsing

  This covers the essential information while keeping it concise and focused on the key benefits and usage.