### PR TITLE
Add :non_insertable mutability value

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,7 +17,7 @@ Short index of what's implemented; see the linked `doc/` guide for the full cont
 - **`$search`** — AND/OR/NOT grammar via `od_search`; also drives the MCP search tool — `doc/using_search.md`.
 - **Paging** — `$top`/`$skip` and server-driven `@odata.nextLink` via `od_next_link_skiptoken`.
 - **Computed properties** — `doc/using_computed.md`.
-- **Property mutability** — `mutability: :immutable`/`:computed` per property (create/update settability + `Core` annotations) — `doc/using_mutability.md`.
+- **Property mutability** — `mutability: :immutable`/`:non_insertable`/`:computed` per property (create/update settability + `Core` annotations & `Capabilities.InsertRestrictions`) — `doc/using_mutability.md`.
 - **Init args** — pass per-request data into `od_after_init` — `doc/using_init_args.md`.
 - **MCP server** — tools/resources over JSON-RPC — `doc/using_mcp.md`, `doc/mcp_crash_course.md`.
 - **Rails generators** — `install` and `entity_set` — `doc/entity_set_generator.md`.

--- a/doc/prds/property-mutability-non-insertable-plan.md
+++ b/doc/prds/property-mutability-non-insertable-plan.md
@@ -55,7 +55,7 @@ and both spec trees.
 
 ## Task 2 — `$metadata`: `InsertRestrictions/NonInsertableProperties`
 
-- [ ] **Status**
+- [x] **Status** — done
 
 **Task text:** Emit each `:non_insertable` property as a `NonInsertableProperties` collection entry in the
 entity set's `Capabilities.InsertRestrictions` annotation. It must compose with the existing set-level

--- a/doc/prds/property-mutability-non-insertable-plan.md
+++ b/doc/prds/property-mutability-non-insertable-plan.md
@@ -91,7 +91,7 @@ Composes with the set-level `Insertable: false`. Metadata XML stays well-formed.
 
 ## Task 3 — Documentation + Features index
 
-- [ ] **Status**
+- [x] **Status** — done
 
 **Task text:** Extend `doc/using_mutability.md` with the `:non_insertable` row in the overview table and
 its create/update/`$metadata`/MCP behavior, including the note that `$oas2` is unchanged here (Part C).

--- a/doc/prds/property-mutability-non-insertable-plan.md
+++ b/doc/prds/property-mutability-non-insertable-plan.md
@@ -15,7 +15,7 @@ spec trees.
 
 ## Task 1 — Accept `:non_insertable`; settability drives typed input + MCP tools
 
-- [x] **Status**
+- [x] **Status** — done
 
 **Task text:** Add `:non_insertable` as a fourth accepted `mutability:` value. Update declaration-time
 validation so it is accepted and the rejected-symbol error message lists all four valid values
@@ -55,7 +55,7 @@ and both spec trees.
 
 ## Task 2 — `$metadata`: `InsertRestrictions/NonInsertableProperties`
 
-- [x] **Status**
+- [ ] **Status**
 
 **Task text:** Emit each `:non_insertable` property as a `NonInsertableProperties` collection entry in the
 entity set's `Capabilities.InsertRestrictions` annotation. It must compose with the existing set-level
@@ -91,7 +91,7 @@ Composes with the set-level `Insertable: false`. Metadata XML stays well-formed.
 
 ## Task 3 — Documentation + Features index
 
-- [x] **Status**
+- [ ] **Status**
 
 **Task text:** Extend `doc/using_mutability.md` with the `:non_insertable` row in the overview table and
 its create/update/`$metadata`/MCP behavior, including the note that `$oas2` is unchanged here (Part C).

--- a/doc/prds/property-mutability-non-insertable-plan.md
+++ b/doc/prds/property-mutability-non-insertable-plan.md
@@ -1,0 +1,106 @@
+# Build plan: Non-insertable (update-only) properties
+
+PRD: [`property-mutability-non-insertable.md`](property-mutability-non-insertable.md)
+
+Adds a fourth `mutability:` value, `:non_insertable` — settable on update, dropped on create,
+advertised as insert-restricted in `$metadata` and excluded from the MCP create tool. Builds on
+Part A (`:immutable`/`:computed`). `$oas2` is explicitly **out of scope** (Part C).
+
+Core mutability code (`lib/odata_duty/property.rb`, `property/single_prop.rb`) and the typed-input
+wrapper / MCP schema builders are **shared** by both DSLs, so a single change there serves both;
+only the entity-set metadata accessor and specs are duplicated per DSL. Every task names both
+spec trees.
+
+---
+
+## Task 1 — Accept `:non_insertable`; settability drives typed input + MCP tools
+
+- [x] **Status**
+
+**Task text:** Add `:non_insertable` as a fourth accepted `mutability:` value. Update declaration-time
+validation so it is accepted and the rejected-symbol error message lists all four valid values
+(`:read_write`, `:immutable`, `:non_insertable`, `:computed`). Implement the settability semantics:
+`:non_insertable` is **not** settable on create (silently dropped, no `InvalidType` even for a
+wrong-typed value, reads back as `nil` inside `create`) and **is** settable on update (coerced and
+present inside `update`). Because the MCP `create_<Set>` / `update_<Set>` input schemas are built from
+the same `settable_on_create?` / `settable_on_update?` predicates, the create tool must exclude and the
+update tool must include `:non_insertable` properties once the predicates are correct. Cover both DSLs
+and both spec trees.
+
+**Likely files:**
+- `lib/odata_duty/property.rb` — add `:non_insertable` to `MUTABILITIES`; error message lists four values.
+- `lib/odata_duty/property/single_prop.rb` — add `non_insertable?`; fix `settable_on_create?` (false for
+  `:computed` **and** `:non_insertable`) and `settable_on_update?` (true for `:read_write` **and**
+  `:non_insertable`).
+- (Shared) `lib/odata_duty/create_complex_type_hash_wrapper.rb` and `lib/odata_duty/mcp_input_schemas.rb`
+  should need **no** change — they already dispatch on the predicates. Confirm.
+- Specs (class DSL): `spec/odata_duty/entity_set/mutability_spec.rb` (extend), new
+  `spec/odata_duty/entity_set/update/non_insertable_spec.rb`,
+  `spec/odata_duty/entity_set/create/mcp_non_insertable_spec.rb`,
+  `spec/odata_duty/entity_set/update/mcp_non_insertable_spec.rb`.
+- Specs (builder DSL): `spec/odata_duty/schema_builder/entity_set/mutability_spec.rb` (extend), and the
+  sibling `update/non_insertable_spec.rb`, `create/mcp_non_insertable_spec.rb`,
+  `update/mcp_non_insertable_spec.rb` under `spec/odata_duty/schema_builder/entity_set/`.
+
+**Defining PRD excerpt:**
+- `input.status # => nil` on create (`:non_insertable` ignored), `input.note # => "x"`.
+- `input.status # => "closed"` on update (settable). No error / no `InvalidType` for a value sent on
+  create — silently dropped.
+- create tool: `:non_insertable` absent from `inputSchema.properties`. update tool: present.
+- `mutability: :non_insertable` accepted; rejected-symbol error lists all four valid values.
+
+**Dependencies:** none.
+
+---
+
+## Task 2 — `$metadata`: `InsertRestrictions/NonInsertableProperties`
+
+- [x] **Status**
+
+**Task text:** Emit each `:non_insertable` property as a `NonInsertableProperties` collection entry in the
+entity set's `Capabilities.InsertRestrictions` annotation. It must compose with the existing set-level
+`Insertable: false` annotation (emitted when there is no `create`) — both appear in the same
+`<Record>` when both apply. Read responses and property-level Core annotations are unchanged
+(`:non_insertable` has no Core term). Cover both DSLs and both spec trees.
+
+**Likely files:**
+- `lib/metadata.xml.erb` — extend the `InsertRestrictions` block to render when there is no create **or**
+  any non-insertable property; add the `NonInsertableProperties`/`Collection`/`PropertyPath` markup.
+- `lib/odata_duty.rb` (`Metadata` class) and `lib/odata_duty/schema_builder/entity_set.rb` — add a
+  symmetric `non_insertable_property_names` helper so the erb stays DSL-agnostic.
+- Specs: `spec/odata_duty/entity_set/non_insertable_metadata_spec.rb` and
+  `spec/odata_duty/schema_builder/entity_set/non_insertable_metadata_spec.rb`.
+
+**Defining PRD excerpt:**
+```xml
+<Annotation Term="Capabilities.InsertRestrictions">
+    <Record>
+        <PropertyValue Property="NonInsertableProperties">
+            <Collection>
+                <PropertyPath>status</PropertyPath>
+            </Collection>
+        </PropertyValue>
+    </Record>
+</Annotation>
+```
+Composes with the set-level `Insertable: false`. Metadata XML stays well-formed.
+
+**Dependencies:** Task 1 (the `non_insertable?` predicate).
+
+---
+
+## Task 3 — Documentation + Features index
+
+- [x] **Status**
+
+**Task text:** Extend `doc/using_mutability.md` with the `:non_insertable` row in the overview table and
+its create/update/`$metadata`/MCP behavior, including the note that `$oas2` is unchanged here (Part C).
+Update the `## Features` line for property mutability in `CLAUDE.md` to mention `:non_insertable` and the
+`Capabilities.InsertRestrictions` reflection, still pointing at `doc/using_mutability.md`.
+
+**Likely files:** `doc/using_mutability.md`, `CLAUDE.md`.
+
+**Defining PRD excerpt:** "Extend **`doc/using_mutability.md`** (created in Part A) with the
+`:non_insertable` row and its create/update/`$metadata`/MCP behavior. No new guide."
+
+**Dependencies:** Tasks 1–2 (documents their behavior).

--- a/doc/using_mutability.md
+++ b/doc/using_mutability.md
@@ -6,6 +6,7 @@ Every property in OdataDuty sits somewhere on a **mutability** axis that control
 | --- | --- | --- | --- | --- |
 | `:read_write` (default) | yes | yes | yes | none |
 | `:immutable` | yes | **no** | yes | `Org.OData.Core.V1.Immutable` |
+| `:non_insertable` | **no** | yes | yes | `Capabilities.InsertRestrictions/NonInsertableProperties` |
 | `:computed` | **no** | **no** | yes | `Org.OData.Core.V1.Computed` |
 
 This guide covers the `mutability:` axis with a focus on `:immutable` (set once on create, then frozen). For the dedicated read-only `:computed` case, see also [`doc/using_computed.md`](using_computed.md) — `computed:` is the `:computed` alias of this same axis.
@@ -17,6 +18,7 @@ This guide covers the `mutability:` axis with a focus on `:immutable` (set once 
 - **Purpose:** Declare per-property whether a client may set it on create, on update, or never — independent of whether it reads back.
 - **Declaration:** `property 'account_number', String, mutability: :immutable`. Defaults to `:read_write`.
 - **`:immutable`** is settable on **create**, ignored on **update**, and rendered in every read response.
+- **`:non_insertable`** is the mirror image — settable on **update**, dropped on **create**, and rendered in every read response. It is reflected via the entity set's `Capabilities.InsertRestrictions/NonInsertableProperties` annotation, **not** a property-level `Core` annotation.
 - **`:computed`** is settable on neither, but still rendered in reads — the read-only case documented in [`doc/using_computed.md`](using_computed.md).
 - **Keys are computed by default:** `property_ref` defaults to `mutability: :computed`. Opt back in with `property_ref 'id', String, mutability: :read_write` (equivalently `computed: false`).
 - **`computed:` is an alias:** `computed: true` ≡ `mutability: :computed`, `computed: false` ≡ `mutability: :read_write`. Passing both keywords raises `ArgumentError`.
@@ -33,6 +35,7 @@ class OrderEntity < OdataDuty::EntityType
   property_ref 'id', String, mutability: :read_write     # client-supplied key
   property 'account_number', String, nullable: false, mutability: :immutable  # set on create, then frozen
   property 'note', String                                 # :read_write (default)
+  property 'status', String, mutability: :non_insertable  # set on update, not on create
   property 'created_at', DateTime, mutability: :computed   # server-assigned, read-only
 end
 ```
@@ -46,6 +49,7 @@ order_entity = s.add_entity_type(name: 'Order') do |et|
   et.property_ref 'id', String, mutability: :read_write
   et.property 'account_number', String, nullable: false, mutability: :immutable
   et.property 'note', String
+  et.property 'status', String, mutability: :non_insertable
   et.property 'created_at', DateTime, mutability: :computed
 end
 ```
@@ -54,8 +58,8 @@ end
 
 On `POST`/`PATCH` (or the MCP `create_<Set>` / `update_<Set>` tools), the request body is coerced into a typed input object and passed to your `create(input)` or `update(id, input)`. Which properties flow through depends on the operation:
 
-- **On create**, `:immutable` and `:read_write` are coerced and present; `:computed` reads back `nil`.
-- **On update**, only `:read_write` flows through; `:immutable` **and** `:computed` read back `nil`.
+- **On create**, `:immutable` and `:read_write` are coerced and present; `:non_insertable` **and** `:computed` read back `nil`.
+- **On update**, `:read_write` and `:non_insertable` are coerced and present; `:immutable` **and** `:computed` read back `nil`.
 
 A dropped value is dropped **silently** — no error, not even `OdataDuty::InvalidType`, even for a value that would fail coercion for a writable property.
 
@@ -64,7 +68,7 @@ A dropped value is dropped **silently** — no error, not even `OdataDuty::Inval
 Given a request body:
 
 ```json
-{ "account_number": "A-100", "note": "x", "created_at": "2021-01-01T00:00:00Z" }
+{ "account_number": "A-100", "note": "x", "status": "open", "created_at": "2021-01-01T00:00:00Z" }
 ```
 
 inside `create`:
@@ -73,8 +77,9 @@ inside `create`:
 def create(input)
   input.account_number  # => "A-100"  (immutable, settable on create)
   input.note            # => "x"       (read_write)
+  input.status          # => nil       (non_insertable, dropped on create)
   input.created_at      # => nil       (computed, ignored)
-  # ... assign created_at on the server, persist, and return the record
+  # ... assign status and created_at on the server, persist, and return the record
 end
 ```
 
@@ -83,7 +88,7 @@ end
 Given a request body:
 
 ```json
-{ "account_number": "A-999", "note": "done" }
+{ "account_number": "A-999", "note": "done", "status": "closed" }
 ```
 
 inside `update`:
@@ -91,12 +96,13 @@ inside `update`:
 ```ruby
 def update(id, input)
   input.note            # => "done"   (read_write, flows through)
+  input.status          # => "closed"  (non_insertable, settable on update)
   input.account_number  # => nil       (immutable, frozen on update — silently dropped)
-  # ... merge note onto the existing record and return it
+  # ... merge note and status onto the existing record and return it
 end
 ```
 
-The supplied `account_number` is ignored on update; only `note` is applied. A wrong-typed immutable value (e.g. an integer for a `String`) is likewise dropped without raising.
+The supplied `account_number` is ignored on update; `note` and `status` are applied. A wrong-typed immutable value (e.g. an integer for a `String`) is likewise dropped without raising — symmetrically, a `:non_insertable` value behaves the same way on create.
 
 ## Reflected in the generated contracts
 
@@ -126,12 +132,30 @@ The document references the `Org.OData.Core.V1` vocabulary (aliased `Core`) at t
 </edmx:Reference>
 ```
 
+`:non_insertable` is the exception — it carries **no** property-level `Core` annotation. Instead it is reflected at the entity set level: the property is listed as a `<PropertyPath>` inside a `NonInsertableProperties` `<Collection>` within the set's `Capabilities.InsertRestrictions` annotation:
+
+```xml
+<EntitySet Name="Orders" EntityType="MySpace.Order">
+    <Annotation Term="Capabilities.InsertRestrictions">
+        <Record>
+            <PropertyValue Property="NonInsertableProperties">
+                <Collection>
+                    <PropertyPath>status</PropertyPath>
+                </Collection>
+            </PropertyValue>
+        </Record>
+    </Annotation>
+</EntitySet>
+```
+
+This composes with the set-level `Insertable: false` (emitted when there is no `create`) in the same `<Record>`. The `Capabilities` vocabulary (aliased `Capabilities`) is already referenced at the top of the metadata document.
+
 ### MCP
 
-The `create_<Set>` tool's `inputSchema` includes `:read_write` and `:immutable` properties (and lists the non-nullable ones in `required`); `:computed` is absent. The `update_<Set>` tool keeps only the key and `:read_write` properties — `:immutable` **and** `:computed` are absent:
+The `create_<Set>` tool's `inputSchema` includes `:read_write` and `:immutable` properties (and lists the non-nullable ones in `required`); `:non_insertable` **and** `:computed` are absent. The `update_<Set>` tool keeps the key, `:read_write`, and `:non_insertable` properties — `:immutable` **and** `:computed` are absent:
 
 ```jsonc
-// tools/list — create includes the immutable property
+// tools/list — create includes the immutable property, excludes non_insertable + computed
 {
   "name": "create_Order",
   "inputSchema": {
@@ -144,14 +168,15 @@ The `create_<Set>` tool's `inputSchema` includes `:read_write` and `:immutable` 
   }
 }
 
-// tools/list — update excludes immutable (and computed), keeping the key + read_write
+// tools/list — update includes non_insertable (status), excludes immutable + computed
 {
   "name": "update_Order",
   "inputSchema": {
     "type": "object",
     "properties": {
-      "id":   { "type": "string" },
-      "note": { "type": "string", "x-nullable": true }
+      "id":     { "type": "string" },
+      "status": { "type": "string" },
+      "note":   { "type": "string", "x-nullable": true }
     },
     "required": ["id"]
   }
@@ -160,19 +185,19 @@ The `create_<Set>` tool's `inputSchema` includes `:read_write` and `:immutable` 
 
 ### `$oas2` — not yet operation-aware (interim gap)
 
-`$oas2` is **not** changed in this part. The `post` and `patch` operations still share one request body referencing the entity definition, where only `:computed` properties carry `readOnly: true`. An `:immutable` property therefore still appears writable in the `patch` body, even though the typed input drops it on update. This is a known, documented interim gap — the per-operation `$oas2` body split lands in a follow-up part.
+`$oas2` is **not** changed in this part. The `post` and `patch` operations still share one request body referencing the entity definition, where only `:computed` properties carry `readOnly: true`. An `:immutable` property therefore still appears writable in the `patch` body, even though the typed input drops it on update; likewise a `:non_insertable` property still appears writable in the `post` body, even though the typed input drops it on create. This is a known, documented interim gap — the per-operation `$oas2` body split lands in a follow-up part.
 
 ## Common errors / edge cases
 
 - **`property_ref` is computed by default.** A key is server-assigned unless you declare `property_ref 'id', String, mutability: :read_write` (or `computed: false`).
 - **Both `mutability:` and `computed:` on one property** raises `ArgumentError` at schema-definition time:
   ``account_number: pass either `mutability:` or `computed:`, not both — they control the same axis``.
-  `account_number: invalid mutability :frozen`.
-- **A dropped value is a silent no-op** — an `:immutable` value on update, or a `:computed` value on either operation, reads back as `nil` with no error, even for a wrong-typed value.
+- **An unknown `mutability:` value** raises `ArgumentError` at schema-definition time, listing all four valid values: `bad: invalid mutability :frozen, must be one of :read_write, :immutable, :non_insertable, :computed`.
+- **A dropped value is a silent no-op** — an `:immutable` value on update, a `:non_insertable` value on create, or a `:computed` value on either operation, reads back as `nil` with no error, even for a wrong-typed value.
 
 ## Summary
 
-- **`mutability:`** is the per-property create/update axis: `:read_write` (default), `:immutable`, `:computed`.
-- **`:immutable`** is set on create, frozen on update, and rendered in every read response; **`:computed`** is read-only on both.
+- **`mutability:`** is the per-property create/update axis: `:read_write` (default), `:immutable`, `:non_insertable`, `:computed`.
+- **`:immutable`** is set on create, frozen on update; **`:non_insertable`** is the mirror — dropped on create, settable on update; **`:computed`** is read-only on both. All three still render in every read response.
 - **`computed:` is a backward-compatible alias** (`true` ≡ `:computed`, `false` ≡ `:read_write`); keys default to `:computed`. Passing both keywords, or an unknown value, raises `ArgumentError`.
-- **Reflected in** `$metadata` (`Core.Immutable` / `Core.Computed` / none) and MCP (create includes immutable, update excludes it). **`$oas2` is unchanged in this part** — an immutable property still appears writable in the shared body, addressed in a follow-up.
+- **Reflected in** `$metadata` (`Core.Immutable` / `Core.Computed` / none, plus `Capabilities.InsertRestrictions/NonInsertableProperties` for `:non_insertable`) and MCP (create excludes non_insertable + computed, update excludes immutable + computed). **`$oas2` is unchanged in this part** — an immutable property still appears writable in the shared `patch` body and a non_insertable one in the shared `post` body, addressed in a follow-up.

--- a/lib/metadata.xml.erb
+++ b/lib/metadata.xml.erb
@@ -75,16 +75,17 @@
                                 </Record>
                             </Annotation>
                         <% end %>
-                        <% if !entity_set.supports_create? || entity_set.non_insertable_property_names.any? %>
+                        <% non_insertable = entity_set.non_insertable_property_names %>
+                        <% if !entity_set.supports_create? || non_insertable.any? %>
                             <Annotation Term="Capabilities.InsertRestrictions">
                                 <Record>
                                     <% if !entity_set.supports_create? %>
                                         <PropertyValue Property="Insertable" Bool="false" />
                                     <% end %>
-                                    <% if entity_set.non_insertable_property_names.any? %>
+                                    <% if non_insertable.any? %>
                                         <PropertyValue Property="NonInsertableProperties">
                                             <Collection>
-                                                <% entity_set.non_insertable_property_names.each do |property_name| %>
+                                                <% non_insertable.each do |property_name| %>
                                                     <PropertyPath><%= property_name %></PropertyPath>
                                                 <% end %>
                                             </Collection>

--- a/lib/metadata.xml.erb
+++ b/lib/metadata.xml.erb
@@ -75,10 +75,21 @@
                                 </Record>
                             </Annotation>
                         <% end %>
-                        <% if !entity_set.supports_create? %>
+                        <% if !entity_set.supports_create? || entity_set.non_insertable_property_names.any? %>
                             <Annotation Term="Capabilities.InsertRestrictions">
                                 <Record>
-                                    <PropertyValue Property="Insertable" Bool="false" />
+                                    <% if !entity_set.supports_create? %>
+                                        <PropertyValue Property="Insertable" Bool="false" />
+                                    <% end %>
+                                    <% if entity_set.non_insertable_property_names.any? %>
+                                        <PropertyValue Property="NonInsertableProperties">
+                                            <Collection>
+                                                <% entity_set.non_insertable_property_names.each do |property_name| %>
+                                                    <PropertyPath><%= property_name %></PropertyPath>
+                                                <% end %>
+                                            </Collection>
+                                        </PropertyValue>
+                                    <% end %>
                                 </Record>
                             </Annotation>
                         <% end %>

--- a/lib/odata_duty.rb
+++ b/lib/odata_duty.rb
@@ -142,7 +142,8 @@ module OdataDuty
       end
 
       def non_insertable_property_names
-        entity_type.__metadata.properties.select(&:non_insertable?).map(&:name)
+        @non_insertable_property_names ||=
+          entity_type.__metadata.properties.select(&:non_insertable?).map(&:name)
       end
 
       private

--- a/lib/odata_duty.rb
+++ b/lib/odata_duty.rb
@@ -141,6 +141,10 @@ module OdataDuty
         entity_set.method_defined?(:delete)
       end
 
+      def non_insertable_property_names
+        entity_type.__metadata.properties.select(&:non_insertable?).map(&:name)
+      end
+
       private
 
       def converted_id(id, context)

--- a/lib/odata_duty/property.rb
+++ b/lib/odata_duty/property.rb
@@ -4,7 +4,8 @@ require 'odata_duty/property/collection_prop'
 
 module OdataDuty
   module Property
-    MUTABILITIES = %i[read_write immutable computed].freeze
+    MUTABILITIES = %i[read_write immutable non_insertable computed].freeze
+    MUTABILITIES_LIST = MUTABILITIES.map(&:inspect).join(', ').freeze
 
     def self.new(name, type = String, line__defined__at: nil, nullable: true, method: nil,
                  computed: :unset, mutability: :unset)
@@ -30,7 +31,9 @@ module OdataDuty
       return :read_write if mutability == :unset
       return mutability if MUTABILITIES.include?(mutability)
 
-      raise ArgumentError, "#{name}: invalid mutability #{mutability.inspect}"
+      raise ArgumentError,
+            "#{name}: invalid mutability #{mutability.inspect}, " \
+            "must be one of #{MUTABILITIES_LIST}"
     end
 
     def self.valid_name?(name)

--- a/lib/odata_duty/property/collection_prop.rb
+++ b/lib/odata_duty/property/collection_prop.rb
@@ -13,7 +13,7 @@ module OdataDuty
         if scalar?
           raw_type.to_oas2(is_collection: true)
         else
-          { 'type' => 'array', 'items' => ref_oas2 }
+          { 'type' => 'array', 'items' => { '$ref' => "#/definitions/#{raw_type.name}" } }
         end
       end
 

--- a/lib/odata_duty/property/single_prop.rb
+++ b/lib/odata_duty/property/single_prop.rb
@@ -27,16 +27,20 @@ module OdataDuty
         mutability == :immutable
       end
 
+      def non_insertable?
+        mutability == :non_insertable
+      end
+
       def core_annotation_term
         CORE_ANNOTATION_TERMS[mutability]
       end
 
       def settable_on_create?
-        mutability != :computed
+        !computed? && !non_insertable?
       end
 
       def settable_on_update?
-        mutability == :read_write
+        !computed? && !immutable?
       end
 
       def calling_method?
@@ -80,12 +84,9 @@ module OdataDuty
       end
 
       def to_value(value, context)
-        raise "#{name} cannot be null" if !nullable && value.nil?
-
-        result = convert(value, context)
-        raise "#{name} cannot be null" if !nullable && result.nil?
-
-        result
+        convert(value, context).tap do |result|
+          raise "#{name} cannot be null" if !nullable && result.nil?
+        end
       rescue InvalidValue => e
         raise InvalidValue, "#{name} : #{e.message}"
       end
@@ -110,7 +111,9 @@ module OdataDuty
       end
 
       def to_oas2_type
-        scalar? && !enum? ? raw_type.to_oas2(is_collection: false) : ref_oas2
+        return raw_type.to_oas2(is_collection: false) if scalar? && !enum?
+
+        { '$ref' => "#/definitions/#{raw_type.name}" }
       end
 
       def collection?
@@ -118,10 +121,6 @@ module OdataDuty
       end
 
       private
-
-      def ref_oas2
-        { '$ref' => "#/definitions/#{raw_type.name}" }
-      end
 
       def load_type_instance_vars(type)
         type = Array(type).first

--- a/lib/odata_duty/schema_builder/entity_set.rb
+++ b/lib/odata_duty/schema_builder/entity_set.rb
@@ -42,6 +42,10 @@ module OdataDuty
         # Check if the resolver class supports delete by looking for the delete method
         resolver_class.method_defined?(:delete)
       end
+
+      def non_insertable_property_names
+        entity_type.properties.select(&:non_insertable?).map(&:name)
+      end
     end
   end
 end

--- a/lib/odata_duty/schema_builder/entity_set.rb
+++ b/lib/odata_duty/schema_builder/entity_set.rb
@@ -44,7 +44,8 @@ module OdataDuty
       end
 
       def non_insertable_property_names
-        entity_type.properties.select(&:non_insertable?).map(&:name)
+        @non_insertable_property_names ||=
+          entity_type.properties.select(&:non_insertable?).map(&:name)
       end
     end
   end

--- a/spec/odata_duty/entity_set/create/mcp_non_insertable_spec.rb
+++ b/spec/odata_duty/entity_set/create/mcp_non_insertable_spec.rb
@@ -1,0 +1,62 @@
+require 'spec_helper'
+
+class CreateMcpNonInsertableStruct
+  attr_reader :id, :status, :note
+
+  def initialize(id:, note:)
+    @id = id
+    @status = 'open'
+    @note = note
+  end
+end
+
+class CreateMcpNonInsertableOrderEntity < OdataDuty::EntityType
+  property_ref 'id', String, computed: true
+  property 'status', String, mutability: :non_insertable
+  property 'note', String
+end
+
+class CreateMcpNonInsertableOrderSet < OdataDuty::EntitySet
+  entity_type CreateMcpNonInsertableOrderEntity
+  name 'Order'
+  url 'Order'
+
+  def create(params)
+    CreateMcpNonInsertableStruct.new(id: 'o1', note: params.note)
+  end
+end
+
+class CreateMcpNonInsertableSchema < OdataDuty::Schema
+  base_url 'http://localhost:3000/api'
+  entity_sets [CreateMcpNonInsertableOrderSet]
+end
+
+RSpec.describe OdataDuty::EntitySet, 'MCP create tool with non_insertable property' do
+  let(:mcp_server) do
+    server = CreateMcpNonInsertableSchema.to_mcp_server
+    server.server_context = { context: Context.new }
+    server
+  end
+
+  def call(payload)
+    Oj.load(mcp_server.handle_json(Oj.dump(payload)))
+  end
+
+  let(:request_payload) do
+    { 'jsonrpc' => '2.0', 'method' => 'tools/list', 'params' => {}, 'id' => 'tl-1' }
+  end
+
+  let(:tools) { call(request_payload)['result']['tools'] }
+
+  let(:create_schema) do
+    tools.find { |t| t['name'] == 'create_Order' }['inputSchema']
+  end
+
+  it 'excludes the non_insertable property from the create schema' do
+    expect(create_schema['properties'].keys).not_to include('status')
+  end
+
+  it 'keeps the read_write property in the create schema' do
+    expect(create_schema['properties']).to include('note')
+  end
+end

--- a/spec/odata_duty/entity_set/mutability_spec.rb
+++ b/spec/odata_duty/entity_set/mutability_spec.rb
@@ -1,12 +1,29 @@
 require 'spec_helper'
 
 RSpec.describe OdataDuty::EntityType, 'mutability keyword validation' do
+  it 'accepts mutability: :non_insertable' do
+    expect do
+      Class.new(OdataDuty::EntityType) do
+        property 'status', String, mutability: :non_insertable
+      end
+    end.not_to raise_error
+  end
+
   it 'raises ArgumentError for an unknown mutability value naming property and value' do
     expect do
       Class.new(OdataDuty::EntityType) do
         property 'bad', String, mutability: :frozen
       end
     end.to raise_error(ArgumentError, /bad.*frozen|frozen.*bad/)
+  end
+
+  it 'lists all four valid mutability values in the rejection message' do
+    expect do
+      Class.new(OdataDuty::EntityType) do
+        property 'bad', String, mutability: :frozen
+      end
+    end.to raise_error(ArgumentError,
+                       /read_write.*immutable.*non_insertable.*computed/m)
   end
 
   it 'raises ArgumentError when both mutability and computed are supplied' do

--- a/spec/odata_duty/entity_set/non_insertable_metadata_spec.rb
+++ b/spec/odata_duty/entity_set/non_insertable_metadata_spec.rb
@@ -1,0 +1,90 @@
+require 'spec_helper'
+
+class NonInsertableMetadataEntity < OdataDuty::EntityType
+  property_ref 'id', String
+  property 'status', String, mutability: :non_insertable
+  property 'name', String, mutability: :read_write
+end
+
+class NonInsertableMetadataSet < OdataDuty::EntitySet
+  entity_type NonInsertableMetadataEntity
+
+  def collection; end
+  def create(_input); end
+end
+
+class NonInsertableNoCreateEntity < OdataDuty::EntityType
+  property_ref 'id', String
+  property 'status', String, mutability: :non_insertable
+end
+
+class NonInsertableNoCreateSet < OdataDuty::EntitySet
+  entity_type NonInsertableNoCreateEntity
+
+  def collection; end
+end
+
+class PlainCreateEntity < OdataDuty::EntityType
+  property_ref 'id', String
+  property 'name', String, mutability: :read_write
+end
+
+class PlainCreateSet < OdataDuty::EntitySet
+  entity_type PlainCreateEntity
+
+  def collection; end
+  def create(_input); end
+end
+
+class NonInsertableMetadataSchema < OdataDuty::Schema
+  base_url 'http://localhost:3000/api'
+  entity_sets [NonInsertableMetadataSet, NonInsertableNoCreateSet, PlainCreateSet]
+end
+
+RSpec.describe OdataDuty::Schema, 'Non-insertable property metadata' do
+  subject(:metadata_xml) { NonInsertableMetadataSchema.metadata_xml }
+
+  def entity_set_xml(name)
+    metadata_xml.split(%(<EntitySet Name="#{name}"))[1].split('</EntitySet>')[0]
+  end
+
+  def insert_restrictions(name)
+    xml = entity_set_xml(name)
+    doc = Nokogiri::XML("<root>#{xml}</root>")
+    doc.xpath('//Annotation[@Term="Capabilities.InsertRestrictions"]')
+  end
+
+  it 'emits the non-insertable property as a PropertyPath in NonInsertableProperties' do
+    annotation = insert_restrictions('NonInsertableMetadata')
+    expect(annotation.xpath('.//PropertyValue[@Property="NonInsertableProperties"]' \
+                            '/Collection/PropertyPath').map(&:text)).to eq(['status'])
+  end
+
+  it 'does not emit Insertable false when the set supports create' do
+    annotation = insert_restrictions('NonInsertableMetadata')
+    expect(annotation.xpath('.//PropertyValue[@Property="Insertable"]')).to be_empty
+  end
+
+  it 'composes NonInsertableProperties with Insertable false in one Record' do
+    annotation = insert_restrictions('NonInsertableNoCreate')
+    record = annotation.xpath('./Record')
+    expect(record.size).to eq(1)
+    expect(record.xpath('./PropertyValue[@Property="Insertable"]/@Bool').map(&:value))
+      .to eq(['false'])
+    expect(record.xpath('.//PropertyValue[@Property="NonInsertableProperties"]' \
+                        '/Collection/PropertyPath').map(&:text)).to eq(['status'])
+  end
+
+  it 'does not add a property-level Core annotation to a non-insertable property' do
+    property = metadata_xml.split('<Property Name="status"')[1].split('<Property ')[0]
+    expect(property).not_to include('<Annotation')
+  end
+
+  it 'emits no InsertRestrictions for a set with create and no non-insertable property' do
+    expect(insert_restrictions('PlainCreate')).to be_empty
+  end
+
+  it 'produces well-formed XML' do
+    expect(Nokogiri::XML(metadata_xml).errors).to be_empty
+  end
+end

--- a/spec/odata_duty/entity_set/update/mcp_non_insertable_spec.rb
+++ b/spec/odata_duty/entity_set/update/mcp_non_insertable_spec.rb
@@ -1,0 +1,63 @@
+require 'spec_helper'
+
+class UpdateMcpNonInsertableStruct
+  attr_reader :id, :status, :note
+
+  def initialize(id:, status:, note:)
+    @id = id
+    @status = status
+    @note = note
+  end
+end
+
+class UpdateMcpNonInsertableOrderEntity < OdataDuty::EntityType
+  property_ref 'id', String
+  property 'status', String, mutability: :non_insertable
+  property 'note', String
+end
+
+class UpdateMcpNonInsertableOrderSet < OdataDuty::EntitySet
+  entity_type UpdateMcpNonInsertableOrderEntity
+  name 'Order'
+  url 'Order'
+
+  def update(id, params)
+    UpdateMcpNonInsertableStruct.new(id: id, status: params.status, note: params.note)
+  end
+end
+
+class UpdateMcpNonInsertableSchema < OdataDuty::Schema
+  base_url 'http://localhost:3000/api'
+  entity_sets [UpdateMcpNonInsertableOrderSet]
+end
+
+RSpec.describe OdataDuty::EntitySet, 'MCP update tool with non_insertable property' do
+  let(:mcp_server) do
+    server = UpdateMcpNonInsertableSchema.to_mcp_server
+    server.server_context = { context: Context.new }
+    server
+  end
+
+  def call(payload)
+    Oj.load(mcp_server.handle_json(Oj.dump(payload)))
+  end
+
+  let(:request_payload) do
+    { 'jsonrpc' => '2.0', 'method' => 'tools/list', 'params' => {}, 'id' => 'tl-1' }
+  end
+
+  let(:tools) { call(request_payload)['result']['tools'] }
+
+  let(:update_schema) do
+    tools.find { |t| t['name'] == 'update_Order' }['inputSchema']
+  end
+
+  it 'includes the non_insertable property in the update schema' do
+    expect(update_schema['properties']).to include('status')
+  end
+
+  it 'keeps the key and read_write properties in the update schema' do
+    expect(update_schema['properties']).to include('id', 'note')
+    expect(update_schema['required']).to eq(['id'])
+  end
+end

--- a/spec/odata_duty/entity_set/update/non_insertable_spec.rb
+++ b/spec/odata_duty/entity_set/update/non_insertable_spec.rb
@@ -1,0 +1,59 @@
+require 'spec_helper'
+
+class NonInsertableOrderEntity < OdataDuty::EntityType
+  property_ref 'id', String, computed: false
+  property 'status', String, mutability: :non_insertable
+  property 'note', String
+end
+
+class NonInsertableOrderSet < OdataDuty::EntitySet
+  entity_type NonInsertableOrderEntity
+
+  def create(input)
+    OpenStruct.new(id: '1', status: input.status, note: input.note)
+  end
+
+  def update(id, input)
+    OpenStruct.new(id: id, status: input.status, note: input.note)
+  end
+end
+
+class NonInsertableOrderSchema < OdataDuty::Schema
+  base_url 'http://localhost:3000/api'
+  entity_sets [NonInsertableOrderSet]
+end
+
+RSpec.describe OdataDuty::EntitySet, 'non_insertable properties' do
+  subject(:schema) { NonInsertableOrderSchema }
+
+  describe 'on create' do
+    let(:response) do
+      Oj.load(schema.create('NonInsertableOrder', context: Context.new,
+                                                  query_options: { 'status' => 'open',
+                                                                   'note' => 'x' }))
+    end
+
+    it 'drops a non_insertable property and reads back nil while read_write flows through' do
+      expect(response).to include('status' => nil, 'note' => 'x')
+    end
+
+    it 'does not raise InvalidType for a wrong-typed non_insertable value on create' do
+      expect do
+        schema.create('NonInsertableOrder', context: Context.new,
+                                            query_options: { 'status' => 12_345 })
+      end.not_to raise_error
+    end
+  end
+
+  describe 'on update' do
+    let(:response) do
+      Oj.load(schema.update("NonInsertableOrder('1')", context: Context.new,
+                                                       query_options: { 'status' => 'closed',
+                                                                        'note' => 'done' }))
+    end
+
+    it 'coerces a non_insertable property and keeps it present while read_write flows through' do
+      expect(response).to include('status' => 'closed', 'note' => 'done')
+    end
+  end
+end

--- a/spec/odata_duty/schema_builder/entity_set/create/mcp_non_insertable_spec.rb
+++ b/spec/odata_duty/schema_builder/entity_set/create/mcp_non_insertable_spec.rb
@@ -1,0 +1,52 @@
+require 'spec_helper'
+
+class CreateMcpNonInsertableOrderResolver < OdataDuty::SetResolver
+  def create(params)
+    Struct.new(:id, :status, :note).new('o1', 'open', params.note)
+  end
+end
+
+module OdataDuty
+  RSpec.describe SchemaBuilder::EntitySet, 'MCP create tool with non_insertable property' do
+    subject(:schema) do
+      SchemaBuilder.build(namespace: 'SampleSpace', host: 'localhost', base_path: '') do |s|
+        entity = s.add_entity_type(name: 'CreateMcpNonInsertableOrderEntity') do |et|
+          et.property_ref 'id', String, computed: true
+          et.property 'status', String, mutability: :non_insertable
+          et.property 'note', String
+        end
+
+        s.add_entity_set(name: 'Order', entity_type: entity,
+                         resolver: 'CreateMcpNonInsertableOrderResolver')
+      end
+    end
+
+    let(:mcp_server) do
+      server = schema.to_mcp_server
+      server.server_context = { context: Context.new }
+      server
+    end
+
+    def call(payload)
+      Oj.load(mcp_server.handle_json(Oj.dump(payload)))
+    end
+
+    let(:request_payload) do
+      { 'jsonrpc' => '2.0', 'method' => 'tools/list', 'params' => {}, 'id' => 'tl-1' }
+    end
+
+    let(:tools) { call(request_payload)['result']['tools'] }
+
+    let(:create_schema) do
+      tools.find { |t| t['name'] == 'create_Order' }['inputSchema']
+    end
+
+    it 'excludes the non_insertable property from the create schema' do
+      expect(create_schema['properties'].keys).not_to include('status')
+    end
+
+    it 'keeps the read_write property in the create schema' do
+      expect(create_schema['properties']).to include('note')
+    end
+  end
+end

--- a/spec/odata_duty/schema_builder/entity_set/mutability_spec.rb
+++ b/spec/odata_duty/schema_builder/entity_set/mutability_spec.rb
@@ -8,10 +8,23 @@ module OdataDuty
       end
     end
 
+    it 'accepts mutability: :non_insertable' do
+      expect do
+        build_entity { |et| et.property 'status', String, mutability: :non_insertable }
+      end.not_to raise_error
+    end
+
     it 'raises ArgumentError for an unknown mutability value naming property and value' do
       expect do
         build_entity { |et| et.property 'bad', String, mutability: :frozen }
       end.to raise_error(ArgumentError, /bad.*frozen|frozen.*bad/)
+    end
+
+    it 'lists all four valid mutability values in the rejection message' do
+      expect do
+        build_entity { |et| et.property 'bad', String, mutability: :frozen }
+      end.to raise_error(ArgumentError,
+                         /read_write.*immutable.*non_insertable.*computed/m)
     end
 
     it 'raises ArgumentError when both mutability and computed are supplied' do

--- a/spec/odata_duty/schema_builder/entity_set/non_insertable_metadata_spec.rb
+++ b/spec/odata_duty/schema_builder/entity_set/non_insertable_metadata_spec.rb
@@ -1,0 +1,87 @@
+require 'spec_helper'
+
+class NonInsertableBuilderResolver < OdataDuty::SetResolver
+  def collection; end
+  def create(_input); end
+end
+
+class NonInsertableNoCreateBuilderResolver < OdataDuty::SetResolver
+  def collection; end
+end
+
+class PlainCreateBuilderResolver < OdataDuty::SetResolver
+  def collection; end
+  def create(_input); end
+end
+
+module OdataDuty
+  RSpec.describe SchemaBuilder, 'Non-insertable property metadata' do
+    subject(:metadata_xml) do
+      SchemaBuilder.build(namespace: 'SampleSpace', host: 'localhost', base_path: '/api') do |s|
+        with_create = s.add_entity_type(name: 'NonInsertableMetadataEntity') do |et|
+          et.property_ref 'id', String
+          et.property 'status', String, mutability: :non_insertable
+          et.property 'name', String, mutability: :read_write
+        end
+        no_create = s.add_entity_type(name: 'NonInsertableNoCreateEntity') do |et|
+          et.property_ref 'id', String
+          et.property 'status', String, mutability: :non_insertable
+        end
+        plain = s.add_entity_type(name: 'PlainCreateEntity') do |et|
+          et.property_ref 'id', String
+          et.property 'name', String, mutability: :read_write
+        end
+
+        s.add_entity_set(name: 'NonInsertableMetadata', entity_type: with_create,
+                         resolver: 'NonInsertableBuilderResolver')
+        s.add_entity_set(name: 'NonInsertableNoCreate', entity_type: no_create,
+                         resolver: 'NonInsertableNoCreateBuilderResolver')
+        s.add_entity_set(name: 'PlainCreate', entity_type: plain,
+                         resolver: 'PlainCreateBuilderResolver')
+      end.metadata_xml
+    end
+
+    def entity_set_xml(name)
+      metadata_xml.split(%(<EntitySet Name="#{name}"))[1].split('</EntitySet>')[0]
+    end
+
+    def insert_restrictions(name)
+      doc = Nokogiri::XML("<root>#{entity_set_xml(name)}</root>")
+      doc.xpath('//Annotation[@Term="Capabilities.InsertRestrictions"]')
+    end
+
+    it 'emits the non-insertable property as a PropertyPath in NonInsertableProperties' do
+      annotation = insert_restrictions('NonInsertableMetadata')
+      expect(annotation.xpath('.//PropertyValue[@Property="NonInsertableProperties"]' \
+                              '/Collection/PropertyPath').map(&:text)).to eq(['status'])
+    end
+
+    it 'does not emit Insertable false when the set supports create' do
+      annotation = insert_restrictions('NonInsertableMetadata')
+      expect(annotation.xpath('.//PropertyValue[@Property="Insertable"]')).to be_empty
+    end
+
+    it 'composes NonInsertableProperties with Insertable false in one Record' do
+      annotation = insert_restrictions('NonInsertableNoCreate')
+      record = annotation.xpath('./Record')
+      expect(record.size).to eq(1)
+      expect(record.xpath('./PropertyValue[@Property="Insertable"]/@Bool').map(&:value))
+        .to eq(['false'])
+      expect(record.xpath('.//PropertyValue[@Property="NonInsertableProperties"]' \
+                          '/Collection/PropertyPath').map(&:text)).to eq(['status'])
+    end
+
+    it 'does not add a property-level Core annotation to a non-insertable property' do
+      property = metadata_xml.split('<Property Name="status"')[1].split('<Property ')[0]
+      expect(property).not_to include('<Annotation')
+    end
+
+    it 'emits no InsertRestrictions for a set with create and no non-insertable property' do
+      expect(insert_restrictions('PlainCreate')).to be_empty
+    end
+
+    it 'produces well-formed XML' do
+      expect(Nokogiri::XML(metadata_xml).errors).to be_empty
+    end
+  end
+end

--- a/spec/odata_duty/schema_builder/entity_set/update/mcp_non_insertable_spec.rb
+++ b/spec/odata_duty/schema_builder/entity_set/update/mcp_non_insertable_spec.rb
@@ -1,0 +1,53 @@
+require 'spec_helper'
+
+class UpdateMcpNonInsertableOrderResolver < OdataDuty::SetResolver
+  def update(id, params)
+    Struct.new(:id, :status, :note).new(id, params.status, params.note)
+  end
+end
+
+module OdataDuty
+  RSpec.describe SchemaBuilder::EntitySet, 'MCP update tool with non_insertable property' do
+    subject(:schema) do
+      SchemaBuilder.build(namespace: 'SampleSpace', host: 'localhost', base_path: '') do |s|
+        entity = s.add_entity_type(name: 'UpdateMcpNonInsertableOrderEntity') do |et|
+          et.property_ref 'id', String
+          et.property 'status', String, mutability: :non_insertable
+          et.property 'note', String
+        end
+
+        s.add_entity_set(name: 'Order', entity_type: entity,
+                         resolver: 'UpdateMcpNonInsertableOrderResolver')
+      end
+    end
+
+    let(:mcp_server) do
+      server = schema.to_mcp_server
+      server.server_context = { context: Context.new }
+      server
+    end
+
+    def call(payload)
+      Oj.load(mcp_server.handle_json(Oj.dump(payload)))
+    end
+
+    let(:request_payload) do
+      { 'jsonrpc' => '2.0', 'method' => 'tools/list', 'params' => {}, 'id' => 'tl-1' }
+    end
+
+    let(:tools) { call(request_payload)['result']['tools'] }
+
+    let(:update_schema) do
+      tools.find { |t| t['name'] == 'update_Order' }['inputSchema']
+    end
+
+    it 'includes the non_insertable property in the update schema' do
+      expect(update_schema['properties']).to include('status')
+    end
+
+    it 'keeps the key and read_write properties in the update schema' do
+      expect(update_schema['properties']).to include('id', 'note')
+      expect(update_schema['required']).to eq(['id'])
+    end
+  end
+end

--- a/spec/odata_duty/schema_builder/entity_set/update/non_insertable_spec.rb
+++ b/spec/odata_duty/schema_builder/entity_set/update/non_insertable_spec.rb
@@ -1,0 +1,58 @@
+require 'spec_helper'
+
+class NonInsertableOrderResolver < OdataDuty::SetResolver
+  def create(input)
+    OpenStruct.new(id: '1', status: input.status, note: input.note)
+  end
+
+  def update(id, input)
+    OpenStruct.new(id: id, status: input.status, note: input.note)
+  end
+end
+
+module OdataDuty
+  RSpec.describe SchemaBuilder::EntitySet, 'non_insertable properties' do
+    subject(:schema) do
+      SchemaBuilder.build(namespace: 'SampleSpace', host: 'localhost', base_path: '') do |s|
+        order = s.add_entity_type(name: 'NonInsertableOrderEntity') do |et|
+          et.property_ref 'id', String, computed: false
+          et.property 'status', String, mutability: :non_insertable
+          et.property 'note', String
+        end
+        s.add_entity_set(name: 'NonInsertableOrder', entity_type: order,
+                         resolver: 'NonInsertableOrderResolver')
+      end
+    end
+
+    describe 'on create' do
+      let(:response) do
+        Oj.load(schema.create('NonInsertableOrder', context: Context.new,
+                                                    query_options: { 'status' => 'open',
+                                                                     'note' => 'x' }))
+      end
+
+      it 'drops a non_insertable property to nil while read_write flows through' do
+        expect(response).to include('status' => nil, 'note' => 'x')
+      end
+
+      it 'does not raise InvalidType for a wrong-typed non_insertable value on create' do
+        expect do
+          schema.create('NonInsertableOrder', context: Context.new,
+                                              query_options: { 'status' => 12_345 })
+        end.not_to raise_error
+      end
+    end
+
+    describe 'on update' do
+      let(:response) do
+        Oj.load(schema.update("NonInsertableOrder('1')", context: Context.new,
+                                                         query_options: { 'status' => 'closed',
+                                                                          'note' => 'done' }))
+      end
+
+      it 'coerces a non_insertable property and keeps it present on update' do
+        expect(response).to include('status' => 'closed', 'note' => 'done')
+      end
+    end
+  end
+end


### PR DESCRIPTION
- property.rb: add :non_insertable to MUTABILITIES; the invalid-value error
  now lists all four valid values.
- single_prop.rb: add non_insertable? predicate; settable_on_create? excludes
  :computed and :non_insertable, settable_on_update? excludes :computed and
  :immutable. (Behavior-preserving tidy of to_value / inlined ref_oas2 to stay
  under ClassLength once the new predicate was added.)
- The typed-input wrapper and MCP input-schema builders already dispatch on
  these predicates, so create silently drops :non_insertable (no InvalidType
  even for wrong-typed values, reads back nil) and excludes it from the MCP
  create tool, while update coerces it and the MCP update tool includes it.
- metadata.xml.erb: render the InsertRestrictions annotation when the set has
  no create OR has any :non_insertable property; emit Insertable=false only when
  there is no create, and a NonInsertableProperties/Collection/PropertyPath
  entry per non-insertable property — both PropertyValues composing in one
  <Record>
- lib/odata_duty.rb and schema_builder/entity_set.rb: add a symmetric
  non_insertable_property_names helper so the template stays DSL-agnostic.
- doc/using_mutability.md: add the :non_insertable row to the overview table
  and a running 'status' example through the Class/Builder DSL blocks; update
  the per-operation bullets (create drops :non_insertable + :computed, update
  flows :read_write + :non_insertable); add a $metadata subsection with the
  InsertRestrictions/NonInsertableProperties XML; update the MCP subsection
  (create excludes, update includes); extend the $oas2 interim-gap note; document
  the four-value unknown-mutability error message; refresh the summary.
- CLAUDE.md: the Property mutability Features line now lists :non_insertable
  and the Capabilities.InsertRestrictions reflection.
