### PR TITLE
Document create/update error behavior and bump to 0.20.1 (PRD task 3)

### DIFF
--- a/doc/prds/task-tha318dgaxbwdjDxzs-plan.md
+++ b/doc/prds/task-tha318dgaxbwdjDxzs-plan.md
@@ -49,7 +49,7 @@ already exist for both DSLs.
   `spec/odata_duty/entity_set/delete/with_scalars_spec.rb:88` and
   `spec/odata_duty/schema_builder/entity_set/delete/with_scalars_spec.rb:86`.
 
-- [ ] **Task 2 — Fix `update`: gate on `supports_update?`, stop masking `NoMethodError`**
+- [x] **Task 2 — Fix `update`: gate on `supports_update?`, stop masking `NoMethodError`**
 
   Task text: Change `Executor#update` (`lib/odata_duty/executor.rb`) the same way as Task 1:
   raise `NoImplementationError, "update not implemented for #{endpoint.url}"` up front when

--- a/doc/prds/task-tha318dgaxbwdjDxzs-plan.md
+++ b/doc/prds/task-tha318dgaxbwdjDxzs-plan.md
@@ -77,7 +77,7 @@ already exist for both DSLs.
 
   Dependencies: Task 1 (same file `#create` already gated — keep `#update` symmetric).
 
-- [ ] **Task 3 — Documentation note + patch version bump**
+- [x] **Task 3 — Documentation note + patch version bump**
 
   Task text: Extend `doc/using_create_update_and_delete.md` **Common Error Cases** section with a
   note (parallel to the existing "not implemented" bullet) clarifying that a `NoMethodError`

--- a/doc/prds/task-tha318dgaxbwdjDxzs-plan.md
+++ b/doc/prds/task-tha318dgaxbwdjDxzs-plan.md
@@ -49,7 +49,7 @@ already exist for both DSLs.
   `spec/odata_duty/entity_set/delete/with_scalars_spec.rb:88` and
   `spec/odata_duty/schema_builder/entity_set/delete/with_scalars_spec.rb:86`.
 
-- [x] **Task 2 — Fix `update`: gate on `supports_update?`, stop masking `NoMethodError`**
+- [ ] **Task 2 — Fix `update`: gate on `supports_update?`, stop masking `NoMethodError`**
 
   Task text: Change `Executor#update` (`lib/odata_duty/executor.rb`) the same way as Task 1:
   raise `NoImplementationError, "update not implemented for #{endpoint.url}"` up front when
@@ -77,7 +77,7 @@ already exist for both DSLs.
 
   Dependencies: Task 1 (same file `#create` already gated — keep `#update` symmetric).
 
-- [x] **Task 3 — Documentation note + patch version bump**
+- [ ] **Task 3 — Documentation note + patch version bump**
 
   Task text: Extend `doc/using_create_update_and_delete.md` **Common Error Cases** section with a
   note (parallel to the existing "not implemented" bullet) clarifying that a `NoMethodError`

--- a/doc/prds/task-tha318dgaxbwdjDxzs-plan.md
+++ b/doc/prds/task-tha318dgaxbwdjDxzs-plan.md
@@ -1,0 +1,95 @@
+# Build plan — Stop masking `create` / `update` implementation errors
+
+PRD: [task-tha318dgaxbwdjDxzs.md](./task-tha318dgaxbwdjDxzs.md)
+
+## Overview
+
+`Executor#create` / `Executor#update` currently call the consumer's data method and
+blanket-rescue `NoMethodError`, re-labeling *every* `NoMethodError` (including bugs inside the
+consumer's own code) as `NoImplementationError`. `delete` already does the right thing: it gates
+on the `supports_delete?` capability predicate up front and lets any `NoMethodError` from the
+consumer bubble up. This plan makes `create` and `update` mirror `delete`.
+
+The production change is in a single shared file — `lib/odata_duty/executor.rb` — which both DSLs
+route through, so there is no separate class-DSL vs builder-DSL production change. Tests, however,
+must be added to **both** spec trees (`spec/odata_duty/entity_set/**` and
+`spec/odata_duty/schema_builder/**`). The `supports_create?` / `supports_update?` predicates
+already exist for both DSLs.
+
+## Tasks
+
+- [x] **Task 1 — Fix `create`: gate on `supports_create?`, stop masking `NoMethodError`**
+
+  Task text: Change `Executor#create` (`lib/odata_duty/executor.rb`) to mirror `Executor#delete`:
+  raise `NoImplementationError, "create not implemented for #{endpoint.url}"` up front when
+  `!endpoint.supports_create?`, then call `endpoint.create` *without* a `rescue NoMethodError`,
+  so a `NoMethodError` raised inside the consumer's own `create` propagates unchanged (message +
+  backtrace preserved). The genuinely-missing-`create` case keeps the identical message, now
+  produced by the capability gate. Add TDD tests to **both** spec trees proving (a) a consumer
+  `create` that raises `NoMethodError` propagates that `NoMethodError` (not
+  `NoImplementationError`), and (b) a set without `create` still raises `NoImplementationError`
+  with the same message. The existing "does not support create" tests already cover (b) — add the
+  new "genuine NoMethodError inside create" case mirroring the existing delete spec.
+
+  Likely files:
+  - `lib/odata_duty/executor.rb` (`#create`)
+  - `spec/odata_duty/entity_set/create/with_scalars_spec.rb` (add `CreateRaisesTestSet` + test)
+  - `spec/odata_duty/schema_builder/entity_set/create/with_scalars_spec.rb`
+    (add `CreateRaisesTestResolver` + test)
+
+  PRD excerpt — After:
+  ```ruby
+  schema.create("People", context: ctx, query_options: { "name" => "Alice" })
+  # => raises NoMethodError: undefined method `creat!' for Person (consumer's real error)
+  ```
+  Unchanged genuinely-missing: `schema.create("Countries", ...)` →
+  `OdataDuty::NoImplementationError: create not implemented for Countries`.
+
+  Dependencies: none. Mirror the existing delete precedent in
+  `spec/odata_duty/entity_set/delete/with_scalars_spec.rb:88` and
+  `spec/odata_duty/schema_builder/entity_set/delete/with_scalars_spec.rb:86`.
+
+- [x] **Task 2 — Fix `update`: gate on `supports_update?`, stop masking `NoMethodError`**
+
+  Task text: Change `Executor#update` (`lib/odata_duty/executor.rb`) the same way as Task 1:
+  raise `NoImplementationError, "update not implemented for #{endpoint.url}"` up front when
+  `!endpoint.supports_update?`, then call `endpoint.update` *without* a `rescue NoMethodError`.
+  A `NoMethodError` inside the consumer's `update` propagates unchanged. The genuinely-missing
+  case keeps the identical message via the capability gate. The existing `ResourceNotFoundError`
+  (falsey return) and key-coercion error paths must remain unchanged. Add TDD tests to **both**
+  spec trees: (a) consumer `update` raising `NoMethodError` propagates it, (b) set without
+  `update` still raises `NoImplementationError` (already covered), and confirm the
+  `ResourceNotFoundError` path still works.
+
+  Likely files:
+  - `lib/odata_duty/executor.rb` (`#update`)
+  - `spec/odata_duty/entity_set/update/with_scalars_spec.rb` (add `UpdateRaisesTestSet` + test)
+  - `spec/odata_duty/schema_builder/entity_set/update/with_scalars_spec.rb`
+    (add `UpdateRaisesTestResolver` + test)
+
+  PRD excerpt — After:
+  ```ruby
+  schema.update("People('1')", context: ctx, query_options: { "name" => "Alice" })
+  # => raises NoMethodError: undefined method `touchh' for #<Person ...> (consumer's real error)
+  ```
+  Unchanged: missing `update` → `NoImplementationError: update not implemented for <url>`;
+  falsey return → `ResourceNotFoundError`.
+
+  Dependencies: Task 1 (same file `#create` already gated — keep `#update` symmetric).
+
+- [x] **Task 3 — Documentation note + patch version bump**
+
+  Task text: Extend `doc/using_create_update_and_delete.md` **Common Error Cases** section with a
+  note (parallel to the existing "not implemented" bullet) clarifying that a `NoMethodError`
+  raised *inside* a consumer's `create` / `update` propagates unchanged and is **not** rewritten
+  to `NoImplementationError` — consistent with `delete`. Bump `spec.version` in
+  `odata_duty.gemspec` from `0.20.0` to `0.20.1`.
+
+  Likely files:
+  - `doc/using_create_update_and_delete.md`
+  - `odata_duty.gemspec`
+
+  PRD excerpt — Documentation impact / Scope: "Patch version bump in `odata_duty.gemspec`
+  (`0.20.0` → `0.20.1`)."
+
+  Dependencies: Tasks 1 & 2 (documents the behavior they implement).

--- a/doc/prds/task-tha318dgaxbwdjDxzs.md
+++ b/doc/prds/task-tha318dgaxbwdjDxzs.md
@@ -1,0 +1,198 @@
+# Stop masking `create` / `update` implementation errors
+
+## Summary
+
+When a writable entity set's `create` or `update` implementation raises a `NoMethodError`
+internally, OdataDuty currently swallows it and re-raises a misleading
+`NoImplementationError` ("create not implemented for …"). This PRD makes `create` and
+`update` behave like `delete` already does: decide "is this operation implemented?" from the
+`supports_create?` / `supports_update?` capability check, and let any `NoMethodError` thrown
+*inside* the consumer's own code bubble up unchanged.
+
+## Goal / Problem
+
+`delete` distinguishes "the set has no `delete` method" from "the consumer's `delete` blew up"
+by gating on the capability predicate first and only then calling the data method:
+
+```ruby
+# Executor#delete (today)
+unless endpoint.supports_delete?
+  raise NoImplementationError, "delete not implemented for #{endpoint.url}"
+end
+# ... calls endpoint.delete; any NoMethodError it raises propagates as-is
+```
+
+`create` and `update` do **not** do this. They call the data method and blanket-rescue
+`NoMethodError`, re-labeling *every* `NoMethodError` — including bugs deep inside the
+consumer's own `create`/`update` — as "not implemented":
+
+```ruby
+# Executor#create (today)
+def create
+  Oj.dump(endpoint.create(context: wrapped_context).merge(...), mode: :compat)
+rescue NoMethodError
+  raise NoImplementationError, "create not implemented for #{endpoint.url}"
+end
+```
+
+**Current (wrong) behavior:** A consumer whose `create` calls `Person.creat!(...)` (typo) or
+references an undefined helper sees `OdataDuty::NoImplementationError: create not implemented
+for People`, with the real `NoMethodError` and its backtrace discarded. The error points at
+the framework, not at the bug.
+
+**Expected behavior:** That `NoMethodError` propagates with its original message and backtrace.
+`NoImplementationError` is raised **only** when the set genuinely does not define `create` /
+`update` — determined up front by `supports_create?` / `supports_update?`, never by catching a
+`NoMethodError` after the fact.
+
+## What it enables
+
+- As a gem consumer, when I have a bug in my `create` or `update` implementation (a typo, a
+  call to a method that doesn't exist, a `nil` where I expected an object), I see the actual
+  `NoMethodError` from my code instead of a misleading "not implemented" message — so I can
+  find and fix it.
+- As a gem consumer, the diagnostic story is now uniform across all three writes (`create`,
+  `update`, `delete`): "operation absent" is one error, "your code raised" is another, and the
+  two are never conflated.
+
+Scope limit: this changes only *which* error surfaces when a consumer's `create`/`update`
+raises `NoMethodError`. The behavior for a set that legitimately lacks `create`/`update` is
+unchanged — same `NoImplementationError`, same message.
+
+## External API
+
+No new DSL, hook, or query option. This is a fix to the observable error behavior of the
+existing `create` / `update` operations, reached through the existing public entry points
+`Schema.create` / `Schema.update` (POST / PATCH) and the MCP `create_<Set>` / `update_<Set>`
+tools.
+
+Writability is still inferred exactly as documented in
+[`doc/using_create_update_and_delete.md`](../using_create_update_and_delete.md): a set is
+creatable iff it defines `create`, updatable iff it defines `update`. The capability checks
+already exist for both DSLs (`supports_create?` / `supports_update?`), so no consumer-facing
+declaration changes.
+
+Both DSLs are covered, because the shared GET/write executor is what changes:
+
+```ruby
+# Builder DSL (OdataDuty::SetResolver) — a buggy create
+class PeopleResolver < OdataDuty::SetResolver
+  def create(input)
+    Person.creat!(name: input.name)   # typo: NoMethodError raised inside consumer code
+  end
+end
+```
+
+```ruby
+# Class DSL (OdataDuty::EntitySet) — a buggy update
+class PeopleSet < OdataDuty::EntitySet
+  entity_type PersonEntity
+
+  def update(id, input)
+    record = @records.find(id)
+    record.touchh                       # typo: NoMethodError raised inside consumer code
+    record
+  end
+end
+```
+
+## Behavior & expected I/O
+
+### Before (current)
+
+```ruby
+schema.create("People", context: ctx, query_options: { "name" => "Alice" })
+# => raises OdataDuty::NoImplementationError: create not implemented for People
+#    (the real NoMethodError from `Person.creat!` is lost)
+
+schema.update("People('1')", context: ctx, query_options: { "name" => "Alice" })
+# => raises OdataDuty::NoImplementationError: update not implemented for People
+#    (the real NoMethodError from `record.touchh` is lost)
+```
+
+### After (fixed)
+
+```ruby
+schema.create("People", context: ctx, query_options: { "name" => "Alice" })
+# => raises NoMethodError: undefined method `creat!' for Person
+#    (the consumer's real error, with its original backtrace)
+
+schema.update("People('1')", context: ctx, query_options: { "name" => "Alice" })
+# => raises NoMethodError: undefined method `touchh' for #<Person ...>
+#    (the consumer's real error, with its original backtrace)
+```
+
+### Unchanged: genuinely-missing operation
+
+For a read-only set (no `create` / no `update`), the error is identical before and after — now
+produced by the capability gate rather than a rescued `NoMethodError`:
+
+```ruby
+# Set defines neither create nor update
+schema.create("Countries", context: ctx, query_options: { ... })
+# => raises OdataDuty::NoImplementationError: create not implemented for Countries
+
+schema.update("Countries('1')", context: ctx, query_options: { ... })
+# => raises OdataDuty::NoImplementationError: update not implemented for Countries
+```
+
+### Unchanged: successful write
+
+A correct `create` / `update` still returns the affected entity, mapper-rendered with the
+`@odata.context` anchor, exactly as documented today — no change to the success path.
+
+### Generated contracts
+
+No change to `$metadata`, `$oas2`, the index document, or the MCP `tools/list` shapes. Insert/
+update capability is still advertised via the presence of the method
+(`InsertRestrictions` / `UpdateRestrictions` annotations, `post` / `patch` operations, and the
+`create_<Set>` / `update_<Set>` tools), exactly as
+[`doc/using_create_update_and_delete.md`](../using_create_update_and_delete.md) describes.
+
+## Common error cases
+
+- **`POST` to a set without `create` / `PATCH` to a set without `update`:** raises
+  `OdataDuty::NoImplementationError` with `create not implemented for <url>` /
+  `update not implemented for <url>` (the set's URL, e.g. `create not implemented for People`).
+  Same message as today; now produced by the `supports_create?` / `supports_update?` gate.
+- **Consumer's `create` / `update` raises `NoMethodError`:** that `NoMethodError` now
+  propagates unchanged (message + backtrace preserved). It is **no longer** rewritten to
+  `NoImplementationError`. This is the behavioral change.
+- **`PATCH` for a key that doesn't exist:** unchanged — when `update` returns falsey the
+  framework raises `OdataDuty::ResourceNotFoundError` (`No such entity <id>`).
+- **Invalid key in the `PATCH` URL / body that fails coercion:** unchanged —
+  `OdataDuty::InvalidPropertyReferenceValue` for a bad key, `OdataDuty::InvalidType` for a
+  wrong-typed body value, `OdataDuty::NoSuchPropertyError` for accessing an undefined property
+  on the input object.
+- **MCP `create_<Set>` / `update_<Set>` for a set lacking the capability:** unchanged — the
+  tool is never listed, so `tools/call` raises `"Unknown tool: <tool>"`.
+
+## Scope
+
+**In:**
+- `create` and `update` decide "implemented?" via the existing capability predicates
+  (`supports_create?` / `supports_update?`) up front, and stop blanket-rescuing `NoMethodError`
+  from the consumer's data method — mirroring `delete`.
+- Applies to **both** DSLs (class-based and builder), since the shared write executor is what
+  changes and both DSLs already expose `supports_create?` / `supports_update?`.
+- Patch version bump in `odata_duty.gemspec` (`0.20.0` → `0.20.1`).
+
+**Out:**
+- No change to the success path, the `$metadata` / `$oas2` / index / MCP outputs, or any DSL
+  declaration / hook.
+- No change to `delete` (already correct) or to non-write operations (`collection`,
+  `individual`, `count`).
+- No change to `NoImplementationError`'s message text for a genuinely-missing operation.
+
+## Documentation impact
+
+Extend [`doc/using_create_update_and_delete.md`](../using_create_update_and_delete.md): in its
+**Common Error Cases** section, add a note (parallel to the existing "not implemented" bullet)
+clarifying that a `NoMethodError` raised *inside* a consumer's `create` / `update` propagates
+unchanged and is **not** rewritten to `NoImplementationError` — so a real bug in the
+implementation surfaces as the real error, consistent with `delete`. No new guide needed.
+
+## Open questions
+
+None. The design follows the established `delete` precedent and the predicates it relies on
+already exist for both DSLs.

--- a/doc/using_create_update_and_delete.md
+++ b/doc/using_create_update_and_delete.md
@@ -432,7 +432,10 @@ A read-only set advertises none of these tools, so calling one raises an "Unknow
 ## Common Error Cases
 
 - **`POST` to a set without `create` / `PATCH` to a set without `update` / `DELETE` to a set without `delete`:**
-  Raises `OdataDuty::NoImplementationError` with the message `create not implemented for <url>`, `update not implemented for <url>`, or `delete not implemented for <url>` respectively (the set's URL, e.g. `delete not implemented for People`).
+  Raises `OdataDuty::NoImplementationError` with the message `create not implemented for <url>`, `update not implemented for <url>`, or `delete not implemented for <url>` respectively (the set's URL, e.g. `delete not implemented for People`). This `NoImplementationError` is raised only when the set genuinely does not define the operation, determined up front by a capability check.
+
+- **A `NoMethodError` raised *inside* your `create` / `update`:**
+  A `NoMethodError` that originates within your own `create` or `update` implementation (a typo, a call to an undefined method, a `nil` where an object was expected) propagates unchanged — with its original message and backtrace — and is **not** rewritten to `NoImplementationError`. So a real bug in your implementation surfaces as the real `NoMethodError`, consistent with how `delete` already behaves.
 
 - **`PATCH` / `DELETE` for a key that doesn't exist:**
   When your `update` or `delete` cannot find the record and returns a falsey value, the framework raises `OdataDuty::ResourceNotFoundError` (`No such entity <id>`), the same way `individual` does for a missing record.

--- a/lib/odata_duty/executor.rb
+++ b/lib/odata_duty/executor.rb
@@ -60,6 +60,10 @@ module OdataDuty
     end
 
     def update
+      unless endpoint.supports_update?
+        raise NoImplementationError, "update not implemented for #{endpoint.url}"
+      end
+
       entity_id = extract_value_from_brackets(url)
       Oj.dump(endpoint
           .update(entity_id, context: wrapped_context)
@@ -68,8 +72,6 @@ module OdataDuty
                                                           anchor: "#{endpoint.name}/$entity")
           ),
               mode: :compat)
-    rescue NoMethodError
-      raise NoImplementationError, "update not implemented for #{endpoint.url}"
     end
 
     def delete

--- a/lib/odata_duty/executor.rb
+++ b/lib/odata_duty/executor.rb
@@ -46,6 +46,10 @@ module OdataDuty
     end
 
     def create
+      unless endpoint.supports_create?
+        raise NoImplementationError, "create not implemented for #{endpoint.url}"
+      end
+
       Oj.dump(endpoint
           .create(context: wrapped_context)
           .merge(
@@ -53,8 +57,6 @@ module OdataDuty
                                                           anchor: "#{endpoint.name}/$entity")
           ),
               mode: :compat)
-    rescue NoMethodError
-      raise NoImplementationError, "create not implemented for #{endpoint.url}"
     end
 
     def update

--- a/odata_duty.gemspec
+++ b/odata_duty.gemspec
@@ -2,7 +2,7 @@
 
 Gem::Specification.new do |spec|
   spec.name          = 'odata_duty'
-  spec.version       = '0.20.0'
+  spec.version       = '0.20.1'
   spec.authors       = ['Grant Petersen-Speelman']
   spec.email         = ['grant@nexl.io']
 

--- a/spec/odata_duty/entity_set/create/with_scalars_spec.rb
+++ b/spec/odata_duty/entity_set/create/with_scalars_spec.rb
@@ -30,9 +30,17 @@ class DoesNotSupportCreateSet < OdataDuty::EntitySet
   entity_type CreateScalarsTestEntity
 end
 
+class CreateRaisesTestSet < OdataDuty::EntitySet
+  entity_type CreateScalarsTestEntity
+
+  def create(_input)
+    nil.genuinely_undefined_method_inside_create
+  end
+end
+
 class CreateTestSchema < OdataDuty::Schema
   base_url 'http://localhost:3000/api'
-  entity_sets [CreateScalarsTestSet, DoesNotSupportCreateSet]
+  entity_sets [CreateScalarsTestSet, DoesNotSupportCreateSet, CreateRaisesTestSet]
 end
 
 RSpec.describe OdataDuty::EntitySet, 'Can create' do
@@ -239,6 +247,15 @@ RSpec.describe OdataDuty::EntitySet, 'Can create' do
           schema.create('DoesNotSupportCreate', context: Context.new,
                                                 query_options: { 'id' => '1' })
         end.to raise_error(OdataDuty::NoImplementationError)
+      end
+    end
+
+    context 'genuine NoMethodError inside create' do
+      it 'is not masked as NoImplementationError' do
+        expect do
+          schema.create('CreateRaisesTest', context: Context.new,
+                                            query_options: { 'id' => '1' })
+        end.to raise_error(NoMethodError, /genuinely_undefined_method_inside_create/)
       end
     end
   end

--- a/spec/odata_duty/entity_set/update/with_scalars_spec.rb
+++ b/spec/odata_duty/entity_set/update/with_scalars_spec.rb
@@ -33,9 +33,18 @@ class DoesNotSupportUpdateSet < OdataDuty::EntitySet
   entity_type UpdateScalarsTestEntity
 end
 
+class UpdateRaisesTestSet < OdataDuty::EntitySet
+  entity_type UpdateScalarsTestEntity
+
+  def update(_id, _input)
+    nil.genuinely_undefined_method_inside_update
+  end
+end
+
 class UpdateTestSchema < OdataDuty::Schema
   base_url 'http://localhost:3000/api'
-  entity_sets [UpdateScalarsTestSet, UpdateIntegerTestSet, DoesNotSupportUpdateSet]
+  entity_sets [UpdateScalarsTestSet, UpdateIntegerTestSet, DoesNotSupportUpdateSet,
+               UpdateRaisesTestSet]
 end
 
 RSpec.describe OdataDuty::EntitySet, 'Can update' do
@@ -98,6 +107,14 @@ RSpec.describe OdataDuty::EntitySet, 'Can update' do
         expect do
           schema.update("DoesNotSupportUpdate('1')", context: Context.new, query_options: {})
         end.to raise_error(OdataDuty::NoImplementationError)
+      end
+    end
+
+    context 'genuine NoMethodError inside update' do
+      it 'is not masked as NoImplementationError' do
+        expect do
+          schema.update("UpdateRaisesTest('1')", context: Context.new, query_options: {})
+        end.to raise_error(NoMethodError, /genuinely_undefined_method_inside_update/)
       end
     end
   end

--- a/spec/odata_duty/schema_builder/entity_set/create/with_scalars_spec.rb
+++ b/spec/odata_duty/schema_builder/entity_set/create/with_scalars_spec.rb
@@ -13,6 +13,12 @@ end
 class DoesNotSupportCreateResolver < OdataDuty::SetResolver
 end
 
+class CreateRaisesTestResolver < OdataDuty::SetResolver
+  def create(_input)
+    nil.genuinely_undefined_method_inside_create
+  end
+end
+
 module OdataDuty
   RSpec.describe SchemaBuilder::EntitySet, 'Can create' do
     subject(:schema) do
@@ -35,6 +41,8 @@ module OdataDuty
                          resolver: 'CreateScalarsTestResolver')
         s.add_entity_set(name: 'DoesNotSupportCreate', entity_type: collection_entity,
                          resolver: 'DoesNotSupportCreateResolver')
+        s.add_entity_set(name: 'CreateRaisesTest', entity_type: collection_entity,
+                         resolver: 'CreateRaisesTestResolver')
       end
     end
 
@@ -239,6 +247,15 @@ module OdataDuty
             schema.create('DoesNotSupportCreate', context: Context.new,
                                                   query_options: { 'id' => '1' })
           end.to raise_error(OdataDuty::NoImplementationError)
+        end
+      end
+
+      context 'genuine NoMethodError inside create' do
+        it 'is not masked as NoImplementationError' do
+          expect do
+            schema.create('CreateRaisesTest', context: Context.new,
+                                              query_options: { 'id' => '1' })
+          end.to raise_error(NoMethodError, /genuinely_undefined_method_inside_create/)
         end
       end
     end

--- a/spec/odata_duty/schema_builder/entity_set/update/with_scalars_spec.rb
+++ b/spec/odata_duty/schema_builder/entity_set/update/with_scalars_spec.rb
@@ -17,6 +17,12 @@ end
 class DoesNotSupportUpdateResolver < OdataDuty::SetResolver
 end
 
+class UpdateRaisesTestResolver < OdataDuty::SetResolver
+  def update(_id, _input)
+    nil.genuinely_undefined_method_inside_update
+  end
+end
+
 module OdataDuty
   RSpec.describe SchemaBuilder::EntitySet, 'Can update' do
     subject(:schema) do
@@ -37,6 +43,8 @@ module OdataDuty
                          resolver: 'UpdateIntegerTestResolver')
         s.add_entity_set(name: 'DoesNotSupportUpdate', entity_type: string_entity,
                          resolver: 'DoesNotSupportUpdateResolver')
+        s.add_entity_set(name: 'UpdateRaisesTest', entity_type: string_entity,
+                         resolver: 'UpdateRaisesTestResolver')
       end
     end
 
@@ -97,6 +105,14 @@ module OdataDuty
           expect do
             schema.update("DoesNotSupportUpdate('1')", context: Context.new, query_options: {})
           end.to raise_error(OdataDuty::NoImplementationError)
+        end
+      end
+
+      context 'genuine NoMethodError inside update' do
+        it 'is not masked as NoImplementationError' do
+          expect do
+            schema.update("UpdateRaisesTest('1')", context: Context.new, query_options: {})
+          end.to raise_error(NoMethodError, /genuinely_undefined_method_inside_update/)
         end
       end
     end


### PR DESCRIPTION
Extend doc/using_create_update_and_delete.md Common Error Cases with a
note (parallel to the existing 'not implemented' bullet) clarifying
that a NoMethodError raised inside a consumer's create/update
propagates unchanged and is not rewritten to NoImplementationError,
consistent with delete. NoImplementationError is now raised only for a
genuinely-missing operation, determined up front by the capability
check. Bump spec.version from 0.20.0 to 0.20.1.

Co-Authored-By: Claude Opus 4.8 (1M context) &lt;noreply@anthropic.com&gt;