### PR TITLE
Document computed (read-only) properties (PRD task 5)

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -11,6 +11,8 @@ AllCops:
 
 Metrics/AbcSize:
   Max: 30
+Metrics/ParameterLists:
+  CountKeywordArgs: false
 Metrics/ClassLength:
   Max: 99
 Metrics/ModuleLength:

--- a/README.md
+++ b/README.md
@@ -239,6 +239,7 @@ end
 - [Using `$select`](doc/using_select.md)
 - [Using `$search`](doc/using_search.md)
 - [Using `create`](doc/using_create.md)
+- [Using `computed` (read-only) properties](doc/using_computed.md)
 
 > **Documentation convention:** Every externally-facing feature (a new DSL option,
 > query option, or protocol surface) ships with a `doc/using_*.md` guide and a link

--- a/doc/prds/task-th2tnp4qjxbGEoiNs2-plan.md
+++ b/doc/prds/task-th2tnp4qjxbGEoiNs2-plan.md
@@ -51,7 +51,7 @@ input schema consumes `property.to_oas2`).
     `required`.
   - Depends on: Task 1.
 
-- [ ] **Task 3 — `$metadata` Core.Computed annotation + vocabulary reference.**
+- [x] **Task 3 — `$metadata` Core.Computed annotation + vocabulary reference.**
   Render `<Annotation Term="Org.OData.Core.V1.Computed" Bool="true" />` inside each computed
   `<Property>` (entity and complex), and add the `edmx:Reference` for the
   `Org.OData.Core.V1` vocabulary (Alias `Core`), mirroring the existing Capabilities reference.

--- a/doc/prds/task-th2tnp4qjxbGEoiNs2-plan.md
+++ b/doc/prds/task-th2tnp4qjxbGEoiNs2-plan.md
@@ -1,0 +1,87 @@
+# Build plan: Computed (read-only) properties
+
+PRD: [task-th2tnp4qjxbGEoiNs2.md](./task-th2tnp4qjxbGEoiNs2.md)
+
+Adds a `computed: true` option to the `property` DSL marking a property as server-generated /
+read-only. Computed properties stay in every *read* contract (GET, `$metadata`, OAS2 entity
+definition) but are removed from every *create-input* contract (typed `create` input object, MCP
+`create_<Set>` tool, OAS2 `readOnly`). `property_ref` defaults to `computed: true`.
+
+## Key ripple (every implementer must know)
+
+`property_ref` now defaults to `computed: true`. That means **every existing entity key** becomes
+read-only: `input.id` returns `nil` on create, the key gains a `Core.Computed` annotation in
+`$metadata`, `readOnly: true` in OAS2, and is excluded from the MCP create tool. **Many existing
+specs across both `spec/odata_duty/entity_set/**` and `spec/odata_duty/schema_builder/**` will need
+updated expectations.** Where an existing test genuinely relies on a *client-supplied* key, opt it
+back in with `property_ref 'id', String, computed: false` (this also exercises the opt-out). Each
+task must finish on a fully green `bundle exec rake`.
+
+Task order is chosen so each task's output change owns its own spec ripple and no task leaves a
+transient breakage (notably MCP exclusion lands before the OAS2 `readOnly` change, since MCP's
+input schema consumes `property.to_oas2`).
+
+## Tasks
+
+- [ ] **Task 1 — DSL `computed:` flag + create-input exclusion.**
+  Add a `computed:` keyword (default `false`) to property definition in both DSLs and store it on
+  the shared `Property` representation with a `computed?` predicate. Make `property_ref` default to
+  `computed: true` (overridable via `computed: false`) in both DSLs. In the create-input wrapper,
+  a computed property is silently ignored: `input.<computed_prop>` returns `nil` regardless of the
+  body — no coercion, no `InvalidType`, no error. `respond_to?` for the property stays `true`.
+  - Files: `lib/odata_duty/property.rb`, `lib/odata_duty/property/single_prop.rb`,
+    `lib/odata_duty/entity_type.rb`, `lib/odata_duty/complex_type.rb`,
+    `lib/odata_duty/schema_builder/entity_type.rb`, `lib/odata_duty/schema_builder/complex_type.rb`,
+    `lib/odata_duty/create_complex_type_hash_wrapper.rb`.
+  - Specs (both trees): `spec/odata_duty/entity_set/create/with_scalars_spec.rb`,
+    `.../create/with_complex_spec.rb`, and schema_builder equivalents; update any create spec that
+    relied on a client-supplied key.
+  - PRD excerpt: "`computed: true` marks a property read-only … removed from the *create input*
+    surface … A client value supplied for a computed property is **silently ignored** — no error —
+    and `input.<computed_prop>` inside `create` returns `nil`." `property_ref` defaults
+    `computed: true`; `property_ref 'id', String, computed: false` opts back in.
+  - Depends on: none.
+
+- [ ] **Task 2 — MCP `create_<Set>` tool excludes computed properties.**
+  In `create_input_schema`, exclude computed properties from both `properties` and `required`.
+  - Files: `lib/odata_duty/mcp_server_builder.rb`.
+  - Specs (both trees): `spec/odata_duty/entity_set/create/mcp_spec.rb`, schema_builder equivalent.
+  - PRD excerpt: MCP `tools/list` — `inputSchema.properties` omits `id`/`created_at`; `required` is
+    `["user_name"]` (was `["id", "user_name"]`). Computed properties absent from `properties` and
+    `required`.
+  - Depends on: Task 1.
+
+- [ ] **Task 3 — `$metadata` Core.Computed annotation + vocabulary reference.**
+  Render `<Annotation Term="Org.OData.Core.V1.Computed" Bool="true" />` inside each computed
+  `<Property>` (entity and complex), and add the `edmx:Reference` for the
+  `Org.OData.Core.V1` vocabulary (Alias `Core`), mirroring the existing Capabilities reference.
+  - Files: `lib/metadata.xml.erb` (+ a `computed?` accessor on the metadata-side property if needed).
+  - Specs (both trees): `spec/odata_duty/entity_set/create/metadata_spec.rb`, schema_builder
+    equivalent, plus any metadata spec asserting key/property XML.
+  - PRD excerpt: the `edmx:Reference` for `Org.OData.Core.V1.xml` with `Include Namespace=
+    "Org.OData.Core.V1" Alias="Core"`, and `<Annotation Term="Org.OData.Core.V1.Computed"
+    Bool="true" />` on `created_at` and on the `id` key property.
+  - Depends on: Task 1.
+
+- [ ] **Task 4 — `$oas2` `readOnly: true` on computed properties.**
+  Add `'readOnly' => true` to a computed property's OAS2 representation so the shared entity
+  definition (used by GET responses and the POST `$ref`) marks it read-only. POST body keeps
+  referencing `#/definitions/<Entity>`.
+  - Files: `lib/odata_duty/property/single_prop.rb` (`to_oas2`).
+  - Specs (both trees): `spec/odata_duty/entity_set/create/oas2_spec.rb`, schema_builder
+    equivalent, plus any OAS2 spec asserting entity definitions.
+  - PRD excerpt: definitions show `"id": { "type": "string", "readOnly": true }` and
+    `"created_at": { "type": "string", "format": "date-time", "readOnly": true, "x-nullable": true }`.
+  - Depends on: Tasks 1–2 (MCP exclusion must land first so `to_oas2` readOnly does not leak into
+    the MCP create input schema).
+
+- [ ] **Task 5 — Documentation.**
+  New guide `doc/using_computed.md` modeled on `doc/using_create.md` (purpose → both DSLs →
+  reflected contracts: GET, `$metadata`, `$oas2`, MCP → common errors), linked from the README's
+  "Further Documentation". State the broader convention: the gem adopts OData Core vocabulary
+  keyword names where practical.
+  - Files: `doc/using_computed.md`, `README.md`.
+  - PRD excerpt: "New guide `doc/using_computed.md`, modeled on `doc/using_create.md` … linked from
+    README's 'Further Documentation'. It should also state the broader convention: the gem adopts
+    OData Core vocabulary keyword names where practical."
+  - Depends on: Tasks 1–4.

--- a/doc/prds/task-th2tnp4qjxbGEoiNs2-plan.md
+++ b/doc/prds/task-th2tnp4qjxbGEoiNs2-plan.md
@@ -42,7 +42,7 @@ input schema consumes `property.to_oas2`).
     `computed: true`; `property_ref 'id', String, computed: false` opts back in.
   - Depends on: none.
 
-- [ ] **Task 2 — MCP `create_<Set>` tool excludes computed properties.**
+- [x] **Task 2 — MCP `create_<Set>` tool excludes computed properties.**
   In `create_input_schema`, exclude computed properties from both `properties` and `required`.
   - Files: `lib/odata_duty/mcp_server_builder.rb`.
   - Specs (both trees): `spec/odata_duty/entity_set/create/mcp_spec.rb`, schema_builder equivalent.

--- a/doc/prds/task-th2tnp4qjxbGEoiNs2-plan.md
+++ b/doc/prds/task-th2tnp4qjxbGEoiNs2-plan.md
@@ -63,7 +63,7 @@ input schema consumes `property.to_oas2`).
     Bool="true" />` on `created_at` and on the `id` key property.
   - Depends on: Task 1.
 
-- [ ] **Task 4 — `$oas2` `readOnly: true` on computed properties.**
+- [x] **Task 4 — `$oas2` `readOnly: true` on computed properties.**
   Add `'readOnly' => true` to a computed property's OAS2 representation so the shared entity
   definition (used by GET responses and the POST `$ref`) marks it read-only. POST body keeps
   referencing `#/definitions/<Entity>`.

--- a/doc/prds/task-th2tnp4qjxbGEoiNs2-plan.md
+++ b/doc/prds/task-th2tnp4qjxbGEoiNs2-plan.md
@@ -23,7 +23,7 @@ input schema consumes `property.to_oas2`).
 
 ## Tasks
 
-- [ ] **Task 1 — DSL `computed:` flag + create-input exclusion.**
+- [x] **Task 1 — DSL `computed:` flag + create-input exclusion.**
   Add a `computed:` keyword (default `false`) to property definition in both DSLs and store it on
   the shared `Property` representation with a `computed?` predicate. Make `property_ref` default to
   `computed: true` (overridable via `computed: false`) in both DSLs. In the create-input wrapper,

--- a/doc/prds/task-th2tnp4qjxbGEoiNs2-plan.md
+++ b/doc/prds/task-th2tnp4qjxbGEoiNs2-plan.md
@@ -75,7 +75,7 @@ input schema consumes `property.to_oas2`).
   - Depends on: Tasks 1–2 (MCP exclusion must land first so `to_oas2` readOnly does not leak into
     the MCP create input schema).
 
-- [ ] **Task 5 — Documentation.**
+- [x] **Task 5 — Documentation.**
   New guide `doc/using_computed.md` modeled on `doc/using_create.md` (purpose → both DSLs →
   reflected contracts: GET, `$metadata`, `$oas2`, MCP → common errors), linked from the README's
   "Further Documentation". State the broader convention: the gem adopts OData Core vocabulary

--- a/doc/prds/task-th2tnp4qjxbGEoiNs2.md
+++ b/doc/prds/task-th2tnp4qjxbGEoiNs2.md
@@ -1,0 +1,149 @@
+# PRD: Computed (read-only) properties
+
+## Summary
+Add a `computed: true` option to the `property` DSL so a gem consumer can mark a property as
+server-generated / read-only. Computed properties still appear in GET responses, `$metadata`, and
+the entity's OAS2 definition, but are excluded from the create-input contract (OAS2 POST body, MCP
+`create_<Set>` tool, and the typed `create` input object). This follows OData's
+`Org.OData.Core.V1.Computed` term; the gem documents that it adopts OData Core vocabulary keyword
+names where practical.
+
+## Goal / Problem
+Today every property is implicitly writable on create. The framework's `create` input wrapper
+accepts a value for *any* declared property, the OAS2 `POST` body references the full entity
+definition, and the MCP `create_<Set>` tool lists *all* properties (with non-nullable ones marked
+`required`). There is no way to express "this value is assigned by the server, not the client" —
+e.g. an `id`, `created_at`, or a derived/virtual field. Consumers are forced to document such
+fields out-of-band, and tools (PowerBI, PowerAutomate, LLMs via MCP) wrongly prompt for them on
+create.
+
+**Expected:** A consumer declares a property `computed: true` and that single declaration removes
+it from every create-input contract while keeping it in every read contract.
+
+## What it enables
+- As a gem consumer, I can mark `property 'created_at', DateTime, computed: true` so clients see it
+  in responses but are never asked to supply it on create.
+- As a gem consumer, I get the entity key (`property_ref`) treated as server-assigned **by
+  default**, matching common OData practice — no extra flag needed.
+- As a gem consumer, I can opt a key back into client-supplied creates with
+  `property_ref 'id', String, computed: false`.
+- The distinction propagates automatically to `$metadata` (Core.Computed annotation), `$oas2`
+  (`readOnly: true`), and MCP (excluded from the create tool input schema) — define once, reflected
+  everywhere.
+
+Scope limit: this controls **create** input only (the gem has no update/PATCH today). The term is
+forward-compatible with a future update path.
+
+## External API
+
+A new keyword `computed:` (default `false`) on `property`. `property_ref` defaults to
+`computed: true`.
+
+### Class DSL (`OdataDuty::EntityType`)
+```ruby
+class PersonEntity < OdataDuty::EntityType
+  property_ref 'id', String                      # computed (read-only) by default
+  property 'user_name', String, nullable: false  # writable
+  property 'name', String                         # writable
+  property 'created_at', DateTime, computed: true # read-only, server-assigned
+end
+```
+
+### Builder DSL (`OdataDuty::SchemaBuilder`)
+```ruby
+s.add_entity_type(name: 'Person') do |et|
+  et.property_ref 'id', String                       # computed by default
+  et.property 'user_name', String, nullable: false
+  et.property 'created_at', DateTime, computed: true
+end
+```
+
+**Contract:** `computed: true` marks a property read-only. It is still rendered by the entity mapper
+in `collection`/`individual`/`create` *responses*. It is removed from the *create input* surface:
+the OAS2 POST schema, the MCP `create_<Set>` `inputSchema`, and the typed input object. A client
+value supplied for a computed property is **silently ignored** — no error — and
+`input.<computed_prop>` inside `create` returns `nil` regardless of what the body contained.
+
+## Behavior & expected I/O
+
+**GET (unchanged):** computed properties render normally.
+```jsonc
+{ "@odata.id": "...People('1')", "id": "1", "user_name": "alice",
+  "name": "Alice", "created_at": "2026-06-23T10:00:00Z" }
+```
+
+**`$metadata` (EDMX):** a computed property carries the Core annotation; the document gains a `Core`
+vocabulary reference.
+```xml
+<edmx:Reference Uri=".../Org.OData.Core.V1.xml">
+  <edmx:Include Namespace="Org.OData.Core.V1" Alias="Core" />
+</edmx:Reference>
+...
+<Property Name="created_at" Nullable="true" Type="Edm.DateTimeOffset">
+  <Annotation Term="Org.OData.Core.V1.Computed" Bool="true" />
+</Property>
+<Property Name="id" Nullable="false" Type="Edm.String">
+  <Annotation Term="Org.OData.Core.V1.Computed" Bool="true" />
+</Property>
+```
+
+**`$oas2`:** the entity definition marks computed properties `readOnly: true` (Swagger 2.0: may
+appear in responses, MUST NOT be sent in requests). The `POST` body keeps referencing the same
+`#/definitions/Person`, so the flag alone drives create-input exclusion.
+```jsonc
+"definitions": {
+  "Person": {
+    "type": "object",
+    "properties": {
+      "id":         { "type": "string", "readOnly": true },
+      "user_name":  { "type": "string" },
+      "name":       { "type": "string", "x-nullable": true },
+      "created_at": { "type": "string", "format": "date-time", "readOnly": true, "x-nullable": true }
+    }
+  }
+}
+```
+
+**MCP `tools/list` (writable set):** computed properties are absent from `properties` and from
+`required`.
+```jsonc
+{ "name": "create_People", "description": "Create a new People record",
+  "inputSchema": {
+    "type": "object",
+    "properties": {
+      "user_name": { "type": "string" },
+      "name":      { "type": "string", "x-nullable": true }
+    },
+    "required": ["user_name"] } }
+```
+Before this change, `inputSchema.properties` also included `id` and `created_at`, and `required` was
+`["id", "user_name"]`.
+
+**Create (POST / MCP `create_People`):** a body of
+`{ "id": "999", "user_name": "alice", "created_at": "..." }` ignores `id` and `created_at`;
+`input.user_name` is `"alice"`, `input.id` is `nil`.
+
+## Common error cases
+- **Computed value supplied on create:** silently dropped — **no** error raised (notably, no
+  `InvalidType` even if the supplied value is the wrong type, since the value is never coerced).
+- **`computed:` given a non-boolean:** treated truthily like other boolean flags (`nullable:`),
+  consistent with existing DSL behavior; no new error.
+- All existing create errors are unchanged: wrong-typed *writable* values still raise
+  `OdataDuty::InvalidType`; `POST` to a set without `create` still raises
+  `OdataDuty::NoImplementationError`.
+
+## Scope
+- **In:** class-based DSL and builder DSL `property`/`property_ref`; `$metadata`, `$oas2`, and MCP
+  create-tool outputs; the typed `create` input object.
+- **Out:** update/PATCH semantics (none exist yet); per-operation granularity beyond create
+  (`Core.Immutable`, `Core.Permissions`); `$select`/`$filter` behavior (computed properties remain
+  fully selectable and filterable).
+
+## Documentation impact
+New guide `doc/using_computed.md`, modeled on `doc/using_create.md` (purpose → both DSLs → reflected
+contracts → common errors), linked from README's "Further Documentation". It should also state the
+broader convention: the gem adopts OData Core vocabulary keyword names where practical.
+
+## Open questions
+- Should `input.<computed_prop>` raise instead of returning `nil`? Draft assumes `nil` so existing
+  `create` bodies that reference the key won't break.

--- a/doc/using_computed.md
+++ b/doc/using_computed.md
@@ -1,0 +1,151 @@
+# Using `computed` (read-only) properties with OdataDuty
+
+A **computed** property is one the server generates — an auto-incrementing key, a `created_at` timestamp, a derived field. It still appears in every read response, but clients must not (and cannot) set it when creating a record. OdataDuty marks such a property with the `computed:` keyword on `property`. A computed property renders normally in `GET`/`collection`/`individual`/`create` responses but is excluded from the **create input** surface across all three contracts.
+
+This guide explains how to declare a computed property in both DSLs and how the read-only distinction is reflected in the generated `$metadata`, `$oas2`, MCP, and the typed `create` input.
+
+> **Scope:** `computed:` controls the **create input** only — there is no update/PATCH path yet. The term mirrors the OData `Org.OData.Core.V1.Computed` vocabulary annotation and is forward-compatible with a future update path.
+
+## Overview
+
+- **Purpose:** Mark a property server-generated / read-only so clients can read it but never supply it on create.
+- **Declaration:** `property 'created_at', DateTime, computed: true`. The keyword defaults to `false` (writable).
+- **Keys are computed by default:** `property_ref` defaults to `computed: true` (a server-assigned key). Opt back in with `property_ref 'id', String, computed: false`.
+- **Read responses unchanged:** A computed property is rendered in `collection`, `individual`, and the `create` response exactly like any other property.
+- **Excluded from create input:** It is absent from the MCP `create_<Set>` tool's `inputSchema`, carries `readOnly: true` in `$oas2`, and the typed `create` input object returns `nil` for it regardless of the request body.
+- **Convention:** OdataDuty adopts OData Core vocabulary keyword names where practical — `computed:` mirrors `Org.OData.Core.V1.Computed`.
+
+## Declaring a computed property
+
+Both DSLs take the same `computed:` keyword.
+
+### Class DSL (`OdataDuty::EntityType`)
+
+```ruby
+class PersonEntity < OdataDuty::EntityType
+  property_ref 'id', String                          # key: computed: true by default
+  property 'user_name', String, nullable: false      # writable
+  property 'created_at', DateTime, computed: true     # read-only, server-assigned
+end
+```
+
+To make the key writable (client-supplied) instead, opt back in explicitly:
+
+```ruby
+property_ref 'id', String, computed: false
+```
+
+### Builder DSL (`OdataDuty::SchemaBuilder`)
+
+The builder DSL behaves identically:
+
+```ruby
+person_entity = s.add_entity_type(name: 'Person') do |et|
+  et.property_ref 'id', String                        # key: computed: true by default
+  et.property 'user_name', String, nullable: false    # writable
+  et.property 'created_at', DateTime, computed: true   # read-only, server-assigned
+end
+```
+
+## The typed `create` input drops computed values
+
+On `POST` (or the MCP `create_<Set>` tool), the request body is coerced into a typed input object and passed to your `create`. Computed properties are stripped from that object: reading one returns `nil` no matter what the body contained, and a wrong-typed computed value is dropped **silently** — no error, not even `OdataDuty::InvalidType`.
+
+Given a request body:
+
+```json
+{ "id": "999", "user_name": "alice", "created_at": "2021-01-01T00:00:00Z" }
+```
+
+inside `create`:
+
+```ruby
+def create(input)
+  input.user_name   # => "alice"   (writable, coerced normally)
+  input.id          # => nil        (computed key, ignored)
+  input.created_at  # => nil        (computed, ignored)
+  # ... assign id / created_at on the server, persist, and return the record
+end
+```
+
+Both the supplied `id` and `created_at` are ignored; only `user_name` flows through. The record your `create` returns is rendered through the entity type's mapper, so the response **does** include the server-assigned `id` and `created_at`.
+
+## Reflected in the generated contracts
+
+### Read responses (`GET`, `create` response) — unchanged
+
+Computed properties render in `collection`, `individual`, and the `create` response exactly like writable ones. Marking a property `computed:` changes nothing about what is read back.
+
+### `$metadata` (EDMX)
+
+A computed `<Property>` carries the `Org.OData.Core.V1.Computed` annotation:
+
+```xml
+<Property Name="created_at" Nullable="true" Type="Edm.DateTimeOffset">
+    <Annotation Term="Org.OData.Core.V1.Computed" Bool="true" />
+</Property>
+```
+
+A writable property gets no such annotation. Because the key is computed by default, its `<Property>` carries the same annotation unless declared `computed: false`.
+
+The document references the `Org.OData.Core.V1` vocabulary (aliased `Core`) at the top:
+
+```xml
+<edmx:Reference Uri="https://docs.oasis-open.org/odata/odata-vocabularies/v4.0/vocabularies/Org.OData.Core.V1.xml">
+    <edmx:Include Namespace="Org.OData.Core.V1" Alias="Core" />
+</edmx:Reference>
+```
+
+### `$oas2`
+
+A computed property is marked `readOnly: true` in the shared entity definition:
+
+```jsonc
+{
+  "definitions": {
+    "Person": {
+      "properties": {
+        "id":         { "type": "string", "readOnly": true },
+        "user_name":  { "type": "string" },
+        "created_at": { "type": "string", "format": "date-time", "readOnly": true, "x-nullable": true }
+      }
+    }
+  }
+}
+```
+
+The `post` body still references the shared `#/definitions/Person`; `readOnly: true` is the OAS2 signal that the field is response-only.
+
+### MCP
+
+The `create_<Set>` tool's `inputSchema` lists only writable properties — computed ones are absent from both `properties` and `required`:
+
+```jsonc
+// tools/list result for a set with a computed `id` and `created_at`
+{
+  "name": "create_Person",
+  "description": "Create a new Person record",
+  "inputSchema": {
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "type": "object",
+    "properties": {
+      "user_name": { "type": "string" }
+    },
+    "required": ["user_name"]
+  }
+}
+```
+
+`id` and `created_at` never appear in the create tool's input, so an agent cannot supply them.
+
+## Common errors / edge cases
+
+- **A computed value supplied on create is silently dropped.** Whether well-typed or wrong-typed, a computed value in the request body is ignored — no error is raised, and there is no `OdataDuty::InvalidType` even for a value that would fail coercion for a writable property. The typed input reads it back as `nil`.
+- **`property_ref` is computed by default.** A key is server-assigned unless you declare `property_ref 'id', String, computed: false`. If clients must supply the key, opt out explicitly.
+- **Opt back in with `computed: false`.** This restores a property (including a key) to the writable surface: it reappears in the MCP `create_<Set>` `inputSchema`, drops `readOnly` in `$oas2`, loses the `Core.Computed` annotation in `$metadata`, and is coerced onto the typed `create` input.
+
+## Summary
+
+- **Mark a property read-only** with `property 'created_at', DateTime, computed: true` (default `false`); keys (`property_ref`) are computed by default — opt out with `computed: false`.
+- **Computed properties render normally** in every read response but are dropped from the create input: absent from the MCP `create_<Set>` `inputSchema`, `readOnly: true` in `$oas2`, annotated `Org.OData.Core.V1.Computed` in `$metadata`, and `nil` on the typed `create` input.
+- **Supplying a computed value on create is a silent no-op** — never an error, even for a wrong-typed value.

--- a/doc/using_computed.md
+++ b/doc/using_computed.md
@@ -1,6 +1,6 @@
 # Using `computed` (read-only) properties with OdataDuty
 
-A **computed** property is one the server generates — an auto-incrementing key, a `created_at` timestamp, a derived field. It still appears in every read response, but clients must not (and cannot) set it when creating a record. OdataDuty marks such a property with the `computed:` keyword on `property`. A computed property renders normally in `GET`/`collection`/`individual`/`create` responses but is excluded from the **create input** surface across all three contracts.
+A **computed** property is one that the server generates — an auto-incrementing key, a `created_at` timestamp, a derived field. It still appears in every read response, but clients must not (and cannot) set it when creating a record. OdataDuty marks such a property with the `computed:` keyword on `property`. A computed property renders normally in `GET`/`collection`/`individual`/`create` responses but is excluded from the **create input** surface across all three contracts.
 
 This guide explains how to declare a computed property in both DSLs and how the read-only distinction is reflected in the generated `$metadata`, `$oas2`, MCP, and the typed `create` input.
 

--- a/lib/metadata.xml.erb
+++ b/lib/metadata.xml.erb
@@ -21,9 +21,13 @@
             <% metadata.complex_types.each do |complex_type| %>
                 <ComplexType Name="<%= complex_type.name %>">
                     <% complex_type.properties.each do |property| %>
-                        <Property Name="<%= property.name %>" Nullable="<%= property.nullable %>" Type="<%= property.collection? ? "Collection(" : "" %><%= property.type.include?(".") ? "" : "#{metadata.namespace}." %><%= property.type %><%= property.collection? ? ")" : "" %>"<% if property.computed? %>>
-                            <Annotation Term="Org.OData.Core.V1.Computed" Bool="true" />
-                        </Property><% else %> /><% end %>
+                        <% if property.computed? %>
+                            <Property Name="<%= property.name %>" Nullable="<%= property.nullable %>" Type="<%= property.collection? ? "Collection(" : "" %><%= property.type.include?(".") ? "" : "#{metadata.namespace}." %><%= property.type %><%= property.collection? ? ")" : "" %>">
+                                <Annotation Term="Org.OData.Core.V1.Computed" Bool="true" />
+                            </Property>
+                        <% else %>
+                            <Property Name="<%= property.name %>" Nullable="<%= property.nullable %>" Type="<%= property.collection? ? "Collection(" : "" %><%= property.type.include?(".") ? "" : "#{metadata.namespace}." %><%= property.type %><%= property.collection? ? ")" : "" %>" />
+                        <% end %>
                     <% end %>
                 </ComplexType>
             <% end %>
@@ -35,9 +39,13 @@
                         <% end %>
                     </Key>
                     <% entity_type.properties.each do |property| %>
-                        <Property Name="<%= property.name %>" Nullable="<%= property.nullable %>" Type="<%= property.collection? ? "Collection(" : "" %><%= property.type.include?(".") ? "" : "#{metadata.namespace}." %><%= property.type %><%= property.collection? ? ")" : "" %>"<% if property.computed? %>>
-                            <Annotation Term="Org.OData.Core.V1.Computed" Bool="true" />
-                        </Property><% else %> /><% end %>
+                        <% if property.computed? %>
+                            <Property Name="<%= property.name %>" Nullable="<%= property.nullable %>" Type="<%= property.collection? ? "Collection(" : "" %><%= property.type.include?(".") ? "" : "#{metadata.namespace}." %><%= property.type %><%= property.collection? ? ")" : "" %>">
+                                <Annotation Term="Org.OData.Core.V1.Computed" Bool="true" />
+                            </Property>
+                        <% else %>
+                            <Property Name="<%= property.name %>" Nullable="<%= property.nullable %>" Type="<%= property.collection? ? "Collection(" : "" %><%= property.type.include?(".") ? "" : "#{metadata.namespace}." %><%= property.type %><%= property.collection? ? ")" : "" %>" />
+                        <% end %>
                     <% end %>
                 </EntityType>
             <% end %>

--- a/lib/metadata.xml.erb
+++ b/lib/metadata.xml.erb
@@ -3,6 +3,9 @@
     <edmx:Reference Uri="https://docs.oasis-open.org/odata/odata-vocabularies/v4.0/vocabularies/Org.OData.Capabilities.V1.xml">
         <edmx:Include Namespace="Org.OData.Capabilities.V1" Alias="Capabilities" />
     </edmx:Reference>
+    <edmx:Reference Uri="https://docs.oasis-open.org/odata/odata-vocabularies/v4.0/vocabularies/Org.OData.Core.V1.xml">
+        <edmx:Include Namespace="Org.OData.Core.V1" Alias="Core" />
+    </edmx:Reference>
     <edmx:DataServices>
         <Schema Namespace="<%= metadata.namespace %>" xmlns="http://docs.oasis-open.org/odata/ns/edm">
              <% if metadata.version %><Annotation Term="<%= metadata.namespace %>.Version" String="<%= metadata.version %>" /><% end %>
@@ -18,7 +21,9 @@
             <% metadata.complex_types.each do |complex_type| %>
                 <ComplexType Name="<%= complex_type.name %>">
                     <% complex_type.properties.each do |property| %>
-                        <Property Name="<%= property.name %>" Nullable="<%= property.nullable %>" Type="<%= property.collection? ? "Collection(" : "" %><%= property.type.include?(".") ? "" : "#{metadata.namespace}." %><%= property.type %><%= property.collection? ? ")" : "" %>" />
+                        <Property Name="<%= property.name %>" Nullable="<%= property.nullable %>" Type="<%= property.collection? ? "Collection(" : "" %><%= property.type.include?(".") ? "" : "#{metadata.namespace}." %><%= property.type %><%= property.collection? ? ")" : "" %>"<% if property.computed? %>>
+                            <Annotation Term="Org.OData.Core.V1.Computed" Bool="true" />
+                        </Property><% else %> /><% end %>
                     <% end %>
                 </ComplexType>
             <% end %>
@@ -30,7 +35,9 @@
                         <% end %>
                     </Key>
                     <% entity_type.properties.each do |property| %>
-                        <Property Name="<%= property.name %>" Nullable="<%= property.nullable %>" Type="<%= property.collection? ? "Collection(" : "" %><%= property.type.include?(".") ? "" : "#{metadata.namespace}." %><%= property.type %><%= property.collection? ? ")" : "" %>" />
+                        <Property Name="<%= property.name %>" Nullable="<%= property.nullable %>" Type="<%= property.collection? ? "Collection(" : "" %><%= property.type.include?(".") ? "" : "#{metadata.namespace}." %><%= property.type %><%= property.collection? ? ")" : "" %>"<% if property.computed? %>>
+                            <Annotation Term="Org.OData.Core.V1.Computed" Bool="true" />
+                        </Property><% else %> /><% end %>
                     <% end %>
                 </EntityType>
             <% end %>

--- a/lib/odata_duty/create_complex_type_hash_wrapper.rb
+++ b/lib/odata_duty/create_complex_type_hash_wrapper.rb
@@ -24,6 +24,7 @@ module OdataDuty
     private
 
     def __load(matching_prop, method_name, value)
+      return nil if matching_prop.computed?
       return nil if value.nil?
       return matching_prop.to_value(value, @context) if matching_prop.scalar?
 

--- a/lib/odata_duty/entity_type.rb
+++ b/lib/odata_duty/entity_type.rb
@@ -6,8 +6,8 @@ module OdataDuty
       @property_refs ||= []
     end
 
-    def self.property_ref(*args)
-      property(*args, nullable: false).tap do |property|
+    def self.property_ref(*args, computed: true, **kwargs)
+      property(*args, nullable: false, computed: computed, **kwargs).tap do |property|
         raise 'Multiple Property Reference not yet supported' if property_refs.size.positive?
 
         property_refs << property

--- a/lib/odata_duty/mcp_server_builder.rb
+++ b/lib/odata_duty/mcp_server_builder.rb
@@ -107,8 +107,9 @@ module OdataDuty
     end
 
     def create_input_schema(entity_type)
-      properties = entity_type.properties.to_h { |p| [p.name.to_s, p.to_oas2] }
-      required = entity_type.properties.reject(&:nullable).map { |p| p.name.to_s }
+      writable = entity_type.properties.reject(&:computed?)
+      properties = writable.to_h { |p| [p.name.to_s, p.to_oas2] }
+      required = writable.reject(&:nullable).map { |p| p.name.to_s }
       { 'type' => 'object', 'properties' => properties, 'required' => required }
     end
   end

--- a/lib/odata_duty/property.rb
+++ b/lib/odata_duty/property.rb
@@ -4,7 +4,8 @@ require 'odata_duty/property/collection_prop'
 
 module OdataDuty
   module Property
-    def self.new(name, type = String, line__defined__at: nil, nullable: true, method: nil)
+    def self.new(name, type = String, line__defined__at: nil, nullable: true, method: nil,
+                 computed: false)
       unless valid_name?(name)
         raise InvalidNCNamesError, "\"#{name}\" is not a valid property name"
       end
@@ -13,7 +14,8 @@ module OdataDuty
       prop_class.new(name, type,
                      line__defined__at: line__defined__at,
                      nullable: nullable,
-                     method: method)
+                     method: method,
+                     computed: computed)
     end
 
     def self.valid_name?(name)

--- a/lib/odata_duty/property/single_prop.rb
+++ b/lib/odata_duty/property/single_prop.rb
@@ -2,17 +2,23 @@ module OdataDuty
   module Property
     class SingleProp
       attr_reader :name, :nullable, :calling_method, :line__defined__at, :raw_type, :type,
-                  :set_type, :method_name
+                  :set_type, :method_name, :computed
 
-      def initialize(name, type = String, line__defined__at: nil, nullable: true, method: nil)
+      def initialize(name, type = String, line__defined__at: nil, nullable: true, method: nil,
+                     computed: false)
         @line__defined__at = line__defined__at
         @name = name.to_str.to_sym
         @calling_method = method.respond_to?(:call) ? method : nil
         method = nil if method.respond_to?(:call)
         @method_name = (method || name).to_sym
         @nullable = nullable ? true : false
+        @computed = computed ? true : false
 
         load_type_instance_vars(type)
+      end
+
+      def computed?
+        computed
       end
 
       def calling_method?

--- a/lib/odata_duty/property/single_prop.rb
+++ b/lib/odata_duty/property/single_prop.rb
@@ -88,7 +88,9 @@ module OdataDuty
       end
 
       def to_oas2
-        nullable ? to_oas2_type.merge('x-nullable' => true) : to_oas2_type
+        oas2 = to_oas2_type
+        oas2 = oas2.merge('readOnly' => true) if computed?
+        nullable ? oas2.merge('x-nullable' => true) : oas2
       end
 
       def to_oas2_type

--- a/lib/odata_duty/property/single_prop.rb
+++ b/lib/odata_duty/property/single_prop.rb
@@ -88,9 +88,10 @@ module OdataDuty
       end
 
       def to_oas2
-        oas2 = to_oas2_type
-        oas2 = oas2.merge('readOnly' => true) if computed?
-        nullable ? oas2.merge('x-nullable' => true) : oas2
+        to_oas2_type.dup.tap do |oas2|
+          oas2.merge!('readOnly' => true) if computed?
+          oas2.merge!('x-nullable' => true) if nullable
+        end
       end
 
       def to_oas2_type

--- a/lib/odata_duty/schema_builder/entity_type.rb
+++ b/lib/odata_duty/schema_builder/entity_type.rb
@@ -10,8 +10,8 @@ module OdataDuty
         @property_refs = []
       end
 
-      def property_ref(*args)
-        property(*args, nullable: false).tap do |property|
+      def property_ref(*args, computed: true, **kwargs)
+        property(*args, nullable: false, computed: computed, **kwargs).tap do |property|
           raise 'Multiple Property Reference not yet supported' if property_refs.size.positive?
 
           property_refs << property

--- a/odata_duty.gemspec
+++ b/odata_duty.gemspec
@@ -2,7 +2,7 @@
 
 Gem::Specification.new do |spec|
   spec.name          = 'odata_duty'
-  spec.version       = '0.17.0'
+  spec.version       = '0.18.0'
   spec.authors       = ['Grant Petersen-Speelman']
   spec.email         = ['grant@nexl.io']
 

--- a/spec/metadata.xml
+++ b/spec/metadata.xml
@@ -4,6 +4,9 @@
     <edmx:Reference Uri="https://docs.oasis-open.org/odata/odata-vocabularies/v4.0/vocabularies/Org.OData.Capabilities.V1.xml">
         <edmx:Include Namespace="Org.OData.Capabilities.V1" Alias="Capabilities" />
     </edmx:Reference>
+    <edmx:Reference Uri="https://docs.oasis-open.org/odata/odata-vocabularies/v4.0/vocabularies/Org.OData.Core.V1.xml">
+        <edmx:Include Namespace="Org.OData.Core.V1" Alias="Core" />
+    </edmx:Reference>
     <edmx:DataServices>
         <Schema Namespace="SampleSpace" xmlns="http://docs.oasis-open.org/odata/ns/edm">
             <Annotation Term="SampleSpace.Version" String="1.2.3" />
@@ -27,7 +30,9 @@
                 <Key>
                     <PropertyRef Name="id" />
                 </Key>
-                <Property Name="id" Nullable="false" Type="Edm.String" />
+                <Property Name="id" Nullable="false" Type="Edm.String">
+                    <Annotation Term="Org.OData.Core.V1.Computed" Bool="true" />
+                </Property>
                 <Property Name="user_name" Nullable="false" Type="Edm.String" />
                 <Property Name="name" Nullable="true" Type="Edm.String" />
                 <Property Name="emails" Nullable="false" Type="Collection(Edm.String)" />

--- a/spec/oas_2.json
+++ b/spec/oas_2.json
@@ -187,7 +187,8 @@
       "type": "object",
       "properties": {
         "id": {
-          "type": "string"
+          "type": "string",
+          "readOnly": true
         },
         "user_name": {
           "type": "string"

--- a/spec/odata_duty/entity_set/computed_metadata_spec.rb
+++ b/spec/odata_duty/entity_set/computed_metadata_spec.rb
@@ -45,4 +45,14 @@ RSpec.describe OdataDuty::Schema, 'Computed property metadata' do
       '<edmx:Include Namespace="Org.OData.Core.V1" Alias="Core" />'
     )
   end
+
+  it 'produces well-formed XML' do
+    doc = Nokogiri::XML(metadata_xml)
+    expect(doc.errors).to be_empty
+  end
+
+  it 'renders a non-computed property as a clean element with no stray markup' do
+    expect(property_xml('name')).not_to include('> />')
+    expect(property_xml('name')).not_to include('></Property>')
+  end
 end

--- a/spec/odata_duty/entity_set/computed_metadata_spec.rb
+++ b/spec/odata_duty/entity_set/computed_metadata_spec.rb
@@ -1,0 +1,48 @@
+require 'spec_helper'
+
+class ComputedMetadataEntity < OdataDuty::EntityType
+  property_ref 'id', String
+  property 'created_at', DateTime, computed: true
+  property 'name', String
+end
+
+class ComputedMetadataSet < OdataDuty::EntitySet
+  entity_type ComputedMetadataEntity
+end
+
+class ComputedMetadataSchema < OdataDuty::Schema
+  base_url 'http://localhost:3000/api'
+  entity_sets [ComputedMetadataSet]
+end
+
+RSpec.describe OdataDuty::Schema, 'Computed property metadata' do
+  subject(:metadata_xml) { ComputedMetadataSchema.metadata_xml }
+
+  def property_xml(name)
+    metadata_xml.split(%(<Property Name="#{name}"))[1].split('<Property ')[0]
+  end
+
+  it 'renders the Core Computed annotation for a computed property' do
+    expect(property_xml('created_at'))
+      .to include('<Annotation Term="Org.OData.Core.V1.Computed" Bool="true" />')
+  end
+
+  it 'does not render the Computed annotation for a writable property' do
+    expect(property_xml('name')).not_to include('Org.OData.Core.V1.Computed')
+  end
+
+  it 'renders the Computed annotation for the entity key by default' do
+    expect(property_xml('id'))
+      .to include('<Annotation Term="Org.OData.Core.V1.Computed" Bool="true" />')
+  end
+
+  it 'includes the Core vocabulary reference and include' do
+    expect(metadata_xml).to include(
+      '<edmx:Reference Uri="https://docs.oasis-open.org/odata/odata-vocabularies/' \
+      'v4.0/vocabularies/Org.OData.Core.V1.xml">'
+    )
+    expect(metadata_xml).to include(
+      '<edmx:Include Namespace="Org.OData.Core.V1" Alias="Core" />'
+    )
+  end
+end

--- a/spec/odata_duty/entity_set/computed_oas2_spec.rb
+++ b/spec/odata_duty/entity_set/computed_oas2_spec.rb
@@ -1,0 +1,49 @@
+require 'spec_helper'
+
+class ComputedOas2CollectionResolver < OdataDuty::SetResolver
+  def collection
+    []
+  end
+
+  def create(params)
+    params
+  end
+end
+
+RSpec.describe OdataDuty::EntitySet, 'computed properties as readOnly in $oas2' do
+  let(:oas2_schema) do
+    OdataDuty::SchemaBuilder.build(namespace: 'SampleSpace', host: 'localhost',
+                                   base_path: '/api') do |s|
+      entity = s.add_entity_type(name: 'ComputedOas2Entity') do |et|
+        et.property_ref 'id', String
+        et.property 'user_name', String, nullable: false
+        et.property 'created_at', DateTime, computed: true
+      end
+
+      s.add_entity_set(name: 'ComputedOas2Collection', entity_type: entity,
+                       resolver: 'ComputedOas2CollectionResolver')
+    end
+  end
+
+  let(:json) { OdataDuty::OAS2.build_json(oas2_schema, context: Context.new) }
+  let(:properties) { json.dig('definitions', 'ComputedOas2Entity', 'properties') }
+
+  it 'marks the key property as readOnly by default (computed)' do
+    expect(properties['id']).to eq('type' => 'string', 'readOnly' => true)
+  end
+
+  it 'does not mark a writable property as readOnly' do
+    expect(properties['user_name']).to eq('type' => 'string')
+  end
+
+  it 'marks a computed nullable property with both readOnly and x-nullable' do
+    expect(properties['created_at']).to eq(
+      'type' => 'string', 'format' => 'date-time', 'readOnly' => true, 'x-nullable' => true
+    )
+  end
+
+  it 'keeps the post body referencing the shared entity definition' do
+    body = json.dig('paths', '/ComputedOas2Collection', 'post', 'parameters').first
+    expect(body['schema']).to eq('$ref' => '#/definitions/ComputedOas2Entity')
+  end
+end

--- a/spec/odata_duty/entity_set/create/computed_spec.rb
+++ b/spec/odata_duty/entity_set/create/computed_spec.rb
@@ -1,0 +1,72 @@
+require 'spec_helper'
+
+class CreateComputedTestEntity < OdataDuty::EntityType
+  property_ref 'id', String, computed: false
+  property 'name', String
+  property 'created_at', DateTime, computed: true
+end
+
+class CreateComputedTestSet < OdataDuty::EntitySet
+  entity_type CreateComputedTestEntity
+
+  def create(params)
+    raise 'created_at must be nil' unless params.created_at.nil?
+
+    params
+  end
+end
+
+class CreateComputedKeyTestEntity < OdataDuty::EntityType
+  property_ref 'id', String
+  property 'name', String
+
+  def id
+    object.id
+  end
+end
+
+class CreateComputedKeyTestSet < OdataDuty::EntitySet
+  entity_type CreateComputedKeyTestEntity
+
+  ServerAssigned = Struct.new(:id, :name)
+
+  def create(params)
+    raise 'id must be nil' unless params.id.nil?
+
+    ServerAssigned.new('server-assigned', params.name)
+  end
+end
+
+class CreateComputedTestSchema < OdataDuty::Schema
+  base_url 'http://localhost:3000/api'
+  entity_sets [CreateComputedTestSet, CreateComputedKeyTestSet]
+end
+
+RSpec.describe OdataDuty::EntitySet, 'computed properties on create' do
+  subject(:schema) { CreateComputedTestSchema }
+
+  def create(set, query_options)
+    Oj.load(schema.create(set, context: Context.new, query_options: query_options))
+  end
+
+  describe 'computed non-key property' do
+    it 'is silently ignored and reads back as nil while siblings coerce normally' do
+      response = create('CreateComputedTest',
+                        'id' => '1', 'name' => 'foo', 'created_at' => '2021-01-01T00:00:00Z')
+      expect(response).to include('name' => 'foo', 'created_at' => nil)
+    end
+
+    it 'drops a wrong-typed computed value without raising InvalidType' do
+      expect do
+        create('CreateComputedTest', 'id' => '1', 'name' => 'foo', 'created_at' => 12_345)
+      end.not_to raise_error
+    end
+  end
+
+  describe 'property_ref defaulting to computed: true' do
+    it 'makes the key read-only so a supplied id is ignored and server-assigned' do
+      response = create('CreateComputedKeyTest', 'id' => '99', 'name' => 'bar')
+      expect(response).to include('id' => 'server-assigned', 'name' => 'bar')
+    end
+  end
+end

--- a/spec/odata_duty/entity_set/create/mcp_spec.rb
+++ b/spec/odata_duty/entity_set/create/mcp_spec.rb
@@ -1,17 +1,21 @@
 require 'spec_helper'
 
 class CreateMcpStruct
-  attr_reader :id, :name
+  attr_reader :id, :name, :sku, :created_at
 
-  def initialize(id:, name:)
+  def initialize(id:, name:, sku:)
     @id = id
     @name = name
+    @sku = sku
+    @created_at = '2026-06-23'
   end
 end
 
 class CreateMcpWidgetEntity < OdataDuty::EntityType
   property_ref 'id', String
   property 'name', String
+  property 'sku', String, nullable: false
+  property 'created_at', String, computed: true
 end
 
 class CreateMcpWidgetSet < OdataDuty::EntitySet
@@ -20,7 +24,7 @@ class CreateMcpWidgetSet < OdataDuty::EntitySet
   url 'Widgets'
 
   def create(params)
-    CreateMcpStruct.new(id: 'w1', name: params.name)
+    CreateMcpStruct.new(id: 'w1', name: params.name, sku: params.sku)
   end
 end
 
@@ -61,10 +65,10 @@ RSpec.describe OdataDuty::EntitySet, 'MCP create tool' do
           '$schema' => 'https://json-schema.org/draft/2020-12/schema',
           'type' => 'object',
           'properties' => {
-            'id' => { 'type' => 'string' },
-            'name' => { 'type' => 'string', 'x-nullable' => true }
+            'name' => { 'type' => 'string', 'x-nullable' => true },
+            'sku' => { 'type' => 'string' }
           },
-          'required' => ['id']
+          'required' => ['sku']
         }
       )
     end
@@ -78,7 +82,7 @@ RSpec.describe OdataDuty::EntitySet, 'MCP create tool' do
     let(:request_payload) do
       { 'jsonrpc' => '2.0', 'method' => 'tools/call',
         'params' => { 'name' => 'create_Widgets',
-                      'arguments' => { 'id' => 'w1', 'name' => 'Gadget' } },
+                      'arguments' => { 'name' => 'Gadget', 'sku' => 'SKU1' } },
         'id' => 'tc-1' }
     end
 

--- a/spec/odata_duty/entity_set/create/with_complex_spec.rb
+++ b/spec/odata_duty/entity_set/create/with_complex_spec.rb
@@ -14,7 +14,7 @@ class CreateTestComplex < OdataDuty::ComplexType
 end
 
 class CreateComplexTestEntity < OdataDuty::EntityType
-  property_ref 'id', String
+  property_ref 'id', String, computed: false
   property 'complex', CreateTestComplex
 end
 

--- a/spec/odata_duty/entity_set/create/with_scalars_spec.rb
+++ b/spec/odata_duty/entity_set/create/with_scalars_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 class CreateScalarsTestEntity < OdataDuty::EntityType
-  property_ref 'id', String
+  property_ref 'id', String, computed: false
   property 'string', String
   property 'string_list', [String]
   property 'number', Integer

--- a/spec/odata_duty/schema_builder/entity_set/computed_metadata_spec.rb
+++ b/spec/odata_duty/schema_builder/entity_set/computed_metadata_spec.rb
@@ -45,5 +45,15 @@ module OdataDuty
         '<edmx:Include Namespace="Org.OData.Core.V1" Alias="Core" />'
       )
     end
+
+    it 'produces well-formed XML' do
+      doc = Nokogiri::XML(metadata_xml)
+      expect(doc.errors).to be_empty
+    end
+
+    it 'renders a non-computed property as a clean element with no stray markup' do
+      expect(property_xml('name')).not_to include('> />')
+      expect(property_xml('name')).not_to include('></Property>')
+    end
   end
 end

--- a/spec/odata_duty/schema_builder/entity_set/computed_metadata_spec.rb
+++ b/spec/odata_duty/schema_builder/entity_set/computed_metadata_spec.rb
@@ -1,0 +1,49 @@
+require 'spec_helper'
+
+class ComputedMetadataBuilderResolver < OdataDuty::SetResolver
+end
+
+module OdataDuty
+  RSpec.describe SchemaBuilder, 'Computed property metadata' do
+    subject(:metadata_xml) do
+      SchemaBuilder.build(namespace: 'SampleSpace', host: 'localhost', base_path: '/api') do |s|
+        entity = s.add_entity_type(name: 'ComputedMetadataEntity') do |et|
+          et.property_ref 'id', String
+          et.property 'created_at', DateTime, computed: true
+          et.property 'name', String
+        end
+
+        s.add_entity_set(name: 'ComputedMetadata', entity_type: entity,
+                         resolver: 'ComputedMetadataBuilderResolver')
+      end.metadata_xml
+    end
+
+    def property_xml(name)
+      metadata_xml.split(%(<Property Name="#{name}"))[1].split('<Property ')[0]
+    end
+
+    it 'renders the Core Computed annotation for a computed property' do
+      expect(property_xml('created_at'))
+        .to include('<Annotation Term="Org.OData.Core.V1.Computed" Bool="true" />')
+    end
+
+    it 'does not render the Computed annotation for a writable property' do
+      expect(property_xml('name')).not_to include('Org.OData.Core.V1.Computed')
+    end
+
+    it 'renders the Computed annotation for the entity key by default' do
+      expect(property_xml('id'))
+        .to include('<Annotation Term="Org.OData.Core.V1.Computed" Bool="true" />')
+    end
+
+    it 'includes the Core vocabulary reference and include' do
+      expect(metadata_xml).to include(
+        '<edmx:Reference Uri="https://docs.oasis-open.org/odata/odata-vocabularies/' \
+        'v4.0/vocabularies/Org.OData.Core.V1.xml">'
+      )
+      expect(metadata_xml).to include(
+        '<edmx:Include Namespace="Org.OData.Core.V1" Alias="Core" />'
+      )
+    end
+  end
+end

--- a/spec/odata_duty/schema_builder/entity_set/computed_oas2_spec.rb
+++ b/spec/odata_duty/schema_builder/entity_set/computed_oas2_spec.rb
@@ -1,0 +1,49 @@
+require 'spec_helper'
+
+class ComputedOas2BuilderCollectionResolver < OdataDuty::SetResolver
+  def collection
+    []
+  end
+
+  def create(params)
+    params
+  end
+end
+
+RSpec.describe OdataDuty::SchemaBuilder, 'computed properties as readOnly in $oas2' do
+  let(:oas2_schema) do
+    OdataDuty::SchemaBuilder.build(namespace: 'SampleSpace', host: 'localhost',
+                                   base_path: '/api') do |s|
+      entity = s.add_entity_type(name: 'ComputedOas2BuilderEntity') do |et|
+        et.property_ref 'id', String
+        et.property 'user_name', String, nullable: false
+        et.property 'created_at', DateTime, computed: true
+      end
+
+      s.add_entity_set(name: 'ComputedOas2BuilderCollection', entity_type: entity,
+                       resolver: 'ComputedOas2BuilderCollectionResolver')
+    end
+  end
+
+  let(:json) { OdataDuty::OAS2.build_json(oas2_schema, context: Context.new) }
+  let(:properties) { json.dig('definitions', 'ComputedOas2BuilderEntity', 'properties') }
+
+  it 'marks the key property as readOnly by default (computed)' do
+    expect(properties['id']).to eq('type' => 'string', 'readOnly' => true)
+  end
+
+  it 'does not mark a writable property as readOnly' do
+    expect(properties['user_name']).to eq('type' => 'string')
+  end
+
+  it 'marks a computed nullable property with both readOnly and x-nullable' do
+    expect(properties['created_at']).to eq(
+      'type' => 'string', 'format' => 'date-time', 'readOnly' => true, 'x-nullable' => true
+    )
+  end
+
+  it 'keeps the post body referencing the shared entity definition' do
+    body = json.dig('paths', '/ComputedOas2BuilderCollection', 'post', 'parameters').first
+    expect(body['schema']).to eq('$ref' => '#/definitions/ComputedOas2BuilderEntity')
+  end
+end

--- a/spec/odata_duty/schema_builder/entity_set/create/computed_spec.rb
+++ b/spec/odata_duty/schema_builder/entity_set/create/computed_spec.rb
@@ -1,0 +1,66 @@
+require 'spec_helper'
+
+class CreateComputedTestResolver < OdataDuty::SetResolver
+  def create(params)
+    raise 'created_at must be nil' unless params.created_at.nil?
+
+    params
+  end
+end
+
+class CreateComputedKeyTestResolver < OdataDuty::SetResolver
+  ServerAssigned = Struct.new(:id, :name)
+
+  def create(params)
+    raise 'id must be nil' unless params.id.nil?
+
+    ServerAssigned.new('server-assigned', params.name)
+  end
+end
+
+module OdataDuty
+  RSpec.describe SchemaBuilder::EntitySet, 'computed properties on create' do
+    subject(:schema) do
+      SchemaBuilder.build(namespace: 'SampleSpace', host: 'localhost', base_path: '') do |s|
+        computed = s.add_entity_type(name: 'CreateComputedTestEntity') do |et|
+          et.property_ref 'id', String, computed: false
+          et.property 'name', String
+          et.property 'created_at', DateTime, computed: true
+        end
+        key = s.add_entity_type(name: 'CreateComputedKeyTestEntity') do |et|
+          et.property_ref 'id', String
+          et.property 'name', String
+        end
+        s.add_entity_set(name: 'CreateComputedTest', entity_type: computed,
+                         resolver: 'CreateComputedTestResolver')
+        s.add_entity_set(name: 'CreateComputedKeyTest', entity_type: key,
+                         resolver: 'CreateComputedKeyTestResolver')
+      end
+    end
+
+    def create(set, query_options)
+      Oj.load(schema.create(set, context: Context.new, query_options: query_options))
+    end
+
+    describe 'computed non-key property' do
+      it 'is silently ignored and reads back as nil while siblings coerce normally' do
+        response = create('CreateComputedTest',
+                          'id' => '1', 'name' => 'foo', 'created_at' => '2021-01-01T00:00:00Z')
+        expect(response).to include('name' => 'foo', 'created_at' => nil)
+      end
+
+      it 'drops a wrong-typed computed value without raising InvalidType' do
+        expect do
+          create('CreateComputedTest', 'id' => '1', 'name' => 'foo', 'created_at' => 12_345)
+        end.not_to raise_error
+      end
+    end
+
+    describe 'property_ref defaulting to computed: true' do
+      it 'makes the key read-only so a supplied id is ignored and server-assigned' do
+        response = create('CreateComputedKeyTest', 'id' => '99', 'name' => 'bar')
+        expect(response).to include('id' => 'server-assigned', 'name' => 'bar')
+      end
+    end
+  end
+end

--- a/spec/odata_duty/schema_builder/entity_set/create/mcp_spec.rb
+++ b/spec/odata_duty/schema_builder/entity_set/create/mcp_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 
 class CreateMcpWidgetResolver < OdataDuty::SetResolver
   def create(params)
-    Struct.new(:id, :name).new('w1', params.name)
+    Struct.new(:id, :name, :sku, :created_at).new('w1', params.name, params.sku, '2026-06-23')
   end
 end
 
@@ -16,6 +16,8 @@ module OdataDuty
         entity = s.add_entity_type(name: 'CreateMcpWidgetEntity') do |et|
           et.property_ref 'id', String
           et.property 'name', String
+          et.property 'sku', String, nullable: false
+          et.property 'created_at', String, computed: true
         end
 
         s.add_entity_set(name: 'Widgets', entity_type: entity,
@@ -50,10 +52,10 @@ module OdataDuty
             '$schema' => 'https://json-schema.org/draft/2020-12/schema',
             'type' => 'object',
             'properties' => {
-              'id' => { 'type' => 'string' },
-              'name' => { 'type' => 'string', 'x-nullable' => true }
+              'name' => { 'type' => 'string', 'x-nullable' => true },
+              'sku' => { 'type' => 'string' }
             },
-            'required' => ['id']
+            'required' => ['sku']
           }
         )
       end
@@ -67,7 +69,7 @@ module OdataDuty
       let(:request_payload) do
         { 'jsonrpc' => '2.0', 'method' => 'tools/call',
           'params' => { 'name' => 'create_Widgets',
-                        'arguments' => { 'id' => 'w1', 'name' => 'Gadget' } },
+                        'arguments' => { 'name' => 'Gadget', 'sku' => 'SKU1' } },
           'id' => 'tc-1' }
       end
 

--- a/spec/odata_duty/schema_builder/entity_set/create/with_complex_spec.rb
+++ b/spec/odata_duty/schema_builder/entity_set/create/with_complex_spec.rb
@@ -39,7 +39,7 @@ module OdataDuty
         end
 
         collection_entity = s.add_entity_type(name: 'CreateComplexTestEntity') do |et|
-          et.property_ref 'id', String
+          et.property_ref 'id', String, computed: false
           et.property 'complex', complex_type
         end
 

--- a/spec/odata_duty/schema_builder/entity_set/create/with_scalars_spec.rb
+++ b/spec/odata_duty/schema_builder/entity_set/create/with_scalars_spec.rb
@@ -18,7 +18,7 @@ module OdataDuty
     subject(:schema) do
       SchemaBuilder.build(namespace: 'SampleSpace', host: 'localhost', base_path: '') do |s|
         collection_entity = s.add_entity_type(name: 'CreateScalarsTestEntity') do |et|
-          et.property_ref 'id', String
+          et.property_ref 'id', String, computed: false
           et.property 'string', String
           et.property 'string_list', [String]
           et.property 'number', Integer


### PR DESCRIPTION
Add doc/using_computed.md, modeled on doc/using_create.md: purpose, both DSLs, how the
read-only distinction is reflected across GET responses, $metadata (Core.Computed
annotation), $oas2 (readOnly), the MCP create tool, and the typed create input, plus
common edge cases (silent drop of supplied computed values, computed-by-default keys,
the computed: false opt-out). States the broader convention that the gem adopts OData
Core vocabulary keyword names where practical. Linked from the README's Further
Documentation section.

Task 5 of 5 for the computed (read-only) properties PRD.

Co-Authored-By: Claude Opus 4.8 (1M context) &lt;noreply@anthropic.com&gt;