### PR TITLE
Document create / read-only sets in doc/using_create.md (PRD task 4)

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,8 @@ class SampleSchema < OdataDuty::Schema
 end
 ```
 
+Implementing `create` makes a set writable; omitting it keeps the set read-only. This single choice is reflected automatically across `$oas2`, `$metadata`, and MCP — see [Using `create`](doc/using_create.md).
+
 ---
 
 ## Rails Integration Example
@@ -217,6 +219,7 @@ end
 - [MCP Crash Course](doc/mcp_crash_course.md)
 - [Using `$select`](doc/using_select.md)
 - [Using `$search`](doc/using_search.md)
+- [Using `create`](doc/using_create.md)
 
 ---
 

--- a/doc/prds/task-tgp397bx3mf8G8YLJi-plan.md
+++ b/doc/prds/task-tgp397bx3mf8G8YLJi-plan.md
@@ -59,7 +59,7 @@ exercise `EntitySet::Metadata#supports_create?`.
   - Depends on: Task 1 (builder `supports_create?` already present; this adds the class-DSL one and
     the shared template change).
 
-- [ ] **Task 3 — MCP: `create_<EntitySet>` tool in `tools/list` and `tools/call`**
+- [x] **Task 3 — MCP: `create_<EntitySet>` tool in `tools/list` and `tools/call`**
   - Task text: Add `supports_create?` to builder `SchemaBuilder::Endpoint` (delegating to
     `entity_set.supports_create?`), mirroring its `supports_search?` delegation. In
     `MCPExecutor#handle_tools_list`, additionally list a `create_<EntitySet>` tool for each endpoint

--- a/doc/prds/task-tgp397bx3mf8G8YLJi-plan.md
+++ b/doc/prds/task-tgp397bx3mf8G8YLJi-plan.md
@@ -86,7 +86,7 @@ exercise `EntitySet::Metadata#supports_create?`.
     `supports_create?`). Endpoint delegates to EntitySet; class-DSL `EntitySet::Metadata` is the
     endpoint object for the class schema.
 
-- [ ] **Task 4 — Documentation: `doc/using_create.md` + README cross-link**
+- [x] **Task 4 — Documentation: `doc/using_create.md` + README cross-link**
   - Task text: Add `doc/using_create.md` in the house style (purpose-first, example-driven, ending
     in a "Common Error Cases" section), covering: implementing `create` makes a set writable;
     omitting it makes the set read-only; and how that choice is reflected across `$oas2` (post

--- a/doc/prds/task-tgp397bx3mf8G8YLJi-plan.md
+++ b/doc/prds/task-tgp397bx3mf8G8YLJi-plan.md
@@ -103,7 +103,7 @@ exercise `EntitySet::Metadata#supports_create?`.
 
 Four unresolved reviewer comments against the original implementation. Addressed as two tasks.
 
-- [ ] **Task R1 — Guard `handle_tools_call` against a nil endpoint**
+- [x] **Task R1 — Guard `handle_tools_call` against a nil endpoint**
   - Task text: `handle_tools_call` can call `run_tool` with `endpoint == nil` when a client calls a
     tool like `search_Unknown` (or `search_` with an empty suffix), raising `NoMethodError` on
     `endpoint.url` instead of the intended "Unknown tool" error. Validate the endpoint and its

--- a/doc/prds/task-tgp397bx3mf8G8YLJi-plan.md
+++ b/doc/prds/task-tgp397bx3mf8G8YLJi-plan.md
@@ -23,7 +23,7 @@ exercise `EntitySet::Metadata#supports_create?`.
 
 ## Tasks
 
-- [ ] **Task 1 — `$oas2`: gate the `post` collection path on create availability**
+- [x] **Task 1 — `$oas2`: gate the `post` collection path on create availability**
   - Task text: Add a `supports_create?` predicate to the builder `SchemaBuilder::EntitySet`
     (`resolver_class.method_defined?(:create)`), mirroring `supports_search?`. In
     `OAS2#add_collection_paths` (`lib/odata_duty/oas2.rb`), emit the `'post' =>

--- a/doc/prds/task-tgp397bx3mf8G8YLJi-plan.md
+++ b/doc/prds/task-tgp397bx3mf8G8YLJi-plan.md
@@ -96,3 +96,38 @@ exercise `EntitySet::Metadata#supports_create?`.
   - Likely files: `doc/using_create.md` (new), `README.md`.
   - PRD excerpt: "Documentation impact" section.
   - Depends on: Tasks 1–3 (documents their behavior).
+
+---
+
+## Review follow-up (PR review comments — 2026-06-16)
+
+Four unresolved reviewer comments against the original implementation. Addressed as two tasks.
+
+- [ ] **Task R1 — Guard `handle_tools_call` against a nil endpoint**
+  - Task text: `handle_tools_call` can call `run_tool` with `endpoint == nil` when a client calls a
+    tool like `search_Unknown` (or `search_` with an empty suffix), raising `NoMethodError` on
+    `endpoint.url` instead of the intended "Unknown tool" error. Validate the endpoint and its
+    capability before dispatching for the `search_` prefix, mirroring the existing `create_` guard
+    (`endpoint&.supports_create?`). Add a failing test first (e.g. `tools/call` for `search_Unknown`
+    expects an "Unknown tool" error). Mirror the spec in both spec trees.
+  - Likely files: `lib/odata_duty/mcp_executor.rb`; specs
+    `spec/odata_duty/entity_set/create/mcp_spec.rb`,
+    `spec/odata_duty/schema_builder/entity_set/create/mcp_spec.rb` (or a sibling MCP spec).
+  - PRD excerpt: "MCP `tools/call` for `create_<EntitySet>` on a read-only set: the tool is not in
+    `tools/list`, so calling it raises the existing 'Unknown tool' error." The same must hold for an
+    unknown `search_` tool name.
+  - Depends on: original Task 3.
+
+- [ ] **Task R2 — Correct `doc/using_create.md` examples to match the implementation**
+  - Task text: Fix three doc inaccuracies in `doc/using_create.md`: (a) the MCP `tools/list`
+    `required` array must include the key `id` (built from all non-nullable properties, and
+    `property_ref` is always `nullable: false`) → `["id", "user_name", "emails"]`; (b) the
+    `NoImplementationError` message has no leading slash — `create not implemented for People`, since
+    it is built from `endpoint.url`; (c) the coercion/validation error bullet must name the classes
+    the create path actually raises: `CreateComplexTypeHashWrapper` rescues `InvalidValue` and raises
+    `OdataDuty::InvalidType`, and accessing an undefined field on the input raises
+    `OdataDuty::NoSuchPropertyError` (unknown body keys are otherwise ignored unless accessed) — drop
+    the nonexistent `UnknownPropertyError`/standalone `InvalidValue` framing.
+  - Likely files: `doc/using_create.md` (docs only — no code/tests).
+  - PRD excerpt: "Common error cases" and the MCP `tools/list` example in the PRD.
+  - Depends on: Task R1 (documents corrected behavior).

--- a/doc/prds/task-tgp397bx3mf8G8YLJi-plan.md
+++ b/doc/prds/task-tgp397bx3mf8G8YLJi-plan.md
@@ -41,7 +41,7 @@ exercise `EntitySet::Metadata#supports_create?`.
     (`CreateWidgets`/`ListWidgets`). Scope: gating the OAS2 post path on create availability.
   - Depends on: none (introduces `supports_create?` on builder EntitySet).
 
-- [ ] **Task 2 — `$metadata`: `Capabilities.InsertRestrictions` (`Insertable=false`) for read-only sets**
+- [x] **Task 2 — `$metadata`: `Capabilities.InsertRestrictions` (`Insertable=false`) for read-only sets**
   - Task text: Add `supports_create?` to the class-DSL `OdataDuty::EntitySet::Metadata`
     (`entity_set.method_defined?(:create)`), mirroring its `supports_search?`. In the shared EDMX
     template `lib/metadata.xml.erb`, emit an `Annotation Term="Capabilities.InsertRestrictions"`

--- a/doc/prds/task-tgp397bx3mf8G8YLJi-plan.md
+++ b/doc/prds/task-tgp397bx3mf8G8YLJi-plan.md
@@ -1,0 +1,98 @@
+# Build plan — Reflect unimplemented `create` in `$metadata`, `$oas2`, and MCP
+
+PRD: [task-tgp397bx3mf8G8YLJi.md](./task-tgp397bx3mf8G8YLJi.md)
+
+## Context / shared decisions
+
+The feature mirrors the existing `od_search` capability reflection (`supports_search?`).
+Detection contract per PRD: a set "supports create" when its resolver/data class responds to
+`create` — `resolver_class.method_defined?(:create)` (builder DSL),
+`entity_set.method_defined?(:create)` (class DSL). Base classes (`SetResolver`, `EntitySet`) do
+**not** define `create`, so `method_defined?` is clean.
+
+`supports_create?` is internal, so it is exercised only through its observable effects on `$oas2`,
+`$metadata`, and MCP (public-API-only tests). Tasks are therefore decomposed by output, each adding
+the predicate where its consumer needs it.
+
+Established mirror convention (from `search_spec.rb`): the class-DSL spec tree tests `$oas2` and
+`$metadata` by constructing a **builder** schema for those sub-sections (OAS2 is only ever rendered
+from a builder schema), while `#execute`/`mcp` sections use the class-DSL schema directly. Follow
+that convention. The `$metadata` template (`lib/metadata.xml.erb`) is shared by both DSLs, so the
+class-DSL `$metadata` test can additionally use the class schema's `metadata_xml` to genuinely
+exercise `EntitySet::Metadata#supports_create?`.
+
+## Tasks
+
+- [ ] **Task 1 — `$oas2`: gate the `post` collection path on create availability**
+  - Task text: Add a `supports_create?` predicate to the builder `SchemaBuilder::EntitySet`
+    (`resolver_class.method_defined?(:create)`), mirroring `supports_search?`. In
+    `OAS2#add_collection_paths` (`lib/odata_duty/oas2.rb`), emit the `'post' =>
+    CollectionPostPath...` entry only when `entity_set.supports_create?`; the `'get'` is unchanged.
+    Read-only sets (no `create`) get only `get`; writable sets keep both `get` and `post`. Add
+    mirrored specs under `spec/odata_duty/entity_set/**` and `spec/odata_duty/schema_builder/**`
+    (both using a builder-constructed schema for the OAS2 assertions, per the search_spec
+    convention): a creatable set's path has `post` with `operationId "Create<Set>"`; a read-only
+    set's path has no `post`.
+  - Likely files: `lib/odata_duty/schema_builder/entity_set.rb`, `lib/odata_duty/oas2.rb`;
+    specs `spec/odata_duty/entity_set/create/oas2_spec.rb`,
+    `spec/odata_duty/schema_builder/entity_set/create/oas2_spec.rb`.
+  - PRD excerpt: "$oas2 emits a post operation on every collection path … even for read-only sets";
+    read-only `/People` → only `get`; writable `/Widgets` → `get` + `post`
+    (`CreateWidgets`/`ListWidgets`). Scope: gating the OAS2 post path on create availability.
+  - Depends on: none (introduces `supports_create?` on builder EntitySet).
+
+- [ ] **Task 2 — `$metadata`: `Capabilities.InsertRestrictions` (`Insertable=false`) for read-only sets**
+  - Task text: Add `supports_create?` to the class-DSL `OdataDuty::EntitySet::Metadata`
+    (`entity_set.method_defined?(:create)`), mirroring its `supports_search?`. In the shared EDMX
+    template `lib/metadata.xml.erb`, emit an `Annotation Term="Capabilities.InsertRestrictions"`
+    with `<PropertyValue Property="Insertable" Bool="false" />` for each `EntitySet` where
+    `!entity_set.supports_create?`; creatable sets get no such annotation (default-insertable).
+    Add mirrored specs: class-DSL tree uses the class schema's `metadata_xml`; builder-DSL tree
+    uses the builder schema's `metadata_xml`. Assert the annotation is present for a read-only set
+    and absent for a creatable set (scope the XML to each `<EntitySet>` block, as search_spec does).
+  - Likely files: `lib/odata_duty.rb` (`EntitySet::Metadata#supports_create?`),
+    `lib/metadata.xml.erb`; specs `spec/odata_duty/entity_set/create/metadata_spec.rb`,
+    `spec/odata_duty/schema_builder/entity_set/create/metadata_spec.rb`.
+  - PRD excerpt: read-only `<EntitySet Name="People">` carries `Capabilities.InsertRestrictions` →
+    `Insertable="false"`; writable `<EntitySet Name="Widgets" … />` has no annotation. The
+    `Org.OData.Capabilities.V1` reference is already declared at the top of the EDMX.
+  - Depends on: Task 1 (builder `supports_create?` already present; this adds the class-DSL one and
+    the shared template change).
+
+- [ ] **Task 3 — MCP: `create_<EntitySet>` tool in `tools/list` and `tools/call`**
+  - Task text: Add `supports_create?` to builder `SchemaBuilder::Endpoint` (delegating to
+    `entity_set.supports_create?`), mirroring its `supports_search?` delegation. In
+    `MCPExecutor#handle_tools_list`, additionally list a `create_<EntitySet>` tool for each endpoint
+    whose set `supports_create?` (alongside any `search_` tools): name `"create_#{endpoint.name}"`,
+    description `"Create a new #{endpoint.name} record"`, and an `inputSchema` of
+    `{ 'type' => 'object', 'properties' => <entity type properties>, ... }` built from the entity
+    type's properties (`endpoint.entity_type.properties` + `Property#to_oas2`, mirroring
+    `SchemaBuilder::ComplexType#to_oas2`) — the same writable body shape OAS2's post advertises. In
+    `handle_tools_call`, dispatch `create_`-prefixed tool names to the create path
+    (`Executor.create(url:, context:, query_options: arguments, schema:)`), returning the created
+    entity as structured JSON (`Oj.load`), the way `search_` reuses the read path. Read-only sets
+    list no `create_` tool, so calling one hits the existing "Unknown tool" error. Add mirrored
+    specs under both spec trees (class-DSL tree uses the class schema via `handle_jsonrpc`;
+    builder-DSL tree uses the builder schema): `create_<Set>` present for a creatable set and absent
+    for a read-only set; a `tools/call` for `create_<Set>` creates and returns the record.
+  - Likely files: `lib/odata_duty/schema_builder/endpoint.rb`, `lib/odata_duty/mcp_executor.rb`;
+    specs `spec/odata_duty/entity_set/create/mcp_spec.rb`,
+    `spec/odata_duty/schema_builder/entity_set/create/mcp_spec.rb`.
+  - PRD excerpt: `tools/list` includes `create_Widgets` (`"Create a new Widgets record"`,
+    inputSchema object with the writable properties) and omits `create_People`; a `tools/call` for
+    `create_Widgets` creates the record and returns the created entity as structured JSON, reusing
+    `Schema.create`/`Executor.create`. Both DSLs, mirrored specs.
+  - Depends on: Task 1 (builder `supports_create?` on EntitySet), Task 2 (class-DSL
+    `supports_create?`). Endpoint delegates to EntitySet; class-DSL `EntitySet::Metadata` is the
+    endpoint object for the class schema.
+
+- [ ] **Task 4 — Documentation: `doc/using_create.md` + README cross-link**
+  - Task text: Add `doc/using_create.md` in the house style (purpose-first, example-driven, ending
+    in a "Common Error Cases" section), covering: implementing `create` makes a set writable;
+    omitting it makes the set read-only; and how that choice is reflected across `$oas2` (post
+    omitted), `$metadata` (`InsertRestrictions Insertable=false`), and MCP (`create_<EntitySet>`
+    tool present/absent). Show both the builder-DSL resolver and class-DSL entity-set forms.
+    Cross-link the guide from the create-related parts of `README.md`.
+  - Likely files: `doc/using_create.md` (new), `README.md`.
+  - PRD excerpt: "Documentation impact" section.
+  - Depends on: Tasks 1–3 (documents their behavior).

--- a/doc/prds/task-tgp397bx3mf8G8YLJi-plan.md
+++ b/doc/prds/task-tgp397bx3mf8G8YLJi-plan.md
@@ -118,7 +118,7 @@ Four unresolved reviewer comments against the original implementation. Addressed
     unknown `search_` tool name.
   - Depends on: original Task 3.
 
-- [ ] **Task R2 — Correct `doc/using_create.md` examples to match the implementation**
+- [x] **Task R2 — Correct `doc/using_create.md` examples to match the implementation**
   - Task text: Fix three doc inaccuracies in `doc/using_create.md`: (a) the MCP `tools/list`
     `required` array must include the key `id` (built from all non-nullable properties, and
     `property_ref` is always `nullable: false`) → `["id", "user_name", "emails"]`; (b) the

--- a/doc/prds/task-tgp397bx3mf8G8YLJi.md
+++ b/doc/prds/task-tgp397bx3mf8G8YLJi.md
@@ -1,0 +1,177 @@
+# Reflect unimplemented `create` in `$metadata`, `$oas2`, and MCP
+
+## Summary
+When an entity set's data class (class DSL) or resolver (builder DSL) does **not** implement
+`create`, the generated `$metadata` EDMX, `$oas2` JSON, and MCP tool list should all reflect that
+creation is unavailable for that set. Conversely, sets that **do** implement `create` advertise it —
+including a new `create_<EntitySet>` MCP tool. This is for gem consumers who expose read-only (or
+selectively writable) entity sets and want their generated contracts to tell the truth.
+
+## Goal / Problem
+Today an entity set's *read* capability is already reflected accurately: the builder DSL only emits
+OAS2 GET paths for sets that implement `collection` / `individual` (`collection_entity_sets` /
+`individual_entity_sets`), and `Capabilities.SearchRestrictions` is annotated only when `od_search`
+exists. **Create is the exception:**
+
+- **`$oas2`** emits a `post` operation on *every* collection path (`add_collection_paths`), even for
+  read-only sets that never implement `create`. Consumers see a POST in their Swagger that 4xx's at
+  runtime.
+- **`$metadata`** says nothing at all about insert capability.
+- **MCP** exposes no create affordance in either direction.
+
+Expected behavior: the three generated outputs should agree with what the data class/resolver
+actually implements, the same way they already do for read and search.
+
+## What it enables
+- As a gem consumer, when my resolver does **not** define `create`, my `$oas2` document omits the
+  `post` operation for that set, so generated clients don't offer a non-functional create.
+- As a gem consumer, my `$metadata` carries `Capabilities.InsertRestrictions` with
+  `Insertable="false"` for read-only sets, so OData-aware clients know not to attempt inserts.
+- As a gem consumer, when my resolver **does** define `create`, an MCP `create_<EntitySet>` tool
+  appears in `tools/list` and can be called to create a record; when it doesn't, no such tool is
+  listed.
+
+Scope limit: this covers `create` only. `update`/PATCH does not exist in the gem and is explicitly
+out of scope (see Scope).
+
+## External API
+No new consumer-written declaration is introduced — availability is inferred from whether the data
+class/resolver implements `create`, mirroring how `collection`, `individual`, and `od_search` are
+already detected.
+
+**Builder DSL** — a read-only resolver vs. a writable one:
+
+```ruby
+class PeopleResolver < OdataDuty::SetResolver
+  def od_after_init = @records = People.all
+  def collection = @records
+  def individual(id) = @records.find { |r| r.id == id }
+  # no #create  → create is unavailable for this set
+end
+
+class WidgetsResolver < OdataDuty::SetResolver
+  def od_after_init = @records = Widgets.all
+  def collection = @records
+  def create(input)            # presence of #create → create is available
+    Widgets.create!(name: input.name)
+  end
+end
+```
+
+**Class-based DSL** — same inference via the entity set class:
+
+```ruby
+class PeopleSet < OdataDuty::EntitySet
+  entity_type PersonEntity
+  def collection = People.all
+  # no #create  → create is unavailable
+end
+
+class WidgetsSet < OdataDuty::EntitySet
+  entity_type WidgetEntity
+  def collection = Widgets.all
+  def create(input) = Widgets.create!(name: input.name)
+end
+```
+
+Detection contract: a set "supports create" when its resolver/data class responds to `create`
+(`resolver_class.method_defined?(:create)` for the builder DSL; the entity-set class equivalent for
+the class DSL) — analogous to the existing `supports_search?` predicate. No new public method is
+required of consumers.
+
+## Behavior & expected I/O
+
+**`$oas2` — read-only set (`People`, no `create`):** only `get` is emitted.
+
+```jsonc
+"paths": {
+  "/People": {
+    "get": { "operationId": "ListPeople", "...": "..." }
+    // no "post"
+  },
+  "/People({id})": { "get": { "operationId": "GetPeople", "...": "..." } }
+}
+```
+
+**`$oas2` — writable set (`Widgets`, has `create`):** unchanged from today — both `get` and `post`.
+
+```jsonc
+"paths": {
+  "/Widgets": {
+    "get":  { "operationId": "ListWidgets", "...": "..." },
+    "post": { "operationId": "CreateWidgets", "...": "..." }
+  }
+}
+```
+
+**`$metadata` EDMX — read-only set** gets an `InsertRestrictions` annotation (writable sets get no
+such annotation, i.e. default-insertable):
+
+```xml
+<EntitySet Name="People" EntityType="MyNamespace.Person">
+  <Annotation Term="Capabilities.InsertRestrictions">
+    <Record>
+      <PropertyValue Property="Insertable" Bool="false" />
+    </Record>
+  </Annotation>
+</EntitySet>
+<EntitySet Name="Widgets" EntityType="MyNamespace.Widget" />
+```
+
+(The `Org.OData.Capabilities.V1` reference is already declared at the top of the EDMX document, as
+used by `SearchRestrictions`.)
+
+**MCP `tools/list`** — a `create_<EntitySet>` tool is listed for each set that implements `create`
+(alongside any `search_<EntitySet>` tools), and omitted for read-only sets:
+
+```jsonc
+{ "tools": [
+  { "name": "create_Widgets",
+    "description": "Create a new Widgets record",
+    "inputSchema": {
+      "type": "object",
+      "properties": { "name": { "type": "string" }, "...": "..." },
+      "required": ["name"]
+    } }
+  // no create_People
+] }
+```
+
+The `create_<EntitySet>` tool's `inputSchema` mirrors the entity type's writable input shape (the
+same body schema the OAS2 `post` advertises). A `tools/call` for `create_Widgets` creates the record
+and returns the created entity as structured JSON — reusing the existing create path
+(`Schema.create` / `Executor.create`), the same way `search_<EntitySet>` reuses the read path today.
+
+**Runtime REST POST** behavior is unchanged: a POST to a set without `create` still raises
+`NoImplementationError` ("create not implemented"). The outputs simply no longer *advertise* the
+unavailable operation.
+
+## Common error cases
+- **POST to a set without `create`** (class or builder DSL): raises `NoImplementationError` —
+  "create not implemented for <set>". Unchanged; the outputs now just don't advertise it.
+- **MCP `tools/call` for `create_<EntitySet>` on a read-only set**: the tool is not in `tools/list`,
+  so calling it raises the existing "Unknown tool" error.
+- **MCP `create_<EntitySet>` with a body that fails coercion/validation**: surfaces the existing
+  creation errors (e.g. `InvalidValue` / `UnknownPropertyError`) from the create path, as a
+  JSON-RPC error.
+- Read-side errors (`ResourceNotFoundError`, `InvalidQueryOptionError`, etc.) are unaffected.
+
+## Scope
+- **In:** detecting `create` availability per entity set; gating the OAS2 `post` path on it; adding
+  `Capabilities.InsertRestrictions` (`Insertable=false`) to `$metadata` for non-creatable sets;
+  adding a `create_<EntitySet>` MCP tool for creatable sets. Both the class-based DSL and the builder
+  DSL, with mirrored specs in `spec/odata_duty/entity_set/**` and `spec/odata_duty/schema_builder/**`.
+- **Out:** `update`/PATCH (no such operation exists in the gem); delete; per-property insert
+  restrictions; changing the runtime POST execution/coercion behavior; `Updatable` /
+  `UpdateRestrictions` annotations.
+
+## Documentation impact
+Add a new guide `doc/using_create.md` in the house style (purpose-first, example-driven, ending in
+"Common Error Cases"), covering: how implementing `create` makes a set writable, how omitting it
+makes the set read-only, and how that choice is reflected across `$oas2`, `$metadata`, and MCP.
+Cross-link it from the create-related parts of `README.md`. (Guide not written as part of this PRD.)
+
+## Open questions
+- MCP `create_<EntitySet>` `inputSchema`: reflect **all** entity-type properties, or only
+  non-key/writable ones? Default assumption above is "the same writable body shape OAS2's `post`
+  advertises."

--- a/doc/using_create.md
+++ b/doc/using_create.md
@@ -197,7 +197,7 @@ The `Org.OData.Capabilities.V1` vocabulary (aliased `Capabilities`) is already r
           "name": { "type": "string" /* ... */ },
           "emails": { "type": "array" /* ... */ }
         },
-        "required": ["user_name", "emails"]
+        "required": ["id", "user_name", "emails"]
       }
     }
   ]
@@ -222,13 +222,13 @@ A read-only set advertises no `create_<Set>` tool, so calling one raises an "Unk
 ## Common Error Cases
 
 - **`POST` to a set without `create`:**
-  A `POST` to a read-only set raises `OdataDuty::NoImplementationError` with the message `create not implemented for <url>` (the set's URL, e.g. `create not implemented for /People`).
+  A `POST` to a read-only set raises `OdataDuty::NoImplementationError` with the message `create not implemented for <url>` (the set's URL, e.g. `create not implemented for People`).
 
 - **MCP `create_<Set>` for a read-only set:**
   Because the tool is never listed for a read-only set, calling it via `tools/call` raises an `"Unknown tool: create_<Set>"` error rather than `NoImplementationError`.
 
 - **Request body that fails coercion/validation:**
-  When the body cannot be coerced onto the entity type's properties, the standard creation errors propagate from the create path — for example `OdataDuty::InvalidType` or `OdataDuty::InvalidValue` for a value that does not match a property's type, and `OdataDuty::UnknownPropertyError` for a body field that is not a defined property.
+  When a body value cannot be coerced to a property's type, the input wrapper (`CreateComplexTypeHashWrapper`) rescues the internal `InvalidValue` and raises `OdataDuty::InvalidType` — so `OdataDuty::InvalidType` is what propagates for a wrong-typed value. Accessing a field that is not a defined property on the input object raises `OdataDuty::NoSuchPropertyError`; unknown keys in the request body are otherwise ignored unless your `create` accesses them via `input.<that_key>`.
 
 ## Summary
 

--- a/doc/using_create.md
+++ b/doc/using_create.md
@@ -1,0 +1,237 @@
+# Using `create` with OdataDuty
+
+OdataDuty exposes a *writable* entity set the moment your data class (class DSL) or resolver (builder DSL) implements a `create` method. There is no separate flag or declaration to set: availability is inferred from the presence of `create`, exactly the way `collection`, `individual`, and `od_search` are inferred. Implement `create` and the set accepts `POST` requests, gains a `post` operation in `$oas2`, drops the read-only annotation in `$metadata`, and advertises an MCP `create_<Set>` tool. Omit it and the set is read-only across all three contracts.
+
+This guide explains how to implement `create` and how the choice is reflected in the generated `$oas2`, `$metadata`, and MCP contracts.
+
+## Overview
+
+- **Purpose:** Allow clients to create new records through OData `POST` (and the equivalent MCP tool).
+- **Mechanism:** OdataDuty checks whether your data class / resolver defines `create`. If it does, the set is writable; if not, it is read-only.
+- **No new declaration:** Writability is inferred from the method, just like `collection`, `individual`, and `od_search`.
+- **Typed input:** `create` receives a coerced input object built from the request body and mapped onto the entity type's properties. Read fields via `input.property_name`.
+- **Return value:** `create` returns the created record — the same object shape your entity type's mapper renders for `collection`/`individual`.
+- **Reflected everywhere:** A writable set has a `post` in `$oas2`, no `InsertRestrictions` annotation in `$metadata`, and a `create_<Set>` MCP tool. A read-only set has none of these.
+
+## Implementing `create`
+
+Both DSLs work the same way: define `create(input)`, read the coerced fields off `input`, persist the record, and return it.
+
+### Builder DSL (`OdataDuty::SetResolver`)
+
+A resolver that implements `create` is writable:
+
+```ruby
+class PeopleResolver < OdataDuty::SetResolver
+  def od_after_init
+    @records = Person.all
+  end
+
+  def collection
+    @records
+  end
+
+  def individual(id)
+    @records.find { |record| record.id == id }
+  end
+
+  # Receives a typed, coerced input object. Access fields via input.property_name.
+  # Returns the created record (same shape collection/individual return).
+  def create(input)
+    Person.create!(user_name: input.user_name, name: input.name, emails: input.emails)
+  end
+end
+```
+
+A resolver without `create` is read-only — the data methods are identical, just no `create`:
+
+```ruby
+class CountriesResolver < OdataDuty::SetResolver
+  def od_after_init
+    @records = Country.all
+  end
+
+  def collection
+    @records
+  end
+
+  def individual(id)
+    @records.find { |record| record.id == id }
+  end
+end
+```
+
+### Class DSL (`OdataDuty::EntitySet`)
+
+The class DSL behaves identically; the set itself implements `create`:
+
+```ruby
+class PeopleSet < OdataDuty::EntitySet
+  entity_type PersonEntity
+
+  def od_after_init
+    @records = Person.active
+  end
+
+  def collection
+    @records
+  end
+
+  def individual(id)
+    @records.find(id)
+  end
+
+  # Receives a typed, coerced input object. Access fields via input.property_name.
+  def create(input)
+    Person.create!(user_name: input.user_name, name: input.name, emails: input.emails)
+  end
+end
+```
+
+Omit `create` and the same set is read-only:
+
+```ruby
+class CountriesSet < OdataDuty::EntitySet
+  entity_type CountryEntity
+
+  def od_after_init
+    @records = Country.all
+  end
+
+  def collection
+    @records
+  end
+
+  def individual(id)
+    @records.find(id)
+  end
+end
+```
+
+### How It Works
+
+1. **Discovery:** OdataDuty checks whether your data class / resolver responds to `create`. That single check drives every contract below.
+2. **Coercion:** On `POST`, the request body is coerced and validated against the entity type's properties into a typed input object, which is passed to your `create`.
+3. **Persistence:** Your `create` persists the record and returns it.
+4. **Rendering:** The returned record is run through the entity type's mapper, so the response is the same shape a `GET` would produce, plus the `@odata.context` annotation.
+
+## Reflected in the generated contracts
+
+### `$oas2`
+
+A **writable** set's collection path exposes both `get` and `post`. The `post` operation's `operationId` is `Create<Set>` (e.g. `CreatePeople`):
+
+```jsonc
+{
+  "paths": {
+    "/People": {
+      "get": { "operationId": "ListPeople" /* ... */ },
+      "post": {
+        "operationId": "CreatePeople",
+        "produces": ["application/json"],
+        "parameters": [
+          { "name": "body", "in": "body", "required": true,
+            "schema": { "$ref": "#/definitions/Person" } }
+        ],
+        "responses": {
+          "200": { "description": "Success", "schema": { "$ref": "#/definitions/Person" } },
+          "201": { "description": "Created", "schema": { "$ref": "#/definitions/Person" } },
+          "default": { "description": "Unexpected error", "schema": { "$ref": "#/definitions/Error" } }
+        }
+      }
+    }
+  }
+}
+```
+
+A **read-only** set's path carries only `get` — the `post` is omitted entirely:
+
+```jsonc
+{
+  "paths": {
+    "/Countries": {
+      "get": { "operationId": "ListCountries" /* ... */ }
+    }
+  }
+}
+```
+
+### `$metadata` (EDMX)
+
+A **read-only** set's `<EntitySet>` carries an `InsertRestrictions` annotation marking it not insertable:
+
+```xml
+<EntitySet Name="Countries" EntityType="MySpace.Country">
+    <Annotation Term="Capabilities.InsertRestrictions">
+        <Record>
+            <PropertyValue Property="Insertable" Bool="false" />
+        </Record>
+    </Annotation>
+</EntitySet>
+```
+
+A **writable** set gets no such annotation (the OData default is insertable):
+
+```xml
+<EntitySet Name="People" EntityType="MySpace.Person" />
+```
+
+The `Org.OData.Capabilities.V1` vocabulary (aliased `Capabilities`) is already referenced at the top of the metadata document, so the annotation needs no additional setup.
+
+### MCP
+
+`tools/list` includes a `create_<Set>` tool for each writable set. The tool's `name` is `create_<Set>`, its `description` is `"Create a new <Set> record"`, and its `inputSchema` is an object whose `properties` are the entity type's properties and whose `required` array is the non-nullable property names:
+
+```jsonc
+// tools/list result (writable People set)
+{
+  "tools": [
+    {
+      "name": "create_People",
+      "description": "Create a new People record",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "id": { "type": "string" /* ... */ },
+          "user_name": { "type": "string" /* ... */ },
+          "name": { "type": "string" /* ... */ },
+          "emails": { "type": "array" /* ... */ }
+        },
+        "required": ["user_name", "emails"]
+      }
+    }
+  ]
+}
+```
+
+A `tools/call` for `create_<Set>` creates the record and returns the created entity as structured JSON, reusing the same create path as the REST `POST`:
+
+```jsonc
+// tools/call request
+{
+  "method": "tools/call",
+  "params": {
+    "name": "create_People",
+    "arguments": { "user_name": "alice", "name": "Alice", "emails": ["alice@example.com"] }
+  }
+}
+```
+
+A read-only set advertises no `create_<Set>` tool, so calling one raises an "Unknown tool" error (see below).
+
+## Common Error Cases
+
+- **`POST` to a set without `create`:**
+  A `POST` to a read-only set raises `OdataDuty::NoImplementationError` with the message `create not implemented for <url>` (the set's URL, e.g. `create not implemented for /People`).
+
+- **MCP `create_<Set>` for a read-only set:**
+  Because the tool is never listed for a read-only set, calling it via `tools/call` raises an `"Unknown tool: create_<Set>"` error rather than `NoImplementationError`.
+
+- **Request body that fails coercion/validation:**
+  When the body cannot be coerced onto the entity type's properties, the standard creation errors propagate from the create path — for example `OdataDuty::InvalidType` or `OdataDuty::InvalidValue` for a value that does not match a property's type, and `OdataDuty::UnknownPropertyError` for a body field that is not a defined property.
+
+## Summary
+
+- **Make a set writable** by implementing `create(input)` on its data class (class DSL) or resolver (builder DSL); omit it to keep the set read-only.
+- **`create`** receives a typed, coerced input object (read fields via `input.property_name`) and returns the created record in the same shape `collection`/`individual` return.
+- **Writable** sets gain a `post` (`operationId` `Create<Set>`) in `$oas2`, no `InsertRestrictions` annotation in `$metadata`, and a `create_<Set>` MCP tool — all of which **read-only** sets lack.

--- a/lib/metadata.xml.erb
+++ b/lib/metadata.xml.erb
@@ -45,6 +45,13 @@
                                 </Record>
                             </Annotation>
                         <% end %>
+                        <% if !entity_set.supports_create? %>
+                            <Annotation Term="Capabilities.InsertRestrictions">
+                                <Record>
+                                    <PropertyValue Property="Insertable" Bool="false" />
+                                </Record>
+                            </Annotation>
+                        <% end %>
                     </EntitySet>
                 <% end %>
             </EntityContainer>

--- a/lib/odata_duty.rb
+++ b/lib/odata_duty.rb
@@ -105,6 +105,11 @@ module OdataDuty
         entity_set.method_defined?(:od_search)
       end
 
+      def supports_create?
+        # Check if the entity set class supports create by looking for the create method
+        entity_set.method_defined?(:create)
+      end
+
       private
 
       def converted_id(id, context)

--- a/lib/odata_duty/mcp_executor.rb
+++ b/lib/odata_duty/mcp_executor.rb
@@ -1,6 +1,21 @@
 require 'uri'
 
 module OdataDuty
+  MCP_SEARCH_DESCRIPTION = 'Search query using expressions with AND, OR, NOT operators'.freeze
+  MCP_SEARCH_INPUT_SCHEMA = {
+    'type' => 'object',
+    'properties' => {
+      '$search' => { 'type' => 'string', 'description' => MCP_SEARCH_DESCRIPTION }
+    },
+    'required' => ['$search']
+  }.freeze
+
+  MCP_CAPABILITIES = {
+    'logging' => {}, 'prompts' => { 'listChanged' => false },
+    'resources' => { 'subscribe' => false, 'listChanged' => false },
+    'tools' => { 'listChanged' => false }
+  }.freeze
+
   class MCPExecutor
     def self.handle(**)
       new(**).handle
@@ -37,16 +52,8 @@ module OdataDuty
     end
 
     def handle_initialize
-      {
-        'protocolVersion' => '2024-11-05',
-        'capabilities' => {
-          'logging' => {}, 'prompts' => { 'listChanged' => false },
-          'resources' => { 'subscribe' => false, 'listChanged' => false },
-          'tools' => { 'listChanged' => false }
-        },
-        'serverInfo' => { 'name' => schema.title, 'version' => schema.version }
-        # "instructions": "Optional instructions for the client"
-      }
+      { 'protocolVersion' => '2024-11-05', 'capabilities' => MCP_CAPABILITIES,
+        'serverInfo' => { 'name' => schema.title, 'version' => schema.version } }
     end
 
     def run_resources_read
@@ -56,54 +63,64 @@ module OdataDuty
                        query_options: query_options, schema: schema)
     end
 
+    def all_resources
+      schema.endpoints.flat_map { |endpoint| resources_for_endpoint(endpoint) }
+    end
+
     def handle_resources_list
-      resources_list = schema.endpoints.flat_map { |endpoint| resources_for_endpoint(endpoint) }
-      { 'resources' => resources_list.select { |r| r.key?('uri') } }
+      { 'resources' => all_resources.select { |r| r.key?('uri') } }
     end
 
     def handle_resources_templates_list
-      resources_list = schema.endpoints.flat_map { |endpoint| resources_for_endpoint(endpoint) }
-      { 'resourceTemplates' => resources_list.select { |r| r.key?('uriTemplate') } }
+      { 'resourceTemplates' => all_resources.select { |r| r.key?('uriTemplate') } }
     end
 
     def handle_tools_list
-      # Add search tool for each entity set that supports search
-      tools = schema.endpoints.select(&:supports_search?).map do |endpoint|
-        build_tool(endpoint)
-      end
+      search_tools = schema.endpoints.select(&:supports_search?).map { |ep| build_tool(ep) }
+      create_tools = schema.endpoints.select(&:supports_create?).map { |ep| build_create_tool(ep) }
 
-      { 'tools' => tools }
+      { 'tools' => search_tools + create_tools }
     end
 
     def build_tool(endpoint)
       { 'name' => "search_#{endpoint.name}",
         'description' => "Search #{endpoint.name} using expressions with AND, OR, NOT operators",
-        'inputSchema' => {
-          'type' => 'object',
-          'properties' => {
-            '$search' => {
-              'type' => 'string',
-              'description' => 'Search query using expressions with AND, OR, NOT operators'
-            }
-          },
-          'required' => ['$search']
-        } }
+        'inputSchema' => MCP_SEARCH_INPUT_SCHEMA }
+    end
+
+    def build_create_tool(endpoint)
+      { 'name' => "create_#{endpoint.name}",
+        'description' => "Create a new #{endpoint.name} record",
+        'inputSchema' => create_input_schema(endpoint.entity_type) }
+    end
+
+    def create_input_schema(entity_type)
+      properties = entity_type.properties.to_h { |p| [p.name.to_s, p.to_oas2] }
+      required = entity_type.properties.reject(&:nullable).map { |p| p.name.to_s }
+      { 'type' => 'object', 'properties' => properties, 'required' => required }
     end
 
     def handle_tools_call
       tool_name = request_hash['params']['name']
       query_options = request_hash['params']['arguments'] || {}
+      endpoint = find_endpoint(tool_name[7..])
 
-      # Parse tool name to extract entity set
-      raise "Unknown tool: #{tool_name}" unless tool_name.start_with?('search_')
+      if tool_name.start_with?('search_')
+        run_tool(:execute, endpoint, query_options)
+      elsif tool_name.start_with?('create_') && endpoint&.supports_create?
+        run_tool(:create, endpoint, query_options)
+      else
+        raise "Unknown tool: #{tool_name}"
+      end
+    end
 
-      endpoint_name = tool_name[7..] # Remove 'search_' prefix
-      endpoint = schema.endpoints.find { |ep| ep.name == endpoint_name }
+    def find_endpoint(endpoint_name)
+      schema.endpoints.find { |ep| ep.name == endpoint_name }
+    end
 
-      result = Executor.execute(url: endpoint.url, context: context,
-                                query_options: query_options, schema: schema)
-
-      # Parse the JSON result to return it as structured data
+    def run_tool(action, endpoint, query_options)
+      result = Executor.public_send(action, url: endpoint.url, context: context,
+                                            query_options: query_options, schema: schema)
       Oj.load(result)
     end
 

--- a/lib/odata_duty/mcp_executor.rb
+++ b/lib/odata_duty/mcp_executor.rb
@@ -105,7 +105,7 @@ module OdataDuty
       query_options = request_hash['params']['arguments'] || {}
       endpoint = find_endpoint(tool_name[7..])
 
-      if tool_name.start_with?('search_')
+      if tool_name.start_with?('search_') && endpoint&.supports_search?
         run_tool(:execute, endpoint, query_options)
       elsif tool_name.start_with?('create_') && endpoint&.supports_create?
         run_tool(:create, endpoint, query_options)

--- a/lib/odata_duty/oas2.rb
+++ b/lib/odata_duty/oas2.rb
@@ -57,10 +57,9 @@ module OdataDuty
 
     def add_collection_paths
       schema.collection_entity_sets.each do |entity_set|
-        hash['paths']["/#{entity_set.url}"] = {
-          'get' => CollectionGetPath.new(entity_set, wrap_context(entity_set)).to_oas2,
-          'post' => CollectionPostPath.to_oas2(entity_set)
-        }
+        path = { 'get' => CollectionGetPath.new(entity_set, wrap_context(entity_set)).to_oas2 }
+        path['post'] = CollectionPostPath.to_oas2(entity_set) if entity_set.supports_create?
+        hash['paths']["/#{entity_set.url}"] = path
       end
     end
 

--- a/lib/odata_duty/schema_builder/endpoint.rb
+++ b/lib/odata_duty/schema_builder/endpoint.rb
@@ -53,6 +53,10 @@ module OdataDuty
         entity_set.supports_search?
       end
 
+      def supports_create?
+        entity_set.supports_create?
+      end
+
       private
 
       def extend_error(err, set_builder, method_name)

--- a/lib/odata_duty/schema_builder/entity_set.rb
+++ b/lib/odata_duty/schema_builder/entity_set.rb
@@ -23,6 +23,11 @@ module OdataDuty
         # Check if the resolver class supports search by looking for the od_search method
         resolver_class.method_defined?(:od_search)
       end
+
+      def supports_create?
+        # Check if the resolver class supports create by looking for the create method
+        resolver_class.method_defined?(:create)
+      end
     end
   end
 end

--- a/odata_duty.gemspec
+++ b/odata_duty.gemspec
@@ -2,7 +2,7 @@
 
 Gem::Specification.new do |spec|
   spec.name          = 'odata_duty'
-  spec.version       = '0.14.1'
+  spec.version       = '0.15.0'
   spec.authors       = ['Grant Petersen-Speelman']
   spec.email         = ['grant@nexl.io']
 

--- a/spec/metadata.xml
+++ b/spec/metadata.xml
@@ -40,6 +40,7 @@
             <EntityContainer Name="Container">
                 <EntitySet Name="People" EntityType="SampleSpace.Person">
                         
+                        
                     </EntitySet>
             </EntityContainer>
         </Schema>

--- a/spec/odata_duty/entity_set/create/mcp_spec.rb
+++ b/spec/odata_duty/entity_set/create/mcp_spec.rb
@@ -87,5 +87,13 @@ RSpec.describe OdataDuty::EntitySet, 'MCP create tool' do
         mcp_server.handle_jsonrpc(request_payload, context: Context.new)
       end.to raise_error(/Unknown tool/)
     end
+
+    it 'raises Unknown tool for a search tool on an unknown set' do
+      request_payload['params']['name'] = 'search_Unknown'
+
+      expect do
+        mcp_server.handle_jsonrpc(request_payload, context: Context.new)
+      end.to raise_error(/Unknown tool/)
+    end
   end
 end

--- a/spec/odata_duty/entity_set/create/mcp_spec.rb
+++ b/spec/odata_duty/entity_set/create/mcp_spec.rb
@@ -1,0 +1,91 @@
+require 'spec_helper'
+
+class CreateMcpStruct
+  attr_reader :id, :name
+
+  def initialize(id:, name:)
+    @id = id
+    @name = name
+  end
+end
+
+class CreateMcpWidgetEntity < OdataDuty::EntityType
+  property_ref 'id', String
+  property 'name', String
+end
+
+class CreateMcpWidgetSet < OdataDuty::EntitySet
+  entity_type CreateMcpWidgetEntity
+  name 'Widgets'
+  url 'Widgets'
+
+  def create(params)
+    CreateMcpStruct.new(id: 'w1', name: params.name)
+  end
+end
+
+class CreateMcpPersonSet < OdataDuty::EntitySet
+  entity_type CreateMcpWidgetEntity
+  name 'People'
+  url 'People'
+end
+
+class CreateMcpSchema < OdataDuty::Schema
+  base_url 'http://localhost:3000/api'
+  entity_sets [CreateMcpWidgetSet, CreateMcpPersonSet]
+end
+
+RSpec.describe OdataDuty::EntitySet, 'MCP create tool' do
+  subject(:mcp_server) { CreateMcpSchema }
+
+  describe 'tools/list' do
+    let(:request_payload) do
+      { 'jsonrpc' => '2.0', 'method' => 'tools/list', 'params' => {}, 'id' => 'tl-1' }
+    end
+
+    let(:tools) do
+      Oj.load(mcp_server.handle_jsonrpc(request_payload, context: Context.new))['result']['tools']
+    end
+
+    it 'includes a create tool for entity sets that support create' do
+      expect(tools).to include(
+        'name' => 'create_Widgets',
+        'description' => 'Create a new Widgets record',
+        'inputSchema' => {
+          'type' => 'object',
+          'properties' => {
+            'id' => { 'type' => 'string' },
+            'name' => { 'type' => 'string', 'x-nullable' => true }
+          },
+          'required' => ['id']
+        }
+      )
+    end
+
+    it 'does not include a create tool for read-only entity sets' do
+      expect(tools.map { |t| t['name'] }).not_to include('create_People')
+    end
+  end
+
+  describe 'tools/call for create' do
+    let(:request_payload) do
+      { 'jsonrpc' => '2.0', 'method' => 'tools/call',
+        'params' => { 'name' => 'create_Widgets', 'arguments' => { 'name' => 'Gadget' } },
+        'id' => 'tc-1' }
+    end
+
+    it 'creates the record and returns it as structured JSON' do
+      actual = Oj.load(mcp_server.handle_jsonrpc(request_payload, context: Context.new))
+
+      expect(actual['result']).to include('id' => 'w1', 'name' => 'Gadget')
+    end
+
+    it 'raises Unknown tool for a create tool on a read-only set' do
+      request_payload['params']['name'] = 'create_People'
+
+      expect do
+        mcp_server.handle_jsonrpc(request_payload, context: Context.new)
+      end.to raise_error(/Unknown tool/)
+    end
+  end
+end

--- a/spec/odata_duty/entity_set/create/metadata_spec.rb
+++ b/spec/odata_duty/entity_set/create/metadata_spec.rb
@@ -1,0 +1,42 @@
+require 'spec_helper'
+
+class CreateMetadataTestEntity < OdataDuty::EntityType
+  property_ref 'id', String
+  property 'name', String
+end
+
+class WritableMetadataSet < OdataDuty::EntitySet
+  entity_type CreateMetadataTestEntity
+
+  def create(params)
+    params
+  end
+end
+
+class ReadOnlyMetadataSet < OdataDuty::EntitySet
+  entity_type CreateMetadataTestEntity
+end
+
+class CreateMetadataTestSchema < OdataDuty::Schema
+  base_url 'http://localhost:3000/api'
+  entity_sets [WritableMetadataSet, ReadOnlyMetadataSet]
+end
+
+RSpec.describe OdataDuty::EntitySet, 'InsertRestrictions metadata' do
+  subject(:metadata_xml) { CreateMetadataTestSchema.metadata_xml }
+
+  describe '#metadata' do
+    it 'includes InsertRestrictions annotation for read-only entity sets' do
+      read_only_xml = metadata_xml.split('<EntitySet Name="ReadOnlyMetadata"')[1]
+                                  .split('</EntitySet>')[0]
+      expect(read_only_xml).to include('Term="Capabilities.InsertRestrictions"')
+      expect(read_only_xml).to include('Property="Insertable" Bool="false"')
+    end
+
+    it 'does not include InsertRestrictions annotation for writable entity sets' do
+      writable_xml = metadata_xml.split('<EntitySet Name="WritableMetadata"')[1]
+                                 .split('</EntitySet>')[0]
+      expect(writable_xml).not_to include('Capabilities.InsertRestrictions')
+    end
+  end
+end

--- a/spec/odata_duty/entity_set/create/oas2_spec.rb
+++ b/spec/odata_duty/entity_set/create/oas2_spec.rb
@@ -1,0 +1,60 @@
+require 'spec_helper'
+
+class CreatableCollectionResolver < OdataDuty::SetResolver
+  def collection
+    []
+  end
+
+  def create(params)
+    params
+  end
+end
+
+class ReadOnlyCollectionResolver < OdataDuty::SetResolver
+  def collection
+    []
+  end
+end
+
+RSpec.describe OdataDuty::EntitySet, 'gates $oas2 post on create support' do
+  let(:oas2_schema) do
+    OdataDuty::SchemaBuilder.build(namespace: 'SampleSpace', host: 'localhost',
+                                   base_path: '/api') do |s|
+      entity = s.add_entity_type(name: 'CreateOas2TestEntity') do |et|
+        et.property_ref 'id', String
+        et.property 'name', String
+      end
+
+      s.add_entity_set(name: 'CreatableCollection', entity_type: entity,
+                       resolver: 'CreatableCollectionResolver')
+      s.add_entity_set(name: 'ReadOnlyCollection', entity_type: entity,
+                       resolver: 'ReadOnlyCollectionResolver')
+    end
+  end
+
+  let(:json) { OdataDuty::OAS2.build_json(oas2_schema, context: Context.new) }
+
+  describe '/CreatableCollection' do
+    let(:path) { json['paths']['/CreatableCollection'] }
+
+    it 'includes a post operation when create is supported' do
+      expect(path).to have_key('post')
+    end
+
+    it 'uses a Create operationId for the post operation' do
+      expect(path['post']['operationId']).to start_with('Create')
+    end
+  end
+
+  describe '/ReadOnlyCollection' do
+    let(:path) { json['paths']['/ReadOnlyCollection'] }
+
+    it 'includes a get operation' do
+      expect(path).to have_key('get')
+    end
+
+    it 'does not include a post operation when create is not supported' do
+      expect(path).not_to have_key('post')
+    end
+  end
+end

--- a/spec/odata_duty/entity_set/search_spec.rb
+++ b/spec/odata_duty/entity_set/search_spec.rb
@@ -521,12 +521,12 @@ RSpec.describe OdataDuty::EntitySet, 'Can search through collection results' do
         expect(names).to contain_exactly('John Doe', 'Jane Smith')
       end
 
-      it 'raises error for entity set that does not support search' do
+      it 'raises Unknown tool for entity set that does not support search' do
         request_payload['params']['name'] = 'search_SearchlessCollection'
 
         expect do
           mcp_server.handle_jsonrpc(request_payload, context: Context.new)
-        end.to raise_error(OdataDuty::NoImplementationError)
+        end.to raise_error(/Unknown tool/)
       end
 
       it 'raises error for unknown tool' do

--- a/spec/odata_duty/schema_builder/entity_set/create/mcp_spec.rb
+++ b/spec/odata_duty/schema_builder/entity_set/create/mcp_spec.rb
@@ -74,6 +74,14 @@ module OdataDuty
           schema.handle_jsonrpc(request_payload, context: Context.new)
         end.to raise_error(/Unknown tool/)
       end
+
+      it 'raises Unknown tool for a search tool on an unknown set' do
+        request_payload['params']['name'] = 'search_Unknown'
+
+        expect do
+          schema.handle_jsonrpc(request_payload, context: Context.new)
+        end.to raise_error(/Unknown tool/)
+      end
     end
   end
 end

--- a/spec/odata_duty/schema_builder/entity_set/create/mcp_spec.rb
+++ b/spec/odata_duty/schema_builder/entity_set/create/mcp_spec.rb
@@ -1,0 +1,79 @@
+require 'spec_helper'
+
+class CreateMcpWidgetResolver < OdataDuty::SetResolver
+  def create(params)
+    Struct.new(:id, :name).new('w1', params.name)
+  end
+end
+
+class CreateMcpPersonResolver < OdataDuty::SetResolver
+end
+
+module OdataDuty
+  RSpec.describe SchemaBuilder::EntitySet, 'MCP create tool' do
+    subject(:schema) do
+      SchemaBuilder.build(namespace: 'SampleSpace', host: 'localhost', base_path: '') do |s|
+        entity = s.add_entity_type(name: 'CreateMcpWidgetEntity') do |et|
+          et.property_ref 'id', String
+          et.property 'name', String
+        end
+
+        s.add_entity_set(name: 'Widgets', entity_type: entity,
+                         resolver: 'CreateMcpWidgetResolver')
+        s.add_entity_set(name: 'People', entity_type: entity,
+                         resolver: 'CreateMcpPersonResolver')
+      end
+    end
+
+    describe 'tools/list' do
+      let(:request_payload) do
+        { 'jsonrpc' => '2.0', 'method' => 'tools/list', 'params' => {}, 'id' => 'tl-1' }
+      end
+
+      let(:tools) do
+        Oj.load(schema.handle_jsonrpc(request_payload, context: Context.new))['result']['tools']
+      end
+
+      it 'includes a create tool for entity sets that support create' do
+        expect(tools).to include(
+          'name' => 'create_Widgets',
+          'description' => 'Create a new Widgets record',
+          'inputSchema' => {
+            'type' => 'object',
+            'properties' => {
+              'id' => { 'type' => 'string' },
+              'name' => { 'type' => 'string', 'x-nullable' => true }
+            },
+            'required' => ['id']
+          }
+        )
+      end
+
+      it 'does not include a create tool for read-only entity sets' do
+        expect(tools.map { |t| t['name'] }).not_to include('create_People')
+      end
+    end
+
+    describe 'tools/call for create' do
+      let(:request_payload) do
+        { 'jsonrpc' => '2.0', 'method' => 'tools/call',
+          'params' => { 'name' => 'create_Widgets', 'arguments' => { 'name' => 'Gadget' } },
+          'id' => 'tc-1' }
+      end
+
+      it 'creates the record and returns it as structured JSON' do
+        actual = Oj.load(schema.handle_jsonrpc(request_payload, context: Context.new))
+
+        expect(actual['result']).to include('id' => 'w1', 'name' => 'Gadget')
+      end
+
+      it 'raises Unknown tool for a create tool on a read-only set' do
+        request_payload['params']['name'] = 'create_People'
+
+        expect do
+          schema.handle_jsonrpc(request_payload, context: Context.new)
+        end.to raise_error(/Unknown tool/)
+      end
+    end
+  end
+end

--- a/spec/odata_duty/schema_builder/entity_set/create/metadata_spec.rb
+++ b/spec/odata_duty/schema_builder/entity_set/create/metadata_spec.rb
@@ -1,0 +1,43 @@
+require 'spec_helper'
+
+class WritableMetadataResolver < OdataDuty::SetResolver
+  def create(params)
+    params
+  end
+end
+
+class ReadOnlyMetadataResolver < OdataDuty::SetResolver
+end
+
+module OdataDuty
+  RSpec.describe SchemaBuilder::EntitySet, 'InsertRestrictions metadata' do
+    subject(:metadata_xml) do
+      SchemaBuilder.build(namespace: 'SampleSpace', host: 'localhost', base_path: '/api') do |s|
+        entity = s.add_entity_type(name: 'CreateMetadataTestEntity') do |et|
+          et.property_ref 'id', String
+          et.property 'name', String
+        end
+
+        s.add_entity_set(name: 'WritableMetadata', entity_type: entity,
+                         resolver: 'WritableMetadataResolver')
+        s.add_entity_set(name: 'ReadOnlyMetadata', entity_type: entity,
+                         resolver: 'ReadOnlyMetadataResolver')
+      end.metadata_xml
+    end
+
+    describe '#metadata' do
+      it 'includes InsertRestrictions annotation for read-only entity sets' do
+        read_only_xml = metadata_xml.split('<EntitySet Name="ReadOnlyMetadata"')[1]
+                                    .split('</EntitySet>')[0]
+        expect(read_only_xml).to include('Term="Capabilities.InsertRestrictions"')
+        expect(read_only_xml).to include('Property="Insertable" Bool="false"')
+      end
+
+      it 'does not include InsertRestrictions annotation for writable entity sets' do
+        writable_xml = metadata_xml.split('<EntitySet Name="WritableMetadata"')[1]
+                                   .split('</EntitySet>')[0]
+        expect(writable_xml).not_to include('Capabilities.InsertRestrictions')
+      end
+    end
+  end
+end

--- a/spec/odata_duty/schema_builder/entity_set/create/oas2_spec.rb
+++ b/spec/odata_duty/schema_builder/entity_set/create/oas2_spec.rb
@@ -1,0 +1,60 @@
+require 'spec_helper'
+
+class CreatableBuilderCollectionResolver < OdataDuty::SetResolver
+  def collection
+    []
+  end
+
+  def create(params)
+    params
+  end
+end
+
+class ReadOnlyBuilderCollectionResolver < OdataDuty::SetResolver
+  def collection
+    []
+  end
+end
+
+RSpec.describe OdataDuty::SchemaBuilder, 'gates $oas2 post on create support' do
+  let(:oas2_schema) do
+    OdataDuty::SchemaBuilder.build(namespace: 'SampleSpace', host: 'localhost',
+                                   base_path: '/api') do |s|
+      entity = s.add_entity_type(name: 'CreateOas2BuilderTestEntity') do |et|
+        et.property_ref 'id', String
+        et.property 'name', String
+      end
+
+      s.add_entity_set(name: 'CreatableBuilderCollection', entity_type: entity,
+                       resolver: 'CreatableBuilderCollectionResolver')
+      s.add_entity_set(name: 'ReadOnlyBuilderCollection', entity_type: entity,
+                       resolver: 'ReadOnlyBuilderCollectionResolver')
+    end
+  end
+
+  let(:json) { OdataDuty::OAS2.build_json(oas2_schema, context: Context.new) }
+
+  describe '/CreatableBuilderCollection' do
+    let(:path) { json['paths']['/CreatableBuilderCollection'] }
+
+    it 'includes a post operation when create is supported' do
+      expect(path).to have_key('post')
+    end
+
+    it 'uses a Create operationId for the post operation' do
+      expect(path['post']['operationId']).to start_with('Create')
+    end
+  end
+
+  describe '/ReadOnlyBuilderCollection' do
+    let(:path) { json['paths']['/ReadOnlyBuilderCollection'] }
+
+    it 'includes a get operation' do
+      expect(path).to have_key('get')
+    end
+
+    it 'does not include a post operation when create is not supported' do
+      expect(path).not_to have_key('post')
+    end
+  end
+end

--- a/spec/odata_duty/schema_builder/entity_set/search_spec.rb
+++ b/spec/odata_duty/schema_builder/entity_set/search_spec.rb
@@ -402,12 +402,12 @@ module OdataDuty
           expect(names).to contain_exactly('Alice Brown', 'Bob Smith')
         end
 
-        it 'raises error for entity set that does not support search' do
+        it 'raises Unknown tool for entity set that does not support search' do
           request_payload['params']['name'] = 'search_SearchlessCollection'
 
           expect do
             mcp_server.handle_jsonrpc(request_payload, context: Context.new)
-          end.to raise_error(OdataDuty::NoImplementationError)
+          end.to raise_error(/Unknown tool/)
         end
 
         it 'raises error for unknown tool' do

--- a/spec/odata_duty/schema_builder_spec.rb
+++ b/spec/odata_duty/schema_builder_spec.rb
@@ -32,6 +32,17 @@ class PeopleResolver < OdataDuty::SetResolver
   def individual(id)
     @records.find { |record| record.id == id }
   end
+
+  def create(params)
+    address_info = params.address_info.map do |address|
+      AddressInfo.new(address.address,
+                      CountryCity.new(address.city.country_region,
+                                      address.city.name,
+                                      address.city.region))
+    end
+    Person.new('111', params.user_name, params.name, params.emails, address_info, params.gender,
+               params.concurrency)
+  end
 end
 
 module OdataDuty


### PR DESCRIPTION
Adds a doc/using_create.md guide in the house style explaining that
implementing `create` makes an entity set writable while omitting it
keeps the set read-only, and how that single choice is reflected across
$oas2 (post present vs omitted, operationId Create&lt;Set&gt;), $metadata
(Capabilities.InsertRestrictions Insertable="false" for read-only sets),
and MCP (create_&lt;Set&gt; tool present vs absent, tools/call behavior).
Covers both the builder-DSL resolver and class-DSL entity-set forms and
ends with a Common Error Cases section. Cross-links the guide from the
README's create example and Further Documentation list.

PRD: doc/prds/task-tgp397bx3mf8G8YLJi.md