### PR TITLE
Fold create and update into a combined write-operations guide (PRD task 5)

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ class SampleSchema < OdataDuty::Schema
 end
 ```
 
-Implementing `create` makes a set writable; omitting it keeps the set read-only. This single choice is reflected automatically across `$oas2`, `$metadata`, and MCP — see [Using `create`](doc/using_create.md).
+Implementing `create` makes a set insertable and `update` makes it updatable; omitting them keeps the set read-only. Each choice is reflected automatically across `$oas2`, `$metadata`, and MCP — see [Using `create` and `update`](doc/using_create.md).
 
 ---
 
@@ -238,7 +238,7 @@ end
 - [Using MCP](doc/using_mcp.md)
 - [Using `$select`](doc/using_select.md)
 - [Using `$search`](doc/using_search.md)
-- [Using `create`](doc/using_create.md)
+- [Using `create` and `update`](doc/using_create.md)
 - [Using `computed` (read-only) properties](doc/using_computed.md)
 
 > **Documentation convention:** Every externally-facing feature (a new DSL option,

--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ class SampleSchema < OdataDuty::Schema
 end
 ```
 
-Implementing `create` makes a set insertable and `update` makes it updatable; omitting them keeps the set read-only. Each choice is reflected automatically across `$oas2`, `$metadata`, and MCP — see [Using `create` and `update`](doc/using_create.md).
+Implementing `create` makes a set insertable and `update` makes it updatable; omitting them keeps the set read-only. Each choice is reflected automatically across `$oas2`, `$metadata`, and MCP — see [Using `create` and `update`](doc/using_create_and_update.md).
 
 ---
 
@@ -238,7 +238,7 @@ end
 - [Using MCP](doc/using_mcp.md)
 - [Using `$select`](doc/using_select.md)
 - [Using `$search`](doc/using_search.md)
-- [Using `create` and `update`](doc/using_create.md)
+- [Using `create` and `update`](doc/using_create_and_update.md)
 - [Using `computed` (read-only) properties](doc/using_computed.md)
 
 > **Documentation convention:** Every externally-facing feature (a new DSL option,

--- a/doc/prds/task-th38zacwjiEpEAHdxt-plan.md
+++ b/doc/prds/task-th38zacwjiEpEAHdxt-plan.md
@@ -63,7 +63,7 @@ The `$oas2` individual path key encoding (`/Set({id})`) is reused as-is; `update
 
   Dependencies: none. Establishes `supports_update?` used by Tasks 2–4.
 
-- [ ] **Task 2 — `$metadata` `UpdateRestrictions` annotation (both DSLs)**
+- [x] **Task 2 — `$metadata` `UpdateRestrictions` annotation (both DSLs)**
 
   Emit a `Capabilities.UpdateRestrictions` / `Updatable=false` annotation for sets **without**
   `update`, paralleling the existing `InsertRestrictions` block; updatable sets get no annotation.

--- a/doc/prds/task-th38zacwjiEpEAHdxt-plan.md
+++ b/doc/prds/task-th38zacwjiEpEAHdxt-plan.md
@@ -93,7 +93,7 @@ The `$oas2` individual path key encoding (`/Set({id})`) is reused as-is; `update
 
   Dependencies: Task 1.
 
-- [ ] **Task 4 — MCP `update_<Set>` tool (both DSLs)**
+- [x] **Task 4 — MCP `update_<Set>` tool (both DSLs)**
 
   Register an `update_<Set>` tool for each updatable set, mirroring `create_<Set>`. `name`
   `update_<Set>`; `description` `"Update an existing <Set> record"`; `inputSchema` properties =

--- a/doc/prds/task-th38zacwjiEpEAHdxt-plan.md
+++ b/doc/prds/task-th38zacwjiEpEAHdxt-plan.md
@@ -77,7 +77,7 @@ The `$oas2` individual path key encoding (`/Set({id})`) is reused as-is; `update
 
   Dependencies: Task 1 (`supports_update?`).
 
-- [ ] **Task 3 — `$oas2` `patch` on the individual path (both DSLs)**
+- [x] **Task 3 — `$oas2` `patch` on the individual path (both DSLs)**
 
   Add a `patch` to an updatable set's individual path object alongside `get`. `operationId`
   `Update<Set>`; parameters = the `id` path param (as `get` uses) **plus** a required `body` param

--- a/doc/prds/task-th38zacwjiEpEAHdxt-plan.md
+++ b/doc/prds/task-th38zacwjiEpEAHdxt-plan.md
@@ -1,0 +1,122 @@
+# Build plan: Update support (`update` hook / OData `PATCH`)
+
+PRD: [task-th38zacwjiEpEAHdxt.md](./task-th38zacwjiEpEAHdxt.md)
+
+Implements an `update(id, input)` hook that mirrors `create(input)` across both DSLs, exposing
+OData `PATCH`, a `$oas2` `patch` operation, an `UpdateRestrictions` `$metadata` annotation for
+non-updatable sets, and an `update_<Set>` MCP tool. Each task lands as its own commit after
+spec-compliance and code-quality review pass and `bundle exec rake` is green.
+
+## Reference points in the codebase (how `create` is wired — `update` mirrors it)
+
+- `Executor` dispatch: `lib/odata_duty/executor.rb` — `self.create`, instance `#create`,
+  `extract_value_from_brackets`, `#individual` (id coercion path).
+- Class DSL: `lib/odata_duty.rb` — `Schema.create` (262), `EntitySet::Metadata#create` (96),
+  `#supports_create?` (113), `converted_id` (120).
+- Builder DSL: `lib/odata_duty/schema_builder.rb` — `#create` (89); `schema_builder/endpoint.rb`
+  — `#create`, `#supports_create?`, `converted_id`; `schema_builder/entity_set.rb` —
+  `#supports_create?`.
+- Input object: `lib/odata_duty/create_complex_type_hash_wrapper.rb`.
+- `$oas2`: `lib/odata_duty/oas2.rb` (`add_collection_paths`/`add_individual_paths`),
+  `oas2/collection_post_path.rb`, `oas2/individual_get_path.rb`.
+- `$metadata`: `lib/metadata.xml.erb` (InsertRestrictions block ~78).
+- MCP: `lib/odata_duty/mcp_server_builder.rb` (`register_create_tool`, `create_input_schema`,
+  `define_tool`, `run_tool`).
+
+Note: the key property (`property_ref`) defaults to `computed: true`, so it is excluded from
+`create_input_schema`; the `update` MCP tool must add it back and mark it the sole `required`.
+The `$oas2` individual path key encoding (`/Set({id})`) is reused as-is; `update` only adds a
+`patch` to that existing path object.
+
+## Tasks
+
+- [x] **Task 1 — Core REST `PATCH` end-to-end (both DSLs) + `supports_update?` predicate**
+
+  Add the `update(id, input)` hook and route `PATCH` through it, mirroring `create`.
+  - `Executor.update` + instance `#update`: extract the id from the URL brackets (like
+    `#individual`), call `endpoint.update(id, context:)`, merge the individual `@odata.context`
+    anchor (`#{endpoint.name}/$entity`), and rescue `NoMethodError` → `NoImplementationError,
+    "update not implemented for #{endpoint.url}"`.
+  - Class DSL: `Schema.update(url, context:, query_options:)` in `lib/odata_duty.rb`;
+    `EntitySet::Metadata#update(id, context:)` (coerce id via `converted_id`, build
+    `CreateComplexTypeHashWrapper` from `context.query_options`, call
+    `entity_set.new(context:).update(id, wrapper)`, raise `ResourceNotFoundError` on a falsey
+    result, map result via the entity-type mapper); `EntitySet::Metadata#supports_update?` →
+    `entity_set.method_defined?(:update)`.
+  - Builder DSL: `SchemaBuilder#update(...)` in `schema_builder.rb`;
+    `SchemaBuilder::Endpoint#update(id, context:)` (mirror); `Endpoint#supports_update?` and
+    `SchemaBuilder::EntitySet#supports_update?` → `resolver_class.method_defined?(:update)`.
+  - Error cases: `NoImplementationError` (no `update`), `ResourceNotFoundError` (falsey result),
+    `InvalidPropertyReferenceValue` (bad key), `InvalidType` (bad body value),
+    `NoSuchPropertyError` (reading an undefined property) — all identical to `create`/`individual`.
+
+  Defining PRD excerpt: External API → "The `update` hook contract", "Invoking it (Rails
+  controller wiring)" (`schema.update(url, context:, query_options:)`); Behavior → "REST `PATCH`"
+  request/response JSON; all of "Common error cases".
+
+  Likely files: `lib/odata_duty/executor.rb`, `lib/odata_duty.rb`,
+  `lib/odata_duty/schema_builder.rb`, `lib/odata_duty/schema_builder/endpoint.rb`,
+  `lib/odata_duty/schema_builder/entity_set.rb`. Specs:
+  `spec/odata_duty/entity_set/update/*_spec.rb`,
+  `spec/odata_duty/schema_builder/entity_set/update/*_spec.rb` (happy path with partial-merge nil
+  reads + every error case).
+
+  Dependencies: none. Establishes `supports_update?` used by Tasks 2–4.
+
+- [x] **Task 2 — `$metadata` `UpdateRestrictions` annotation (both DSLs)**
+
+  Emit a `Capabilities.UpdateRestrictions` / `Updatable=false` annotation for sets **without**
+  `update`, paralleling the existing `InsertRestrictions` block; updatable sets get no annotation.
+  A set that is neither insertable nor updatable carries both.
+
+  Defining PRD excerpt: Behavior → "`$metadata` (EDMX)" XML block.
+
+  Likely files: `lib/metadata.xml.erb`. Specs:
+  `spec/odata_duty/entity_set/update/metadata_spec.rb`,
+  `spec/odata_duty/schema_builder/entity_set/update/metadata_spec.rb`.
+
+  Dependencies: Task 1 (`supports_update?`).
+
+- [x] **Task 3 — `$oas2` `patch` on the individual path (both DSLs)**
+
+  Add a `patch` to an updatable set's individual path object alongside `get`. `operationId`
+  `Update<Set>`; parameters = the `id` path param (as `get` uses) **plus** a required `body` param
+  whose `schema` `$ref`s the entity definition; responses `200` (Success) + `default` (Error),
+  both schema-`$ref`ing the entity. Omit `patch` when the set has no `update`.
+
+  Defining PRD excerpt: Behavior → "`$oas2`" JSON block.
+
+  Likely files: `lib/odata_duty/oas2.rb` (`add_individual_paths`), new
+  `lib/odata_duty/oas2/individual_patch_path.rb` (require it where the other oas2 paths are
+  required). Specs: `spec/odata_duty/entity_set/update/oas2_spec.rb`,
+  `spec/odata_duty/schema_builder/entity_set/update/oas2_spec.rb`.
+
+  Dependencies: Task 1.
+
+- [x] **Task 4 — MCP `update_<Set>` tool (both DSLs)**
+
+  Register an `update_<Set>` tool for each updatable set, mirroring `create_<Set>`. `name`
+  `update_<Set>`; `description` `"Update an existing <Set> record"`; `inputSchema` properties =
+  create's writable properties **plus the key property** (which is otherwise computed/excluded),
+  `required` = `[key]` only. `tools/call` builds the individual URL from the `id` argument and
+  routes through `Executor.update`, returning the updated entity. Non-updatable sets advertise no
+  tool (calling one → "Unknown tool" error).
+
+  Defining PRD excerpt: Behavior → "MCP" `tools/list` + `tools/call` JSON blocks; Common error
+  cases → "MCP `update_<Set>` for a non-updatable set".
+
+  Likely files: `lib/odata_duty/mcp_server_builder.rb`. Specs:
+  `spec/odata_duty/entity_set/update/mcp_spec.rb`,
+  `spec/odata_duty/schema_builder/entity_set/update/mcp_spec.rb`.
+
+  Dependencies: Task 1.
+
+- [x] **Task 5 — Documentation: fold `create` + `update` into a write-operations guide**
+
+  Evolve `doc/using_create.md` into a combined write-operations guide (Overview → both DSLs → How
+  it works → `$oas2`/`$metadata`/MCP reflection → Common Error Cases), presenting `update`
+  alongside `create`. Update the README *Further Documentation* link to the combined guide.
+
+  Defining PRD excerpt: "Documentation impact".
+
+  Dependencies: Tasks 1–4 (documents shipped behavior).

--- a/doc/prds/task-th38zacwjiEpEAHdxt-plan.md
+++ b/doc/prds/task-th38zacwjiEpEAHdxt-plan.md
@@ -111,7 +111,7 @@ The `$oas2` individual path key encoding (`/Set({id})`) is reused as-is; `update
 
   Dependencies: Task 1.
 
-- [ ] **Task 5 — Documentation: fold `create` + `update` into a write-operations guide**
+- [x] **Task 5 — Documentation: fold `create` + `update` into a write-operations guide**
 
   Evolve `doc/using_create.md` into a combined write-operations guide (Overview → both DSLs → How
   it works → `$oas2`/`$metadata`/MCP reflection → Common Error Cases), presenting `update`

--- a/doc/prds/task-th38zacwjiEpEAHdxt-plan.md
+++ b/doc/prds/task-th38zacwjiEpEAHdxt-plan.md
@@ -63,7 +63,7 @@ The `$oas2` individual path key encoding (`/Set({id})`) is reused as-is; `update
 
   Dependencies: none. Establishes `supports_update?` used by Tasks 2–4.
 
-- [x] **Task 2 — `$metadata` `UpdateRestrictions` annotation (both DSLs)**
+- [ ] **Task 2 — `$metadata` `UpdateRestrictions` annotation (both DSLs)**
 
   Emit a `Capabilities.UpdateRestrictions` / `Updatable=false` annotation for sets **without**
   `update`, paralleling the existing `InsertRestrictions` block; updatable sets get no annotation.
@@ -77,7 +77,7 @@ The `$oas2` individual path key encoding (`/Set({id})`) is reused as-is; `update
 
   Dependencies: Task 1 (`supports_update?`).
 
-- [x] **Task 3 — `$oas2` `patch` on the individual path (both DSLs)**
+- [ ] **Task 3 — `$oas2` `patch` on the individual path (both DSLs)**
 
   Add a `patch` to an updatable set's individual path object alongside `get`. `operationId`
   `Update<Set>`; parameters = the `id` path param (as `get` uses) **plus** a required `body` param
@@ -93,7 +93,7 @@ The `$oas2` individual path key encoding (`/Set({id})`) is reused as-is; `update
 
   Dependencies: Task 1.
 
-- [x] **Task 4 — MCP `update_<Set>` tool (both DSLs)**
+- [ ] **Task 4 — MCP `update_<Set>` tool (both DSLs)**
 
   Register an `update_<Set>` tool for each updatable set, mirroring `create_<Set>`. `name`
   `update_<Set>`; `description` `"Update an existing <Set> record"`; `inputSchema` properties =
@@ -111,7 +111,7 @@ The `$oas2` individual path key encoding (`/Set({id})`) is reused as-is; `update
 
   Dependencies: Task 1.
 
-- [x] **Task 5 — Documentation: fold `create` + `update` into a write-operations guide**
+- [ ] **Task 5 — Documentation: fold `create` + `update` into a write-operations guide**
 
   Evolve `doc/using_create.md` into a combined write-operations guide (Overview → both DSLs → How
   it works → `$oas2`/`$metadata`/MCP reflection → Common Error Cases), presenting `update`

--- a/doc/prds/task-th38zacwjiEpEAHdxt.md
+++ b/doc/prds/task-th38zacwjiEpEAHdxt.md
@@ -1,0 +1,329 @@
+# PRD: Update support (`update` hook / OData `PATCH`)
+
+## Summary
+
+Let a gem consumer make an entity set *updatable* by implementing a single `update(id, input)`
+method on its data class (class DSL) or resolver (builder DSL). Implementing it makes the set
+accept OData `PATCH` requests against an individual URL, adds a `patch` operation to `$oas2`,
+drops the read-only update annotation in `$metadata`, and advertises an `update_<Set>` MCP tool —
+exactly mirroring how `create` makes a set insertable today.
+
+## Goal / Problem
+
+OdataDuty already lets a consumer expose reads (`collection`, `individual`, `count`) and inserts
+(`create`). There is no consumer-facing way to expose *updates*. A consumer who wants clients
+(PowerBI, PowerAutomate, an LLM via MCP) to modify an existing record has to fall outside the
+gem entirely. This PRD closes that gap with the same "implement a method, availability is
+inferred" ergonomics the gem already uses for every other operation.
+
+## What it enables
+
+- As a gem consumer, I can implement `update(id, input)` on a data class / resolver and my set
+  starts accepting OData `PATCH` requests to an individual URL (e.g. `PATCH /People('1')`).
+- As a gem consumer, I get a `patch` operation in the generated `$oas2` for that set's individual
+  path, with no extra declaration.
+- As a gem consumer, my updatable set is **not** annotated read-only-for-update in `$metadata`,
+  while sets without `update` carry an `UpdateRestrictions / Updatable=false` annotation.
+- As an MCP client (or LLM), I can call an `update_<Set>` tool that reuses the same update path
+  as the REST `PATCH`.
+- As a gem consumer, I do nothing extra to keep a set read-only: omit `update` and none of the
+  above appears, across all three contracts.
+
+**Scope limits (this PRD):**
+
+- **PATCH (partial merge) semantics only.** No `PUT` / full-replace verb.
+- The input object exposes **all** writable properties; properties omitted from the request body
+  read as `nil`. This means the consumer **cannot** distinguish "field omitted" from "field
+  explicitly set to null" — see Common Error Cases / Open Questions.
+
+## External API
+
+Availability is **inferred from the presence of `update`**, identical to how `create`,
+`collection`, `individual`, and `od_search` are inferred. No new declaration or flag.
+
+### The `update` hook contract
+
+- **Signature:** `update(id, input)`.
+- **`id`** — the entity key, already coerced to the property-ref's type (the same conversion
+  `individual(id)` receives). For an integer key you get an `Integer`; for a string key, a
+  `String`.
+- **`input`** — a typed, coerced input object built from the `PATCH` request body and mapped onto
+  the entity type's properties, the same object shape `create` receives. Read fields via
+  `input.property_name`. Properties not present in the request body read as `nil`.
+- **Return value:** the updated record — the same object shape your entity type's mapper renders
+  for `collection` / `individual`. The framework runs it through the mapper, so the response is
+  the same shape a `GET` of that individual would produce, plus the `@odata.context` annotation.
+- **When called:** on a `PATCH` to an individual URL of an updatable set, after the id is parsed
+  from the URL and the body is coerced.
+
+### Class DSL (`OdataDuty::EntitySet`)
+
+```ruby
+class PeopleSet < OdataDuty::EntitySet
+  entity_type PersonEntity
+
+  def od_after_init
+    @records = Person.active
+  end
+
+  def collection
+    @records
+  end
+
+  def individual(id)
+    @records.find(id)
+  end
+
+  def create(input)
+    Person.create!(user_name: input.user_name, name: input.name, emails: input.emails)
+  end
+
+  # Receives the coerced key and a typed input object (omitted fields read as nil).
+  # Returns the updated record (same shape collection/individual return).
+  def update(id, input)
+    person = @records.find(id)
+    person.update!(name: input.name) unless input.name.nil?
+    person.update!(emails: input.emails) unless input.emails.nil?
+    person
+  end
+end
+```
+
+Omit `update` and the same set is not updatable — no `patch`, an `UpdateRestrictions` annotation,
+and no MCP `update_<Set>` tool.
+
+### Builder DSL (`OdataDuty::SetResolver`)
+
+```ruby
+class PeopleResolver < OdataDuty::SetResolver
+  def od_after_init
+    @records = Person.all
+  end
+
+  def collection
+    @records
+  end
+
+  def individual(id)
+    @records.find { |record| record.id == id }
+  end
+
+  # Same contract as the class DSL.
+  def update(id, input)
+    person = Person.find(id)
+    person.update!(name: input.name) unless input.name.nil?
+    person
+  end
+end
+```
+
+### Invoking it (Rails controller wiring)
+
+The consumer routes `PATCH` to a new `schema.update`, mirroring `schema.execute` (GET) and
+`schema.create` (POST):
+
+```ruby
+# config/routes.rb
+scope '/api' do
+  root 'api#index'
+  get '$metadata' => 'api#metadata'
+  get '$oas2' => 'api#oas2'
+  get '*url' => 'api#show'
+  post '*url' => 'api#create'
+  patch '*url' => 'api#update'
+end
+```
+
+```ruby
+# app/controllers/api_controller.rb
+def update
+  render json: schema.update(params[:url], context: self, query_options: query_options)
+end
+```
+
+`schema.update(url, context:, query_options:)` is the only new public entry point on `Schema`.
+The individual URL (e.g. `People('1')`) carries the key; the request body arrives through
+`query_options`, the same channel `create` uses for its body.
+
+## Behavior & expected I/O
+
+### REST `PATCH`
+
+Request:
+
+```http
+PATCH /api/People('1')
+Content-Type: application/json
+
+{ "name": "Alice Updated" }
+```
+
+Response (the updated entity, mapper-rendered, with the individual `@odata.context` anchor —
+the same anchor `GET /People('1')` returns):
+
+```jsonc
+{
+  "@odata.context": "https://host/api/$metadata#People/$entity",
+  "id": "1",
+  "user_name": "alice",
+  "name": "Alice Updated",
+  "emails": ["alice@example.com"]
+}
+```
+
+Because semantics are partial-merge, fields omitted from the body (`user_name`, `emails` above)
+read as `nil` inside `update`, and the example consumer leaves them untouched.
+
+### `$oas2`
+
+An **updatable** set's individual path gains a `patch` alongside the existing `get`. The
+`operationId` is `Update<Set>` (e.g. `UpdatePeople`); the body `$ref` and success `schema` both
+point at the entity definition, matching the `create` `post` convention:
+
+```jsonc
+{
+  "paths": {
+    "/People('{id}')": {
+      "get": { "operationId": "GetIndividualPeopleById" /* ... */ },
+      "patch": {
+        "operationId": "UpdatePeople",
+        "produces": ["application/json"],
+        "parameters": [
+          { "name": "id", "in": "path", "required": true, "type": "string" },
+          { "name": "body", "in": "body", "required": true,
+            "schema": { "$ref": "#/definitions/Person" } }
+        ],
+        "responses": {
+          "200": { "description": "Success", "schema": { "$ref": "#/definitions/Person" } },
+          "default": { "description": "Unexpected error", "schema": { "$ref": "#/definitions/Error" } }
+        }
+      }
+    }
+  }
+}
+```
+
+A set without `update` exposes only `get` on its individual path — the `patch` is omitted
+entirely. (The exact individual-path key encoding follows whatever `$oas2` already emits for the
+`get` individual path; `update` adds the `patch` to that same path object.)
+
+### `$metadata` (EDMX)
+
+A set **without** `update` carries a `Capabilities.UpdateRestrictions` annotation marking it not
+updatable, paralleling the existing `InsertRestrictions` annotation for non-insertable sets:
+
+```xml
+<EntitySet Name="Countries" EntityType="MySpace.Country">
+    <Annotation Term="Capabilities.UpdateRestrictions">
+        <Record>
+            <PropertyValue Property="Updatable" Bool="false" />
+        </Record>
+    </Annotation>
+</EntitySet>
+```
+
+An **updatable** set gets no such annotation (the OData default is updatable). A set that is
+neither insertable nor updatable carries both annotations. The `Org.OData.Capabilities.V1`
+vocabulary (aliased `Capabilities`) is already referenced at the top of the metadata document, so
+the annotation needs no additional setup.
+
+### MCP
+
+`tools/list` includes an `update_<Set>` tool for each updatable set, mirroring `create_<Set>`:
+
+- **`name`:** `update_<Set>` (e.g. `update_People`).
+- **`description`:** `"Update an existing <Set> record"`.
+- **`inputSchema`:** an object whose `properties` are the entity type's writable properties (the
+  same set `create_<Set>` exposes), and whose `required` array contains **only the key property**
+  — the key is needed to locate the record, while every other field is optional under
+  partial-merge semantics.
+
+```jsonc
+// tools/list result (updatable People set)
+{
+  "tools": [
+    {
+      "name": "update_People",
+      "description": "Update an existing People record",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "id": { "type": "string" /* ... */ },
+          "user_name": { "type": "string" /* ... */ },
+          "name": { "type": "string" /* ... */ },
+          "emails": { "type": "array" /* ... */ }
+        },
+        "required": ["id"]
+      }
+    }
+  ]
+}
+```
+
+A `tools/call` for `update_<Set>` updates the record and returns the updated entity as structured
+JSON, reusing the same update path as the REST `PATCH`:
+
+```jsonc
+// tools/call request
+{
+  "method": "tools/call",
+  "params": {
+    "name": "update_People",
+    "arguments": { "id": "1", "name": "Alice Updated" }
+  }
+}
+```
+
+A set without `update` advertises no `update_<Set>` tool, so calling one raises an "Unknown tool"
+error.
+
+## Common error cases
+
+- **`PATCH` to a set without `update`:** raises `OdataDuty::NoImplementationError` with the
+  message `update not implemented for <url>` (the set's URL, e.g. `update not implemented for
+  People`) — mirroring `create not implemented for <url>`.
+- **`PATCH` for a key that doesn't exist:** when the consumer's `update` cannot find the record
+  and returns a falsey value, the framework raises `OdataDuty::ResourceNotFoundError`
+  (`No such entity <id>`), the same way `individual` does for a missing record.
+- **Invalid key in the URL:** a key that can't be coerced to the property-ref's type raises
+  `OdataDuty::InvalidPropertyReferenceValue` (`Invalid individual id : ...`), the same conversion
+  error `individual` produces.
+- **Request body that fails coercion/validation:** a body value that cannot be coerced to a
+  property's type raises `OdataDuty::InvalidType` (`The value provided for '<field>' is of wrong
+  type`). Accessing a field that is not a defined property raises
+  `OdataDuty::NoSuchPropertyError`; unknown keys in the body are ignored unless the consumer reads
+  them via `input.<that_key>`. Identical to `create`'s input handling.
+- **MCP `update_<Set>` for a non-updatable set:** because the tool is never listed, calling it via
+  `tools/call` raises an `"Unknown tool: update_<Set>"` error rather than
+  `NoImplementationError`.
+
+## Scope
+
+**In:**
+
+- `update(id, input)` hook on both the class DSL (`OdataDuty::EntitySet`) and the builder DSL
+  (`OdataDuty::SetResolver`).
+- `Schema.update(url, context:, query_options:)` public entry point for routing `PATCH`.
+- OData `PATCH` (partial merge) against an individual URL.
+- Reflection across `$oas2` (`patch` on the individual path), `$metadata`
+  (`UpdateRestrictions` for non-updatable sets), and MCP (`update_<Set>` tool).
+
+**Out:**
+
+- `PUT` / full-replace semantics.
+- Distinguishing "field omitted" from "field explicitly null" (omitted fields read as `nil`).
+- `DELETE` support, upsert, and bulk/batch updates.
+- Concurrency / `If-Match` / ETag handling.
+
+**DSLs covered:** both class-based and builder, with matching spec coverage under
+`spec/odata_duty/entity_set/**` and `spec/odata_duty/schema_builder/**`.
+
+## Documentation impact
+
+Fold `create` and `update` into a single **write-operations guide** — evolve
+**`doc/using_create.md`** (e.g. into a "Using `create` and `update`" / write-operations guide)
+rather than adding a separate `doc/using_update.md`, keeping the same purpose-first,
+example-driven style (Overview → Implementing in both DSLs → How it works → Reflected in
+`$oas2` / `$metadata` / MCP → Common Error Cases), with `update` presented alongside `create`
+throughout. Update the README's *Further Documentation* link to point at the combined guide. Do
+not write the guide as part of this PRD.

--- a/doc/using_create.md
+++ b/doc/using_create.md
@@ -1,25 +1,34 @@
-# Using `create` with OdataDuty
+# Using `create` and `update` with OdataDuty
 
-OdataDuty exposes a *writable* entity set the moment your data class (class DSL) or resolver (builder DSL) implements a `create` method. There is no separate flag or declaration to set: availability is inferred from the presence of `create`, exactly the way `collection`, `individual`, and `od_search` are inferred. Implement `create` and the set accepts `POST` requests, gains a `post` operation in `$oas2`, drops the read-only annotation in `$metadata`, and advertises an MCP `create_<Set>` tool. Omit it and the set is read-only across all three contracts.
+OdataDuty exposes a *writable* entity set the moment your data class (class DSL) or resolver (builder DSL) implements a write method. Two operations are inferred this way:
 
-This guide explains how to implement `create` and how the choice is reflected in the generated `$oas2`, `$metadata`, and MCP contracts.
+- Implement `create(input)` and the set accepts `POST` requests, gains a `post` operation in `$oas2`, drops the `InsertRestrictions` annotation in `$metadata`, and advertises an MCP `create_<Set>` tool.
+- Implement `update(id, input)` and the set accepts `PATCH` requests against an individual URL, gains a `patch` operation in `$oas2`, drops the `UpdateRestrictions` annotation in `$metadata`, and advertises an MCP `update_<Set>` tool.
+
+There is no separate flag or declaration for either: availability is inferred from the presence of the method, exactly the way `collection`, `individual`, and `od_search` are inferred. Omit a method and the corresponding capability disappears across all three contracts; omit both and the set is read-only.
+
+This guide explains how to implement `create` and `update`, and how each choice is reflected in the generated `$oas2`, `$metadata`, and MCP contracts.
 
 ## Overview
 
-- **Purpose:** Allow clients to create new records through OData `POST` (and the equivalent MCP tool).
-- **Mechanism:** OdataDuty checks whether your data class / resolver defines `create`. If it does, the set is writable; if not, it is read-only.
+- **Purpose:** Allow clients to create new records through OData `POST` and modify existing records through OData `PATCH` (and the equivalent MCP tools).
+- **Mechanism:** OdataDuty checks whether your data class / resolver defines `create` and / or `update`. Each method, independently, makes the corresponding operation available; absence keeps it read-only.
 - **No new declaration:** Writability is inferred from the method, just like `collection`, `individual`, and `od_search`.
-- **Typed input:** `create` receives a coerced input object built from the request body and mapped onto the entity type's properties. Read fields via `input.property_name`.
-- **Return value:** `create` returns the created record — the same object shape your entity type's mapper renders for `collection`/`individual`.
-- **Reflected everywhere:** A writable set has a `post` in `$oas2`, no `InsertRestrictions` annotation in `$metadata`, and a `create_<Set>` MCP tool. A read-only set has none of these.
+- **Typed input:** Both methods receive a coerced input object built from the request body and mapped onto the entity type's properties. Read fields via `input.property_name`. `update` additionally receives the entity key as its first argument.
+- **PATCH partial-merge:** `update` uses partial-merge semantics — properties omitted from the request body read as `nil`, so the consumer cannot distinguish "field omitted" from "field explicitly null".
+- **Return value:** Both methods return the affected record — the same object shape your entity type's mapper renders for `collection`/`individual`.
+- **Reflected everywhere:** A `create`able set has a `post` in `$oas2`, no `InsertRestrictions` annotation in `$metadata`, and a `create_<Set>` MCP tool. An `update`able set has a `patch` in `$oas2`, no `UpdateRestrictions` annotation in `$metadata`, and an `update_<Set>` MCP tool. A read-only set has none of these.
 
-## Implementing `create`
+## Implementing `create` and `update`
 
-Both DSLs work the same way: define `create(input)`, read the coerced fields off `input`, persist the record, and return it.
+Both DSLs work the same way:
+
+- `create(input)`: read the coerced fields off `input`, persist a new record, and return it.
+- `update(id, input)`: receive the coerced key plus an input object, merge the present fields onto the existing record, and return it. Fields omitted from the request body read as `nil`, so the partial-merge pattern is `... unless input.field.nil?`.
 
 ### Builder DSL (`OdataDuty::SetResolver`)
 
-A resolver that implements `create` is writable:
+A resolver that implements `create` and `update` is writable on both verbs:
 
 ```ruby
 class PeopleResolver < OdataDuty::SetResolver
@@ -40,10 +49,18 @@ class PeopleResolver < OdataDuty::SetResolver
   def create(input)
     Person.create!(user_name: input.user_name, name: input.name, emails: input.emails)
   end
+
+  # Receives the coerced key and a typed input object (omitted fields read as nil).
+  # Returns the updated record (same shape collection/individual return).
+  def update(id, input)
+    person = Person.find(id)
+    person.update!(name: input.name) unless input.name.nil?
+    person
+  end
 end
 ```
 
-A resolver without `create` is read-only — the data methods are identical, just no `create`:
+A resolver without `create` or `update` is read-only — the data methods are identical, just no write methods:
 
 ```ruby
 class CountriesResolver < OdataDuty::SetResolver
@@ -63,7 +80,7 @@ end
 
 ### Class DSL (`OdataDuty::EntitySet`)
 
-The class DSL behaves identically; the set itself implements `create`:
+The class DSL behaves identically; the set itself implements `create` and `update`:
 
 ```ruby
 class PeopleSet < OdataDuty::EntitySet
@@ -85,10 +102,18 @@ class PeopleSet < OdataDuty::EntitySet
   def create(input)
     Person.create!(user_name: input.user_name, name: input.name, emails: input.emails)
   end
+
+  # Receives the coerced key and a typed input object (omitted fields read as nil).
+  def update(id, input)
+    person = @records.find(id)
+    person.update!(name: input.name) unless input.name.nil?
+    person.update!(emails: input.emails) unless input.emails.nil?
+    person
+  end
 end
 ```
 
-Omit `create` and the same set is read-only:
+Omit `create` and `update` and the same set is read-only:
 
 ```ruby
 class CountriesSet < OdataDuty::EntitySet
@@ -108,18 +133,70 @@ class CountriesSet < OdataDuty::EntitySet
 end
 ```
 
+### Invoking it (Rails controller wiring)
+
+`create` is routed through `schema.create` (POST) and `update` through `schema.update` (PATCH), mirroring `schema.execute` for GET. `schema.update(url, context:, query_options:)` is the only new public entry point beyond `create`; the individual URL (e.g. `People('1')`) carries the key, while the request body arrives through `query_options` — the same channel `create` uses for its body:
+
+```ruby
+# config/routes.rb
+scope '/api' do
+  root 'api#index'
+  get '$metadata' => 'api#metadata'
+  get '$oas2' => 'api#oas2'
+  get '*url' => 'api#show'
+  post '*url' => 'api#create'
+  patch '*url' => 'api#update'
+end
+```
+
+```ruby
+# app/controllers/api_controller.rb
+def create
+  render json: schema.create(params[:url], context: self, query_options: query_options)
+end
+
+def update
+  render json: schema.update(params[:url], context: self, query_options: query_options)
+end
+```
+
 ### How It Works
 
-1. **Discovery:** OdataDuty checks whether your data class / resolver responds to `create`. That single check drives every contract below.
-2. **Coercion:** On `POST`, the request body is coerced and validated against the entity type's properties into a typed input object, which is passed to your `create`.
-3. **Persistence:** Your `create` persists the record and returns it.
-4. **Rendering:** The returned record is run through the entity type's mapper, so the response is the same shape a `GET` would produce, plus the `@odata.context` annotation.
+1. **Discovery:** OdataDuty checks whether your data class / resolver responds to `create` and / or `update`. Each check independently drives the contracts below.
+2. **Coercion:** On `POST` the request body is coerced and validated against the entity type's properties into a typed input object passed to `create`. On `PATCH` the key is parsed from the individual URL and coerced to the property-ref's type (the same conversion `individual(id)` receives), and the body is coerced into the same input-object shape passed to `update`. Under partial-merge semantics, properties absent from the body read as `nil`.
+3. **Persistence:** Your `create` / `update` persists the record and returns it.
+4. **Rendering:** The returned record is run through the entity type's mapper, so the response is the same shape a `GET` would produce, plus the `@odata.context` annotation. For `update` the anchor is the individual `@odata.context` (`.../$metadata#People/$entity`), the same anchor `GET /People('1')` returns.
+
+### Example `PATCH` request / response
+
+A `PATCH` to an individual URL applies a partial merge:
+
+```http
+PATCH /api/People('1')
+Content-Type: application/json
+
+{ "name": "Alice Updated" }
+```
+
+Response (the updated entity, mapper-rendered, with the individual `@odata.context` anchor):
+
+```jsonc
+{
+  "@odata.context": "https://host/api/$metadata#People/$entity",
+  "id": "1",
+  "user_name": "alice",
+  "name": "Alice Updated",
+  "emails": ["alice@example.com"]
+}
+```
+
+Because semantics are partial-merge, fields omitted from the body (`user_name`, `emails` above) read as `nil` inside `update`, and the example consumer leaves them untouched.
 
 ## Reflected in the generated contracts
 
 ### `$oas2`
 
-A **writable** set's collection path exposes both `get` and `post`. The `post` operation's `operationId` is `Create<Set>` (e.g. `CreatePeople`):
+A **`create`able** set's collection path exposes both `get` and `post`. The `post` operation's `operationId` is `Create<Set>` (e.g. `CreatePeople`):
 
 ```jsonc
 {
@@ -144,13 +221,41 @@ A **writable** set's collection path exposes both `get` and `post`. The `post` o
 }
 ```
 
-A **read-only** set's path carries only `get` — the `post` is omitted entirely:
+An **`update`able** set's *individual* path gains a `patch` alongside its `get`. The `operationId` is `Update<Set>` (e.g. `UpdatePeople`); its parameters are the `id` path parameter plus a required `body` parameter `$ref`ing the entity. Note the responses are `200` Success and `default` Error only — there is no `201`, unlike `create`'s `post`:
+
+```jsonc
+{
+  "paths": {
+    "/People({id})": {
+      "get": { "operationId": "GetIndividualPeopleById" /* ... */ },
+      "patch": {
+        "operationId": "UpdatePeople",
+        "produces": ["application/json"],
+        "parameters": [
+          { "name": "id", "in": "path", "required": true, "type": "string" },
+          { "name": "body", "in": "body", "required": true,
+            "schema": { "$ref": "#/definitions/Person" } }
+        ],
+        "responses": {
+          "200": { "description": "Success", "schema": { "$ref": "#/definitions/Person" } },
+          "default": { "description": "Unexpected error", "schema": { "$ref": "#/definitions/Error" } }
+        }
+      }
+    }
+  }
+}
+```
+
+A **read-only** set's collection path carries only `get` and its individual path carries only `get` — the `post` and `patch` are omitted entirely:
 
 ```jsonc
 {
   "paths": {
     "/Countries": {
       "get": { "operationId": "ListCountries" /* ... */ }
+    },
+    "/Countries({id})": {
+      "get": { "operationId": "GetIndividualCountriesById" /* ... */ }
     }
   }
 }
@@ -158,7 +263,7 @@ A **read-only** set's path carries only `get` — the `post` is omitted entirely
 
 ### `$metadata` (EDMX)
 
-A **read-only** set's `<EntitySet>` carries an `InsertRestrictions` annotation marking it not insertable:
+A set **without** `create` carries an `InsertRestrictions` annotation marking it not insertable, and a set **without** `update` carries a parallel `UpdateRestrictions` annotation marking it not updatable. A set that is neither insertable nor updatable carries both:
 
 ```xml
 <EntitySet Name="Countries" EntityType="MySpace.Country">
@@ -167,71 +272,100 @@ A **read-only** set's `<EntitySet>` carries an `InsertRestrictions` annotation m
             <PropertyValue Property="Insertable" Bool="false" />
         </Record>
     </Annotation>
+    <Annotation Term="Capabilities.UpdateRestrictions">
+        <Record>
+            <PropertyValue Property="Updatable" Bool="false" />
+        </Record>
+    </Annotation>
 </EntitySet>
 ```
 
-A **writable** set gets no such annotation (the OData default is insertable):
+A set gets no annotation for a capability it supports (the OData defaults are insertable and updatable). So a set with both `create` and `update` carries neither annotation:
 
 ```xml
 <EntitySet Name="People" EntityType="MySpace.Person" />
 ```
 
-The `Org.OData.Capabilities.V1` vocabulary (aliased `Capabilities`) is already referenced at the top of the metadata document, so the annotation needs no additional setup.
+The `Org.OData.Capabilities.V1` vocabulary (aliased `Capabilities`) is already referenced at the top of the metadata document, so the annotations need no additional setup.
 
 ### MCP
 
-`tools/list` includes a `create_<Set>` tool for each writable set. The tool's `name` is `create_<Set>`, its `description` is `"Create a new <Set> record"`, and its `inputSchema` is an object whose `properties` are the entity type's properties and whose `required` array is the non-nullable property names:
+`tools/list` includes a `create_<Set>` tool for each insertable set and an `update_<Set>` tool for each updatable set.
+
+The `create_<Set>` tool's `name` is `create_<Set>`, its `description` is `"Create a new <Set> record"`, and its `inputSchema` is an object whose `properties` are the entity type's writable properties and whose `required` array is the non-nullable property names:
 
 ```jsonc
-// tools/list result (writable People set)
+// tools/list result (insertable People set)
 {
-  "tools": [
-    {
-      "name": "create_People",
-      "description": "Create a new People record",
-      "inputSchema": {
-        "type": "object",
-        "properties": {
-          "id": { "type": "string" /* ... */ },
-          "user_name": { "type": "string" /* ... */ },
-          "name": { "type": "string" /* ... */ },
-          "emails": { "type": "array" /* ... */ }
-        },
-        "required": ["id", "user_name", "emails"]
-      }
-    }
-  ]
-}
-```
-
-A `tools/call` for `create_<Set>` creates the record and returns the created entity as structured JSON, reusing the same create path as the REST `POST`:
-
-```jsonc
-// tools/call request
-{
-  "method": "tools/call",
-  "params": {
-    "name": "create_People",
-    "arguments": { "user_name": "alice", "name": "Alice", "emails": ["alice@example.com"] }
+  "name": "create_People",
+  "description": "Create a new People record",
+  "inputSchema": {
+    "type": "object",
+    "properties": {
+      "id": { "type": "string" /* ... */ },
+      "user_name": { "type": "string" /* ... */ },
+      "name": { "type": "string" /* ... */ },
+      "emails": { "type": "array" /* ... */ }
+    },
+    "required": ["id", "user_name", "emails"]
   }
 }
 ```
 
-A read-only set advertises no `create_<Set>` tool, so calling one raises an "Unknown tool" error (see below).
+The `update_<Set>` tool's `name` is `update_<Set>`, its `description` is `"Update an existing <Set> record"`, and its `inputSchema` `properties` are the **key property plus the writable properties**. Its `required` array contains **only the key** — the key locates the record, while every other field is optional under partial-merge semantics. The key property defaults to computed, so its schema carries `"readOnly": true`:
+
+```jsonc
+// tools/list result (updatable People set)
+{
+  "name": "update_People",
+  "description": "Update an existing People record",
+  "inputSchema": {
+    "type": "object",
+    "properties": {
+      "id": { "type": "string", "readOnly": true /* ... */ },
+      "user_name": { "type": "string" /* ... */ },
+      "name": { "type": "string" /* ... */ },
+      "emails": { "type": "array" /* ... */ }
+    },
+    "required": ["id"]
+  }
+}
+```
+
+A `tools/call` for `create_<Set>` creates the record and a `tools/call` for `update_<Set>` updates it; each returns the affected entity as structured JSON, reusing the same path as the REST `POST` / `PATCH`:
+
+```jsonc
+// tools/call request (update)
+{
+  "method": "tools/call",
+  "params": {
+    "name": "update_People",
+    "arguments": { "id": "1", "name": "Alice Updated" }
+  }
+}
+```
+
+A read-only set advertises neither tool, so calling one raises an "Unknown tool" error (see below).
 
 ## Common Error Cases
 
-- **`POST` to a set without `create`:**
-  A `POST` to a read-only set raises `OdataDuty::NoImplementationError` with the message `create not implemented for <url>` (the set's URL, e.g. `create not implemented for People`).
+- **`POST` to a set without `create` / `PATCH` to a set without `update`:**
+  Raises `OdataDuty::NoImplementationError` with the message `create not implemented for <url>` or `update not implemented for <url>` respectively (the set's URL, e.g. `update not implemented for People`).
 
-- **MCP `create_<Set>` for a read-only set:**
-  Because the tool is never listed for a read-only set, calling it via `tools/call` raises an `"Unknown tool: create_<Set>"` error rather than `NoImplementationError`.
+- **`PATCH` for a key that doesn't exist:**
+  When your `update` cannot find the record and returns a falsey value, the framework raises `OdataDuty::ResourceNotFoundError` (`No such entity <id>`), the same way `individual` does for a missing record.
+
+- **Invalid key in the `PATCH` URL:**
+  A key that can't be coerced to the property-ref's type raises `OdataDuty::InvalidPropertyReferenceValue` (`Invalid individual id : ...`), the same conversion error `individual` produces.
 
 - **Request body that fails coercion/validation:**
-  When a body value cannot be coerced to a property's type, the input wrapper (`CreateComplexTypeHashWrapper`) rescues the internal `InvalidValue` and raises `OdataDuty::InvalidType` — so `OdataDuty::InvalidType` is what propagates for a wrong-typed value. Accessing a field that is not a defined property on the input object raises `OdataDuty::NoSuchPropertyError`; unknown keys in the request body are otherwise ignored unless your `create` accesses them via `input.<that_key>`.
+  When a body value cannot be coerced to a property's type, the input wrapper rescues the internal `InvalidValue` and raises `OdataDuty::InvalidType` — so `OdataDuty::InvalidType` is what propagates for a wrong-typed value, for both `create` and `update`. Accessing a field that is not a defined property on the input object raises `OdataDuty::NoSuchPropertyError`; unknown keys in the request body are otherwise ignored unless your method accesses them via `input.<that_key>`.
+
+- **MCP `create_<Set>` / `update_<Set>` for a set that lacks the capability:**
+  Because the tool is never listed for such a set, calling it via `tools/call` raises an `"Unknown tool: <tool>"` error rather than `NoImplementationError`.
 
 ## Summary
 
-- **Make a set writable** by implementing `create(input)` on its data class (class DSL) or resolver (builder DSL); omit it to keep the set read-only.
-- **`create`** receives a typed, coerced input object (read fields via `input.property_name`) and returns the created record in the same shape `collection`/`individual` return.
-- **Writable** sets gain a `post` (`operationId` `Create<Set>`) in `$oas2`, no `InsertRestrictions` annotation in `$metadata`, and a `create_<Set>` MCP tool — all of which **read-only** sets lack.
+- **Make a set writable** by implementing `create(input)` (insert) and / or `update(id, input)` (partial-merge update) on its data class (class DSL) or resolver (builder DSL); omit a method to drop that capability, omit both to keep the set read-only.
+- **`create`** receives a typed, coerced input object and returns the created record. **`update`** additionally receives the coerced key as its first argument; omitted fields read as `nil` (partial merge). Both return the affected record in the same shape `collection`/`individual` return.
+- **Insertable** sets gain a `post` (`operationId` `Create<Set>`) on the collection path in `$oas2`, no `InsertRestrictions` annotation in `$metadata`, and a `create_<Set>` MCP tool. **Updatable** sets gain a `patch` (`operationId` `Update<Set>`) on the individual path in `$oas2`, no `UpdateRestrictions` annotation in `$metadata`, and an `update_<Set>` MCP tool (its `inputSchema` includes the key, `required` is the key only). **Read-only** sets lack all of these and carry both restriction annotations.

--- a/doc/using_create_and_update.md
+++ b/doc/using_create_and_update.md
@@ -12,7 +12,7 @@ This guide explains how to implement `create` and `update`, and how each choice 
 ## Overview
 
 - **Purpose:** Allow clients to create new records through OData `POST` and modify existing records through OData `PATCH` (and the equivalent MCP tools).
-- **Mechanism:** OdataDuty checks whether your data class / resolver defines `create` and / or `update`. Each method, independently, makes the corresponding operation available; absence keeps it read-only.
+- **Mechanism:** OdataDuty checks whether your data class / resolver defines `create` and / or `update`. Each method, independently, makes the corresponding operation available; omitting one drops only that capability, and the set is fully read-only only when both `create` and `update` are absent.
 - **No new declaration:** Writability is inferred from the method, just like `collection`, `individual`, and `od_search`.
 - **Typed input:** Both methods receive a coerced input object built from the request body and mapped onto the entity type's properties. Read fields via `input.property_name`. `update` additionally receives the entity key as its first argument.
 - **PATCH partial-merge:** `update` uses partial-merge semantics — properties omitted from the request body read as `nil`, so the consumer cannot distinguish "field omitted" from "field explicitly null".

--- a/doc/using_mcp.md
+++ b/doc/using_mcp.md
@@ -122,7 +122,7 @@ by hand.
   [`od_search`](using_search.md). Its input schema requires a single `$search` string. Calling it
   runs the same `$search` execution as the OData endpoint and returns the collection JSON.
 - **`create_<Set>`** — registered for every writable set (one that implements
-  [`create`](using_create.md)). Its input schema is built from the entity type's properties;
+  [`create`](using_create_and_update.md)). Its input schema is built from the entity type's properties;
   non-nullable properties become `required`.
 
 `tools/list` returns these with their derived names, descriptions, and input schemas. A successful

--- a/lib/metadata.xml.erb
+++ b/lib/metadata.xml.erb
@@ -82,6 +82,13 @@
                                 </Record>
                             </Annotation>
                         <% end %>
+                        <% if !entity_set.supports_update? %>
+                            <Annotation Term="Capabilities.UpdateRestrictions">
+                                <Record>
+                                    <PropertyValue Property="Updatable" Bool="false" />
+                                </Record>
+                            </Annotation>
+                        <% end %>
                     </EntitySet>
                 <% end %>
             </EntityContainer>

--- a/lib/odata_duty.rb
+++ b/lib/odata_duty.rb
@@ -101,6 +101,14 @@ module OdataDuty
         mapper.obj_to_hash(result, context)
       end
 
+      def update(id, context:)
+        wrapper = CreateComplexTypeHashWrapper.new(context.query_options, entity_type, context)
+        result = entity_set.new(context: context).update(converted_id(id, context), wrapper)
+        raise ResourceNotFoundError, "No such entity #{id}" unless result
+
+        entity_type.mapper(context, selected: nil).obj_to_hash(result, context)
+      end
+
       def supports_search?
         # Check if the entity set class supports search by looking for the od_search method
         entity_set.method_defined?(:od_search)
@@ -113,6 +121,11 @@ module OdataDuty
       def supports_create?
         # Check if the entity set class supports create by looking for the create method
         entity_set.method_defined?(:create)
+      end
+
+      def supports_update?
+        # Check if the entity set class supports update by looking for the update method
+        entity_set.method_defined?(:update)
       end
 
       private
@@ -261,6 +274,10 @@ module OdataDuty
 
     def self.create(url, context:, query_options: {})
       Executor.create(url: url, context: context, query_options: query_options, schema: self)
+    end
+
+    def self.update(url, context:, query_options: {})
+      Executor.update(url: url, context: context, query_options: query_options, schema: self)
     end
 
     def self.to_mcp_server

--- a/lib/odata_duty/executor.rb
+++ b/lib/odata_duty/executor.rb
@@ -11,6 +11,10 @@ module OdataDuty
       new(**).create
     end
 
+    def self.update(**)
+      new(**).update
+    end
+
     attr_reader :schema, :url, :context, :query_options
 
     def initialize(schema:, url:, context:, query_options:)
@@ -47,6 +51,19 @@ module OdataDuty
               mode: :compat)
     rescue NoMethodError
       raise NoImplementationError, "create not implemented for #{endpoint.url}"
+    end
+
+    def update
+      entity_id = extract_value_from_brackets(url)
+      Oj.dump(endpoint
+          .update(entity_id, context: wrapped_context)
+          .merge(
+            '@odata.context': wrapped_context.od_full_url('$metadata',
+                                                          anchor: "#{endpoint.name}/$entity")
+          ),
+              mode: :compat)
+    rescue NoMethodError
+      raise NoImplementationError, "update not implemented for #{endpoint.url}"
     end
 
     def prepare_builder(endpoint, context, query_options)

--- a/lib/odata_duty/mcp_input_schemas.rb
+++ b/lib/odata_duty/mcp_input_schemas.rb
@@ -1,0 +1,29 @@
+module OdataDuty
+  module McpInputSchemas
+    module_function
+
+    def search_input_schema
+      { 'type' => 'object',
+        'properties' => { '$search' => {
+          'type' => 'string',
+          'description' => 'Search query using expressions with AND, OR, NOT operators'
+        } },
+        'required' => ['$search'] }
+    end
+
+    def create_input_schema(entity_type)
+      writable = entity_type.properties.reject(&:computed?)
+      properties = writable.to_h { |p| [p.name.to_s, p.to_oas2] }
+      required = writable.reject(&:nullable).map { |p| p.name.to_s }
+      { 'type' => 'object', 'properties' => properties, 'required' => required }
+    end
+
+    def update_input_schema(entity_type)
+      key = entity_type.property_refs.first
+      writable = entity_type.properties.reject(&:computed?)
+      properties = { key.name.to_s => key.to_oas2 }
+      writable.each { |p| properties[p.name.to_s] = p.to_oas2 }
+      { 'type' => 'object', 'properties' => properties, 'required' => [key.name.to_s] }
+    end
+  end
+end

--- a/lib/odata_duty/mcp_server_builder.rb
+++ b/lib/odata_duty/mcp_server_builder.rb
@@ -1,5 +1,6 @@
 require 'mcp'
 require 'uri'
+require 'odata_duty/mcp_input_schemas'
 
 module OdataDuty
   module McpServerBuilder
@@ -14,11 +15,14 @@ module OdataDuty
         resource_templates: resource_templates(schema)
       )
       register_resources_read(server, schema)
-      schema.endpoints.each do |endpoint|
-        register_search_tool(server, schema, endpoint) if endpoint.supports_search?
-        register_create_tool(server, schema, endpoint) if endpoint.supports_create?
-      end
+      schema.endpoints.each { |endpoint| register_endpoint_tools(server, schema, endpoint) }
       server
+    end
+
+    def register_endpoint_tools(server, schema, endpoint)
+      register_search_tool(server, schema, endpoint) if endpoint.supports_search?
+      register_create_tool(server, schema, endpoint) if endpoint.supports_create?
+      register_update_tool(server, schema, endpoint) if endpoint.supports_update?
     end
 
     def direct_resources(schema)
@@ -70,20 +74,29 @@ module OdataDuty
       description = "Search #{endpoint.name} using expressions with AND, OR, NOT operators"
       define_tool(server, schema, endpoint, :execute,
                   name: "search_#{endpoint.name}", description: description,
-                  input_schema: search_input_schema)
+                  input_schema: McpInputSchemas.search_input_schema)
     end
 
     def register_create_tool(server, schema, endpoint)
       define_tool(server, schema, endpoint, :create,
                   name: "create_#{endpoint.name}",
                   description: "Create a new #{endpoint.name} record",
-                  input_schema: create_input_schema(endpoint.entity_type))
+                  input_schema: McpInputSchemas.create_input_schema(endpoint.entity_type))
     end
 
-    def define_tool(server, schema, endpoint, action, **tool_args)
-      url = endpoint.url
+    def register_update_tool(server, schema, endpoint)
+      key_name = endpoint.entity_type.property_refs.first.name.to_sym
+      define_tool(server, schema, endpoint, :update,
+                  url_for: ->(args) { "#{endpoint.url}('#{args[key_name]}')" },
+                  name: "update_#{endpoint.name}",
+                  description: "Update an existing #{endpoint.name} record",
+                  input_schema: McpInputSchemas.update_input_schema(endpoint.entity_type))
+    end
+
+    def define_tool(server, schema, endpoint, action, url_for: nil, **tool_args)
+      url_for ||= ->(_args) { endpoint.url }
       server.define_tool(**tool_args) do |server_context:, **args|
-        McpServerBuilder.run_tool(action, url: url, schema: schema,
+        McpServerBuilder.run_tool(action, url: url_for.call(args), schema: schema,
                                           context: server_context[:context],
                                           query_options: args.transform_keys(&:to_s))
       end
@@ -95,22 +108,6 @@ module OdataDuty
       MCP::Tool::Response.new([{ type: 'text', text: json }])
     rescue OdataDuty::Error => e
       MCP::Tool::Response.new([{ type: 'text', text: e.message }], error: true)
-    end
-
-    def search_input_schema
-      { 'type' => 'object',
-        'properties' => { '$search' => {
-          'type' => 'string',
-          'description' => 'Search query using expressions with AND, OR, NOT operators'
-        } },
-        'required' => ['$search'] }
-    end
-
-    def create_input_schema(entity_type)
-      writable = entity_type.properties.reject(&:computed?)
-      properties = writable.to_h { |p| [p.name.to_s, p.to_oas2] }
-      required = writable.reject(&:nullable).map { |p| p.name.to_s }
-      { 'type' => 'object', 'properties' => properties, 'required' => required }
     end
   end
 end

--- a/lib/odata_duty/oas2.rb
+++ b/lib/odata_duty/oas2.rb
@@ -65,9 +65,9 @@ module OdataDuty
 
     def add_individual_paths
       schema.individual_entity_sets.each do |entity_set|
-        hash['paths']["/#{entity_set.url}({id})"] = {
-          'get' => IndividualGetPath.new(entity_set).to_oas2
-        }
+        path = { 'get' => IndividualGetPath.new(entity_set).to_oas2 }
+        path['patch'] = IndividualPatchPath.to_oas2(entity_set) if entity_set.supports_update?
+        hash['paths']["/#{entity_set.url}({id})"] = path
       end
     end
 
@@ -91,3 +91,4 @@ end
 require 'odata_duty/oas2/collection_get_path'
 require 'odata_duty/oas2/collection_post_path'
 require 'odata_duty/oas2/individual_get_path'
+require 'odata_duty/oas2/individual_patch_path'

--- a/lib/odata_duty/oas2/individual_patch_path.rb
+++ b/lib/odata_duty/oas2/individual_patch_path.rb
@@ -1,0 +1,52 @@
+module OdataDuty
+  class OAS2
+    class IndividualPatchPath
+      def self.to_oas2(entity_set)
+        path_info = new(entity_set)
+        {
+          'operationId' => path_info.operation_id,
+          'produces' => path_info.produces,
+          'parameters' => path_info.parameters,
+          'responses' => path_info.responses
+        }
+      end
+
+      def initialize(entity_set)
+        @entity_set = entity_set
+      end
+
+      def operation_id
+        "Update#{@entity_set.name}"
+      end
+
+      def produces
+        ['application/json']
+      end
+
+      def parameters
+        [
+          { 'name' => 'id', 'in' => 'path', 'required' => true, 'type' => id_type },
+          { 'name' => 'body', 'in' => 'body', 'required' => true, 'schema' => entity_type_schema }
+        ]
+      end
+
+      def responses
+        {
+          '200' => { 'description' => 'Success', 'schema' => entity_type_schema },
+          'default' => { 'description' => 'Unexpected error',
+                         'schema' => { '$ref' => '#/definitions/Error' } }
+        }
+      end
+
+      private
+
+      def id_type
+        @entity_set.entity_type.integer_property_ref? ? 'integer' : 'string'
+      end
+
+      def entity_type_schema
+        { '$ref' => "#/definitions/#{@entity_set.entity_type.name}" }
+      end
+    end
+  end
+end

--- a/lib/odata_duty/schema_builder.rb
+++ b/lib/odata_duty/schema_builder.rb
@@ -90,6 +90,10 @@ module OdataDuty
         Executor.create(url: url, context: context, query_options: query_options, schema: self)
       end
 
+      def update(url, context:, query_options: {})
+        Executor.update(url: url, context: context, query_options: query_options, schema: self)
+      end
+
       def to_mcp_server
         McpServerBuilder.build(self)
       end

--- a/lib/odata_duty/schema_builder/endpoint.rb
+++ b/lib/odata_duty/schema_builder/endpoint.rb
@@ -57,8 +57,20 @@ module OdataDuty
         entity_set.supports_filter_or?
       end
 
+      def update(id, context:)
+        wrapper = CreateComplexTypeHashWrapper.new(context.query_options, entity_type, context)
+        result = new_entity_set(context: context).update(converted_id(id, context), wrapper)
+        raise ResourceNotFoundError, "No such entity #{id}" unless result
+
+        entity_type.mapper(context, selected: nil).obj_to_hash(result, context)
+      end
+
       def supports_create?
         entity_set.supports_create?
+      end
+
+      def supports_update?
+        entity_set.supports_update?
       end
 
       private

--- a/lib/odata_duty/schema_builder/entity_set.rb
+++ b/lib/odata_duty/schema_builder/entity_set.rb
@@ -32,6 +32,11 @@ module OdataDuty
         # Check if the resolver class supports create by looking for the create method
         resolver_class.method_defined?(:create)
       end
+
+      def supports_update?
+        # Check if the resolver class supports update by looking for the update method
+        resolver_class.method_defined?(:update)
+      end
     end
   end
 end

--- a/odata_duty.gemspec
+++ b/odata_duty.gemspec
@@ -2,7 +2,7 @@
 
 Gem::Specification.new do |spec|
   spec.name          = 'odata_duty'
-  spec.version       = '0.18.0'
+  spec.version       = '0.19.0'
   spec.authors       = ['Grant Petersen-Speelman']
   spec.email         = ['grant@nexl.io']
 

--- a/spec/metadata.xml
+++ b/spec/metadata.xml
@@ -44,10 +44,12 @@
 
             <EntityContainer Name="Container">
                 <EntitySet Name="People" EntityType="SampleSpace.Person">
-                        
-                        
-                        
-                    </EntitySet>
+                    <Annotation Term="Capabilities.UpdateRestrictions">
+                        <Record>
+                            <PropertyValue Property="Updatable" Bool="false" />
+                        </Record>
+                    </Annotation>
+                </EntitySet>
             </EntityContainer>
         </Schema>
     </edmx:DataServices>

--- a/spec/odata_duty/entity_set/update/mcp_spec.rb
+++ b/spec/odata_duty/entity_set/update/mcp_spec.rb
@@ -1,0 +1,102 @@
+require 'spec_helper'
+
+class UpdateMcpStruct
+  attr_reader :id, :name, :sku
+
+  def initialize(id:, name:, sku:)
+    @id = id
+    @name = name
+    @sku = sku
+  end
+end
+
+class UpdateMcpWidgetEntity < OdataDuty::EntityType
+  property_ref 'id', String
+  property 'name', String
+  property 'sku', String, nullable: false
+end
+
+class UpdateMcpWidgetSet < OdataDuty::EntitySet
+  entity_type UpdateMcpWidgetEntity
+  name 'Widgets'
+  url 'Widgets'
+
+  def update(id, params)
+    UpdateMcpStruct.new(id: id, name: params.name, sku: params.sku)
+  end
+end
+
+class UpdateMcpPersonSet < OdataDuty::EntitySet
+  entity_type UpdateMcpWidgetEntity
+  name 'People'
+  url 'People'
+end
+
+class UpdateMcpSchema < OdataDuty::Schema
+  base_url 'http://localhost:3000/api'
+  entity_sets [UpdateMcpWidgetSet, UpdateMcpPersonSet]
+end
+
+RSpec.describe OdataDuty::EntitySet, 'MCP update tool' do
+  let(:mcp_server) do
+    server = UpdateMcpSchema.to_mcp_server
+    server.server_context = { context: Context.new }
+    server
+  end
+
+  def call(payload)
+    Oj.load(mcp_server.handle_json(Oj.dump(payload)))
+  end
+
+  describe 'tools/list' do
+    let(:request_payload) do
+      { 'jsonrpc' => '2.0', 'method' => 'tools/list', 'params' => {}, 'id' => 'tl-1' }
+    end
+
+    let(:tools) { call(request_payload)['result']['tools'] }
+
+    it 'includes an update tool for entity sets that support update' do
+      expect(tools).to include(
+        'name' => 'update_Widgets',
+        'description' => 'Update an existing Widgets record',
+        'inputSchema' => {
+          '$schema' => 'https://json-schema.org/draft/2020-12/schema',
+          'type' => 'object',
+          'properties' => {
+            'id' => { 'type' => 'string', 'readOnly' => true },
+            'name' => { 'type' => 'string', 'x-nullable' => true },
+            'sku' => { 'type' => 'string' }
+          },
+          'required' => ['id']
+        }
+      )
+    end
+
+    it 'does not include an update tool for read-only entity sets' do
+      expect(tools.map { |t| t['name'] }).not_to include('update_People')
+    end
+  end
+
+  describe 'tools/call for update' do
+    let(:request_payload) do
+      { 'jsonrpc' => '2.0', 'method' => 'tools/call',
+        'params' => { 'name' => 'update_Widgets',
+                      'arguments' => { 'id' => 'w1', 'name' => 'Updated', 'sku' => 'SKU1' } },
+        'id' => 'tc-1' }
+    end
+
+    it 'updates the record and returns it as structured JSON' do
+      result = call(request_payload)['result']
+      record = Oj.load(result['content'][0]['text'])
+
+      expect(result['isError']).to be(false)
+      expect(record).to include('id' => 'w1', 'name' => 'Updated')
+    end
+
+    it 'returns a tool-not-found error for an update tool on a read-only set' do
+      request_payload['params']['name'] = 'update_People'
+
+      expect(call(request_payload)['error']['code']).to eq(-32_602)
+    end
+  end
+end

--- a/spec/odata_duty/entity_set/update/metadata_spec.rb
+++ b/spec/odata_duty/entity_set/update/metadata_spec.rb
@@ -1,0 +1,49 @@
+require 'spec_helper'
+
+class UpdateMetadataTestEntity < OdataDuty::EntityType
+  property_ref 'id', String
+  property 'name', String
+end
+
+class UpdatableMetadataSet < OdataDuty::EntitySet
+  entity_type UpdateMetadataTestEntity
+
+  def update(id, params)
+    [id, params]
+  end
+end
+
+class ReadOnlyUpdateMetadataSet < OdataDuty::EntitySet
+  entity_type UpdateMetadataTestEntity
+end
+
+class UpdateMetadataTestSchema < OdataDuty::Schema
+  base_url 'http://localhost:3000/api'
+  entity_sets [UpdatableMetadataSet, ReadOnlyUpdateMetadataSet]
+end
+
+RSpec.describe OdataDuty::EntitySet, 'UpdateRestrictions metadata' do
+  subject(:metadata_xml) { UpdateMetadataTestSchema.metadata_xml }
+
+  describe '#metadata' do
+    it 'includes UpdateRestrictions annotation for read-only entity sets' do
+      read_only_xml = metadata_xml.split('<EntitySet Name="ReadOnlyUpdateMetadata"')[1]
+                                  .split('</EntitySet>')[0]
+      expect(read_only_xml).to include('Term="Capabilities.UpdateRestrictions"')
+      expect(read_only_xml).to include('Property="Updatable" Bool="false"')
+    end
+
+    it 'does not include UpdateRestrictions annotation for updatable entity sets' do
+      updatable_xml = metadata_xml.split('<EntitySet Name="UpdatableMetadata"')[1]
+                                  .split('</EntitySet>')[0]
+      expect(updatable_xml).not_to include('Capabilities.UpdateRestrictions')
+    end
+
+    it 'includes both Insert and Update restrictions for read-only entity sets' do
+      read_only_xml = metadata_xml.split('<EntitySet Name="ReadOnlyUpdateMetadata"')[1]
+                                  .split('</EntitySet>')[0]
+      expect(read_only_xml).to include('Term="Capabilities.InsertRestrictions"')
+      expect(read_only_xml).to include('Term="Capabilities.UpdateRestrictions"')
+    end
+  end
+end

--- a/spec/odata_duty/entity_set/update/oas2_spec.rb
+++ b/spec/odata_duty/entity_set/update/oas2_spec.rb
@@ -1,0 +1,79 @@
+require 'spec_helper'
+
+class UpdatableOas2Resolver < OdataDuty::SetResolver
+  def individual(id)
+    { 'id' => id, 'name' => 'x' }
+  end
+
+  def update(id, params)
+    [id, params]
+  end
+end
+
+class ReadOnlyUpdateOas2Resolver < OdataDuty::SetResolver
+  def individual(id)
+    { 'id' => id, 'name' => 'x' }
+  end
+end
+
+RSpec.describe OdataDuty::EntitySet, 'gates $oas2 patch on update support' do
+  let(:oas2_schema) do
+    OdataDuty::SchemaBuilder.build(namespace: 'SampleSpace', host: 'localhost',
+                                   base_path: '/api') do |s|
+      entity = s.add_entity_type(name: 'UpdateOas2TestEntity') do |et|
+        et.property_ref 'id', String
+        et.property 'name', String
+      end
+
+      s.add_entity_set(name: 'UpdatableOas2', entity_type: entity,
+                       resolver: 'UpdatableOas2Resolver')
+      s.add_entity_set(name: 'ReadOnlyUpdateOas2', entity_type: entity,
+                       resolver: 'ReadOnlyUpdateOas2Resolver')
+    end
+  end
+
+  let(:json) { OdataDuty::OAS2.build_json(oas2_schema, context: Context.new) }
+
+  describe '/UpdatableOas2({id})' do
+    let(:path) { json['paths']['/UpdatableOas2({id})'] }
+
+    it 'includes a patch operation when update is supported' do
+      expect(path).to have_key('patch')
+    end
+
+    it 'uses an Update operationId for the patch operation' do
+      expect(path['patch']['operationId']).to eq('UpdateUpdatableOas2')
+    end
+
+    it 'requires an id path parameter and a body parameter' do
+      expect(path['patch']['parameters']).to eq(
+        [
+          { 'name' => 'id', 'in' => 'path', 'required' => true, 'type' => 'string' },
+          { 'name' => 'body', 'in' => 'body', 'required' => true,
+            'schema' => { '$ref' => '#/definitions/UpdateOas2TestEntity' } }
+        ]
+      )
+    end
+
+    it 'exposes 200 and default responses' do
+      expect(path['patch']['responses']).to eq(
+        '200' => { 'description' => 'Success',
+                   'schema' => { '$ref' => '#/definitions/UpdateOas2TestEntity' } },
+        'default' => { 'description' => 'Unexpected error',
+                       'schema' => { '$ref' => '#/definitions/Error' } }
+      )
+    end
+  end
+
+  describe '/ReadOnlyUpdateOas2({id})' do
+    let(:path) { json['paths']['/ReadOnlyUpdateOas2({id})'] }
+
+    it 'includes a get operation' do
+      expect(path).to have_key('get')
+    end
+
+    it 'does not include a patch operation when update is not supported' do
+      expect(path).not_to have_key('patch')
+    end
+  end
+end

--- a/spec/odata_duty/entity_set/update/with_scalars_spec.rb
+++ b/spec/odata_duty/entity_set/update/with_scalars_spec.rb
@@ -1,0 +1,104 @@
+require 'spec_helper'
+
+class UpdateScalarsTestEntity < OdataDuty::EntityType
+  property_ref 'id', String, computed: false
+  property 'string', String
+  property 'number', Integer
+end
+
+class UpdateScalarsTestSet < OdataDuty::EntitySet
+  entity_type UpdateScalarsTestEntity
+
+  def update(id, input)
+    OpenStruct.new(id: id, string: input.string, number: input.number)
+  end
+end
+
+class UpdateIntegerTestEntity < OdataDuty::EntityType
+  property_ref 'id', Integer, computed: false
+  property 'string', String
+end
+
+class UpdateIntegerTestSet < OdataDuty::EntitySet
+  entity_type UpdateIntegerTestEntity
+
+  def update(id, input)
+    return nil unless id == 1
+
+    OpenStruct.new(id: id, string: input.string)
+  end
+end
+
+class DoesNotSupportUpdateSet < OdataDuty::EntitySet
+  entity_type UpdateScalarsTestEntity
+end
+
+class UpdateTestSchema < OdataDuty::Schema
+  base_url 'http://localhost:3000/api'
+  entity_sets [UpdateScalarsTestSet, UpdateIntegerTestSet, DoesNotSupportUpdateSet]
+end
+
+RSpec.describe OdataDuty::EntitySet, 'Can update' do
+  subject(:schema) { UpdateTestSchema }
+
+  describe '#update' do
+    let(:query_options) { { 'string' => 'Alice Updated' } }
+    let(:response) do
+      json_string = schema.update("UpdateScalarsTest('1')", context: Context.new,
+                                                            query_options: query_options)
+      Oj.load(json_string)
+    end
+
+    it 'returns the updated entity with individual @odata.context' do
+      expect(response).to eq(
+        '@odata.context' => 'http://localhost:3000/api/$metadata#UpdateScalarsTest/$entity',
+        '@odata.id' => 'http://localhost:3000/api/UpdateScalarsTest(\'1\')',
+        'id' => '1',
+        'string' => 'Alice Updated',
+        'number' => nil
+      )
+    end
+
+    it 'reads omitted fields as nil' do
+      query_options.delete('string')
+      expect(response).to include('string' => nil)
+    end
+
+    it 'coerces the integer key to Integer' do
+      json_string = schema.update('UpdateIntegerTest(1)', context: Context.new,
+                                                          query_options: { 'string' => 'x' })
+      expect(Oj.load(json_string)).to include('id' => 1, 'string' => 'x')
+    end
+
+    context 'body value cannot be coerced' do
+      it do
+        query_options['number'] = 'not-a-number'
+        expect { response }.to raise_error(OdataDuty::InvalidType)
+      end
+    end
+
+    context 'key does not exist' do
+      it do
+        expect do
+          schema.update('UpdateIntegerTest(999)', context: Context.new, query_options: {})
+        end.to raise_error(OdataDuty::ResourceNotFoundError)
+      end
+    end
+
+    context 'invalid key in url' do
+      it do
+        expect do
+          schema.update('UpdateIntegerTest(abc)', context: Context.new, query_options: {})
+        end.to raise_error(OdataDuty::InvalidPropertyReferenceValue)
+      end
+    end
+
+    context 'does not support update' do
+      it do
+        expect do
+          schema.update("DoesNotSupportUpdate('1')", context: Context.new, query_options: {})
+        end.to raise_error(OdataDuty::NoImplementationError)
+      end
+    end
+  end
+end

--- a/spec/odata_duty/schema_builder/entity_set/update/mcp_spec.rb
+++ b/spec/odata_duty/schema_builder/entity_set/update/mcp_spec.rb
@@ -1,0 +1,91 @@
+require 'spec_helper'
+
+class UpdateMcpWidgetResolver < OdataDuty::SetResolver
+  def update(id, params)
+    Struct.new(:id, :name, :sku).new(id, params.name, params.sku)
+  end
+end
+
+class UpdateMcpPersonResolver < OdataDuty::SetResolver
+end
+
+module OdataDuty
+  RSpec.describe SchemaBuilder::EntitySet, 'MCP update tool' do
+    subject(:schema) do
+      SchemaBuilder.build(namespace: 'SampleSpace', host: 'localhost', base_path: '') do |s|
+        entity = s.add_entity_type(name: 'UpdateMcpWidgetEntity') do |et|
+          et.property_ref 'id', String
+          et.property 'name', String
+          et.property 'sku', String, nullable: false
+        end
+
+        s.add_entity_set(name: 'Widgets', entity_type: entity,
+                         resolver: 'UpdateMcpWidgetResolver')
+        s.add_entity_set(name: 'People', entity_type: entity,
+                         resolver: 'UpdateMcpPersonResolver')
+      end
+    end
+
+    let(:mcp_server) do
+      server = schema.to_mcp_server
+      server.server_context = { context: Context.new }
+      server
+    end
+
+    def call(payload)
+      Oj.load(mcp_server.handle_json(Oj.dump(payload)))
+    end
+
+    describe 'tools/list' do
+      let(:request_payload) do
+        { 'jsonrpc' => '2.0', 'method' => 'tools/list', 'params' => {}, 'id' => 'tl-1' }
+      end
+
+      let(:tools) { call(request_payload)['result']['tools'] }
+
+      it 'includes an update tool for entity sets that support update' do
+        expect(tools).to include(
+          'name' => 'update_Widgets',
+          'description' => 'Update an existing Widgets record',
+          'inputSchema' => {
+            '$schema' => 'https://json-schema.org/draft/2020-12/schema',
+            'type' => 'object',
+            'properties' => {
+              'id' => { 'type' => 'string', 'readOnly' => true },
+              'name' => { 'type' => 'string', 'x-nullable' => true },
+              'sku' => { 'type' => 'string' }
+            },
+            'required' => ['id']
+          }
+        )
+      end
+
+      it 'does not include an update tool for read-only entity sets' do
+        expect(tools.map { |t| t['name'] }).not_to include('update_People')
+      end
+    end
+
+    describe 'tools/call for update' do
+      let(:request_payload) do
+        { 'jsonrpc' => '2.0', 'method' => 'tools/call',
+          'params' => { 'name' => 'update_Widgets',
+                        'arguments' => { 'id' => 'w1', 'name' => 'Updated', 'sku' => 'SKU1' } },
+          'id' => 'tc-1' }
+      end
+
+      it 'updates the record and returns it as structured JSON' do
+        result = call(request_payload)['result']
+        record = Oj.load(result['content'][0]['text'])
+
+        expect(result['isError']).to be(false)
+        expect(record).to include('id' => 'w1', 'name' => 'Updated')
+      end
+
+      it 'returns a tool-not-found error for an update tool on a read-only set' do
+        request_payload['params']['name'] = 'update_People'
+
+        expect(call(request_payload)['error']['code']).to eq(-32_602)
+      end
+    end
+  end
+end

--- a/spec/odata_duty/schema_builder/entity_set/update/metadata_spec.rb
+++ b/spec/odata_duty/schema_builder/entity_set/update/metadata_spec.rb
@@ -1,0 +1,50 @@
+require 'spec_helper'
+
+class UpdatableMetadataResolver < OdataDuty::SetResolver
+  def update(id, params)
+    [id, params]
+  end
+end
+
+class ReadOnlyUpdateMetadataResolver < OdataDuty::SetResolver
+end
+
+module OdataDuty
+  RSpec.describe SchemaBuilder::EntitySet, 'UpdateRestrictions metadata' do
+    subject(:metadata_xml) do
+      SchemaBuilder.build(namespace: 'SampleSpace', host: 'localhost', base_path: '/api') do |s|
+        entity = s.add_entity_type(name: 'UpdateMetadataTestEntity') do |et|
+          et.property_ref 'id', String
+          et.property 'name', String
+        end
+
+        s.add_entity_set(name: 'UpdatableMetadata', entity_type: entity,
+                         resolver: 'UpdatableMetadataResolver')
+        s.add_entity_set(name: 'ReadOnlyUpdateMetadata', entity_type: entity,
+                         resolver: 'ReadOnlyUpdateMetadataResolver')
+      end.metadata_xml
+    end
+
+    describe '#metadata' do
+      it 'includes UpdateRestrictions annotation for read-only entity sets' do
+        read_only_xml = metadata_xml.split('<EntitySet Name="ReadOnlyUpdateMetadata"')[1]
+                                    .split('</EntitySet>')[0]
+        expect(read_only_xml).to include('Term="Capabilities.UpdateRestrictions"')
+        expect(read_only_xml).to include('Property="Updatable" Bool="false"')
+      end
+
+      it 'does not include UpdateRestrictions annotation for updatable entity sets' do
+        updatable_xml = metadata_xml.split('<EntitySet Name="UpdatableMetadata"')[1]
+                                    .split('</EntitySet>')[0]
+        expect(updatable_xml).not_to include('Capabilities.UpdateRestrictions')
+      end
+
+      it 'includes both Insert and Update restrictions for read-only entity sets' do
+        read_only_xml = metadata_xml.split('<EntitySet Name="ReadOnlyUpdateMetadata"')[1]
+                                    .split('</EntitySet>')[0]
+        expect(read_only_xml).to include('Term="Capabilities.InsertRestrictions"')
+        expect(read_only_xml).to include('Term="Capabilities.UpdateRestrictions"')
+      end
+    end
+  end
+end

--- a/spec/odata_duty/schema_builder/entity_set/update/oas2_spec.rb
+++ b/spec/odata_duty/schema_builder/entity_set/update/oas2_spec.rb
@@ -1,0 +1,79 @@
+require 'spec_helper'
+
+class UpdatableBuilderOas2Resolver < OdataDuty::SetResolver
+  def individual(id)
+    { 'id' => id, 'name' => 'x' }
+  end
+
+  def update(id, params)
+    [id, params]
+  end
+end
+
+class ReadOnlyBuilderUpdateOas2Resolver < OdataDuty::SetResolver
+  def individual(id)
+    { 'id' => id, 'name' => 'x' }
+  end
+end
+
+RSpec.describe OdataDuty::SchemaBuilder, 'gates $oas2 patch on update support' do
+  let(:oas2_schema) do
+    OdataDuty::SchemaBuilder.build(namespace: 'SampleSpace', host: 'localhost',
+                                   base_path: '/api') do |s|
+      entity = s.add_entity_type(name: 'UpdateOas2BuilderTestEntity') do |et|
+        et.property_ref 'id', String
+        et.property 'name', String
+      end
+
+      s.add_entity_set(name: 'UpdatableBuilderOas2', entity_type: entity,
+                       resolver: 'UpdatableBuilderOas2Resolver')
+      s.add_entity_set(name: 'ReadOnlyBuilderUpdateOas2', entity_type: entity,
+                       resolver: 'ReadOnlyBuilderUpdateOas2Resolver')
+    end
+  end
+
+  let(:json) { OdataDuty::OAS2.build_json(oas2_schema, context: Context.new) }
+
+  describe '/UpdatableBuilderOas2({id})' do
+    let(:path) { json['paths']['/UpdatableBuilderOas2({id})'] }
+
+    it 'includes a patch operation when update is supported' do
+      expect(path).to have_key('patch')
+    end
+
+    it 'uses an Update operationId for the patch operation' do
+      expect(path['patch']['operationId']).to eq('UpdateUpdatableBuilderOas2')
+    end
+
+    it 'requires an id path parameter and a body parameter' do
+      expect(path['patch']['parameters']).to eq(
+        [
+          { 'name' => 'id', 'in' => 'path', 'required' => true, 'type' => 'string' },
+          { 'name' => 'body', 'in' => 'body', 'required' => true,
+            'schema' => { '$ref' => '#/definitions/UpdateOas2BuilderTestEntity' } }
+        ]
+      )
+    end
+
+    it 'exposes 200 and default responses' do
+      expect(path['patch']['responses']).to eq(
+        '200' => { 'description' => 'Success',
+                   'schema' => { '$ref' => '#/definitions/UpdateOas2BuilderTestEntity' } },
+        'default' => { 'description' => 'Unexpected error',
+                       'schema' => { '$ref' => '#/definitions/Error' } }
+      )
+    end
+  end
+
+  describe '/ReadOnlyBuilderUpdateOas2({id})' do
+    let(:path) { json['paths']['/ReadOnlyBuilderUpdateOas2({id})'] }
+
+    it 'includes a get operation' do
+      expect(path).to have_key('get')
+    end
+
+    it 'does not include a patch operation when update is not supported' do
+      expect(path).not_to have_key('patch')
+    end
+  end
+end

--- a/spec/odata_duty/schema_builder/entity_set/update/with_scalars_spec.rb
+++ b/spec/odata_duty/schema_builder/entity_set/update/with_scalars_spec.rb
@@ -1,0 +1,104 @@
+require 'spec_helper'
+
+class UpdateScalarsTestResolver < OdataDuty::SetResolver
+  def update(id, input)
+    OpenStruct.new(id: id, string: input.string, number: input.number)
+  end
+end
+
+class UpdateIntegerTestResolver < OdataDuty::SetResolver
+  def update(id, input)
+    return nil unless id == 1
+
+    OpenStruct.new(id: id, string: input.string)
+  end
+end
+
+class DoesNotSupportUpdateResolver < OdataDuty::SetResolver
+end
+
+module OdataDuty
+  RSpec.describe SchemaBuilder::EntitySet, 'Can update' do
+    subject(:schema) do
+      SchemaBuilder.build(namespace: 'SampleSpace', host: 'localhost', base_path: '') do |s|
+        string_entity = s.add_entity_type(name: 'UpdateScalarsTestEntity') do |et|
+          et.property_ref 'id', String, computed: false
+          et.property 'string', String
+          et.property 'number', Integer
+        end
+        integer_entity = s.add_entity_type(name: 'UpdateIntegerTestEntity') do |et|
+          et.property_ref 'id', Integer, computed: false
+          et.property 'string', String
+        end
+
+        s.add_entity_set(name: 'UpdateScalarsTest', entity_type: string_entity,
+                         resolver: 'UpdateScalarsTestResolver')
+        s.add_entity_set(name: 'UpdateIntegerTest', entity_type: integer_entity,
+                         resolver: 'UpdateIntegerTestResolver')
+        s.add_entity_set(name: 'DoesNotSupportUpdate', entity_type: string_entity,
+                         resolver: 'DoesNotSupportUpdateResolver')
+      end
+    end
+
+    describe '#update' do
+      let(:query_options) { { 'string' => 'Alice Updated' } }
+      let(:response) do
+        json_string = schema.update("UpdateScalarsTest('1')", context: Context.new,
+                                                              query_options: query_options)
+        Oj.load(json_string)
+      end
+
+      it 'returns the updated entity with individual @odata.context' do
+        expect(response).to eq(
+          '@odata.context' => 'https://localhost/$metadata#UpdateScalarsTest/$entity',
+          '@odata.id' => 'https://localhost/UpdateScalarsTest(\'1\')',
+          'id' => '1',
+          'string' => 'Alice Updated',
+          'number' => nil
+        )
+      end
+
+      it 'reads omitted fields as nil' do
+        query_options.delete('string')
+        expect(response).to include('string' => nil)
+      end
+
+      it 'coerces the integer key to Integer' do
+        json_string = schema.update('UpdateIntegerTest(1)', context: Context.new,
+                                                            query_options: { 'string' => 'x' })
+        expect(Oj.load(json_string)).to include('id' => 1, 'string' => 'x')
+      end
+
+      context 'body value cannot be coerced' do
+        it do
+          query_options['number'] = 'not-a-number'
+          expect { response }.to raise_error(OdataDuty::InvalidType)
+        end
+      end
+
+      context 'key does not exist' do
+        it do
+          expect do
+            schema.update('UpdateIntegerTest(999)', context: Context.new, query_options: {})
+          end.to raise_error(OdataDuty::ResourceNotFoundError)
+        end
+      end
+
+      context 'invalid key in url' do
+        it do
+          expect do
+            schema.update('UpdateIntegerTest(abc)', context: Context.new, query_options: {})
+          end.to raise_error(OdataDuty::InvalidPropertyReferenceValue)
+        end
+      end
+
+      context 'does not support update' do
+        it do
+          expect do
+            schema.update("DoesNotSupportUpdate('1')", context: Context.new, query_options: {})
+          end.to raise_error(OdataDuty::NoImplementationError)
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Evolve doc/using_create.md into a single 'Using create and update' guide that
presents update alongside create throughout: inferred availability, the
update(id, input) hook contract and partial-merge semantics, the schema.update
entry point and Rails PATCH wiring, a REST PATCH example, and the reflections
in $oas2 (patch with operationId Update&lt;Set&gt;), $metadata (UpdateRestrictions
for non-updatable sets), and MCP (update_&lt;Set&gt; tool). Common Error Cases now
cover both verbs. Update the README Further Documentation link and inline
reference to the combined guide (target unchanged).

Co-Authored-By: Claude Opus 4.8 (1M context) &lt;noreply@anthropic.com&gt;