### PR TITLE
Document per-operation $oas2 request bodies

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,7 +17,7 @@ Short index of what's implemented; see the linked `doc/` guide for the full cont
 - **`$search`** — AND/OR/NOT grammar via `od_search`; also drives the MCP search tool — `doc/using_search.md`.
 - **Paging** — `$top`/`$skip` and server-driven `@odata.nextLink` via `od_next_link_skiptoken`.
 - **Computed properties** — `doc/using_computed.md`.
-- **Property mutability** — `mutability: :immutable`/`:non_insertable`/`:computed` per property (create/update settability + `Core` annotations & `Capabilities.InsertRestrictions`) — `doc/using_mutability.md`.
+- **Property mutability** — `mutability: :immutable`/`:non_insertable`/`:computed` per property (create/update settability + `Core` annotations & `Capabilities.InsertRestrictions`; `$oas2` per-operation `<Entity>Create`/`<Entity>Update` request bodies) — `doc/using_mutability.md`.
 - **Init args** — pass per-request data into `od_after_init` — `doc/using_init_args.md`.
 - **MCP server** — tools/resources over JSON-RPC — `doc/using_mcp.md`, `doc/mcp_crash_course.md`.
 - **Rails generators** — `install` and `entity_set` — `doc/entity_set_generator.md`.

--- a/doc/prds/property-mutability-oas2-bodies-plan.md
+++ b/doc/prds/property-mutability-oas2-bodies-plan.md
@@ -56,7 +56,7 @@ specs `spec/odata_duty/entity_set/create/oas2_spec.rb`,
 
 ### Task 2 — Emit `<Entity>Update` definition; point `PATCH` body at it
 
-- [x] **Title:** Per-operation Update request body in `$oas2`
+- [ ] **Title:** Per-operation Update request body in `$oas2`
 
 **Task text:** In `lib/odata_duty/oas2.rb` + `lib/odata_duty/oas2/individual_patch_path.rb`,
 emit a new `<Entity>Update` definition for every update-able entity set and make the `patch`
@@ -88,7 +88,7 @@ spec in both trees.
 
 ### Task 3 — Documentation + Features index
 
-- [x] **Title:** Document per-operation `$oas2` bodies
+- [ ] **Title:** Document per-operation `$oas2` bodies
 
 **Task text:** Update `doc/using_mutability.md`: replace the "`$oas2` — not yet
 operation-aware (interim gap)" section (and the "`$oas2` is unchanged"/"addressed in a

--- a/doc/prds/property-mutability-oas2-bodies-plan.md
+++ b/doc/prds/property-mutability-oas2-bodies-plan.md
@@ -1,0 +1,113 @@
+# Build plan: Per-operation `$oas2` request-body schemas
+
+PRD: [`property-mutability-oas2-bodies.md`](property-mutability-oas2-bodies.md)
+
+## Context
+
+`$oas2` generation lives entirely in `lib/odata_duty/oas2.rb` + `lib/odata_duty/oas2/*`
+and operates on a `SchemaBuilder::Schema` (DSL-agnostic). Both spec trees
+(`spec/odata_duty/entity_set/**` and `spec/odata_duty/schema_builder/**`) exercise it via
+`OdataDuty::OAS2.build_json(schema, context:)` with builder-constructed schemas — the
+existing convention. Properties already expose `settable_on_create?` (`:read_write` +
+`:immutable`) and `settable_on_update?` (`:read_write` + `:non_insertable`) from Parts A/B,
+and `to_oas2` already emits `readOnly: true` for `:computed`.
+
+Existing specs that assert the OLD shared-ref bodies and must be revised as part of the
+relevant task:
+- `spec/odata_duty/{entity_set,schema_builder/entity_set}/computed_oas2_spec.rb` — "keeps the
+  post body referencing the shared entity definition" (Task 1).
+- `spec/odata_duty/{entity_set,schema_builder/entity_set}/update/oas2_spec.rb` — patch body
+  `$ref` to shared entity (Task 2).
+
+## Tasks
+
+### Task 1 — Emit `<Entity>Create` definition; point `POST` body at it
+
+- [x] **Title:** Per-operation Create request body in `$oas2`
+
+**Task text:** In `lib/odata_duty/oas2.rb` + `lib/odata_duty/oas2/collection_post_path.rb`,
+emit a new `<Entity>Create` definition for every create-able entity set and make the `post`
+operation's `body` parameter reference `#/definitions/<Entity>Create` instead of the shared
+`#/definitions/<Entity>`. The `200`/`201` responses keep referencing the full
+`#/definitions/<Entity>`. `<Entity>Create` contains only properties settable on create
+(`property.settable_on_create?` — i.e. `:read_write` + `:immutable`; `:computed` and
+`:non_insertable` omitted), using the same `property.to_oas2` rendering as the response
+definition. Its `required` array lists the non-nullable create-settable properties (mirroring
+`McpInputSchemas.create_input_schema`); omit the `required` key when empty. Emit
+`<Entity>Create` for **every** create-able set, even one with no constrained properties (body
+then equals the writable set). Do **not** emit `x-ms-mutability`. Update the existing specs
+that assert the old shared post-body ref. Add specs in **both** spec trees covering: the
+`<Entity>Create` definition's properties + `required`, the post body `$ref` pointing at it,
+the responses still pointing at `<Entity>`, and the uniform-emission case (no constrained
+props).
+
+**Defining PRD excerpt:** `<Entity>Create` — the `POST` request body. Only properties
+settable on create (`:read_write` + `:immutable`); `:computed` and `:non_insertable` omitted.
+`OrderCreate` example with `"required": ["account_number"]`. The `post` operation's `body`
+parameter references `#/definitions/OrderCreate`; responds with `#/definitions/Order`
+(`200`/`201`). Emitted for every create-able set even with no constrained properties.
+
+**Likely files:** `lib/odata_duty/oas2.rb`, `lib/odata_duty/oas2/collection_post_path.rb`;
+specs `spec/odata_duty/entity_set/create/oas2_spec.rb`,
+`spec/odata_duty/schema_builder/entity_set/create/oas2_spec.rb`,
+`spec/odata_duty/{entity_set,schema_builder/entity_set}/computed_oas2_spec.rb`.
+
+**Depends on:** none.
+
+### Task 2 — Emit `<Entity>Update` definition; point `PATCH` body at it
+
+- [x] **Title:** Per-operation Update request body in `$oas2`
+
+**Task text:** In `lib/odata_duty/oas2.rb` + `lib/odata_duty/oas2/individual_patch_path.rb`,
+emit a new `<Entity>Update` definition for every update-able entity set and make the `patch`
+operation's `body` parameter reference `#/definitions/<Entity>Update` instead of the shared
+`#/definitions/<Entity>`. The `id` path parameter and the `200` response are unchanged (`200`
+still references `#/definitions/<Entity>`). `<Entity>Update` contains only properties settable
+on update (`property.settable_on_update?` — i.e. `:read_write` + `:non_insertable`;
+`:computed` and `:immutable` omitted; the key travels in the path, not the body), using the
+same `property.to_oas2` rendering. PATCH is partial-merge, so emit **no** `required` key
+(matching the PRD's `OrderUpdate` example). Emit `<Entity>Update` for **every** update-able
+set, even one with no constrained properties. Do **not** emit `x-ms-mutability`. Update the
+existing specs that assert the old shared patch-body ref. Add specs in **both** spec trees
+covering: the `<Entity>Update` definition's properties, the patch body `$ref` pointing at it,
+the `200` response still pointing at `<Entity>`, and the uniform-emission case.
+
+**Defining PRD excerpt:** `<Entity>Update` — the `PATCH` request body. Only properties
+settable on update (`:read_write` + `:non_insertable`); `:computed` and `:immutable` omitted.
+(The key travels in the path, not the body.) `OrderUpdate` example has no `required`. The
+`patch` operation's body references `#/definitions/OrderUpdate`; responds with
+`#/definitions/Order` (`200`). Emitted for every update-able set even with no constrained
+properties.
+
+**Likely files:** `lib/odata_duty/oas2.rb`, `lib/odata_duty/oas2/individual_patch_path.rb`;
+specs `spec/odata_duty/entity_set/update/oas2_spec.rb`,
+`spec/odata_duty/schema_builder/entity_set/update/oas2_spec.rb`, plus a constrained-properties
+spec in both trees.
+
+**Depends on:** Task 1 (shared `add_request_body_definitions` plumbing in `oas2.rb`).
+
+### Task 3 — Documentation + Features index
+
+- [x] **Title:** Document per-operation `$oas2` bodies
+
+**Task text:** Update `doc/using_mutability.md`: replace the "`$oas2` — not yet
+operation-aware (interim gap)" section (and the "`$oas2` is unchanged"/"addressed in a
+follow-up" note in the summary) with a `$oas2` section describing the three definitions
+(`<Entity>`, `<Entity>Create`, `<Entity>Update`) and the per-operation body mapping (post →
+Create, patch → Update, responses → `<Entity>`, `readOnly: true` on `:computed` in the
+response, no `x-ms-mutability`). Update `doc/using_create_update_and_delete.md`: revise the
+`$oas2` examples so the `post` body references `#/definitions/<Entity>Create` and the `patch`
+body references `#/definitions/<Entity>Update` (responses unchanged), including for sets with
+no constrained properties; adjust surrounding prose accordingly. Keep `CLAUDE.md`'s `## Features`
+"Property mutability" line current (it already points at `doc/using_mutability.md` and now
+covers `$oas2`).
+
+**Defining PRD excerpt:** Documentation impact — update `doc/using_mutability.md` with the
+`$oas2` section and remove "`$oas2` deferred" notes; update
+`doc/using_create_update_and_delete.md`'s `$oas2` examples to reference `<Entity>Create` /
+`<Entity>Update`, including for sets with no constrained properties.
+
+**Likely files:** `doc/using_mutability.md`, `doc/using_create_update_and_delete.md`,
+`CLAUDE.md`.
+
+**Depends on:** Tasks 1 & 2.

--- a/doc/prds/property-mutability-oas2-bodies-plan.md
+++ b/doc/prds/property-mutability-oas2-bodies-plan.md
@@ -56,7 +56,7 @@ specs `spec/odata_duty/entity_set/create/oas2_spec.rb`,
 
 ### Task 2 — Emit `<Entity>Update` definition; point `PATCH` body at it
 
-- [ ] **Title:** Per-operation Update request body in `$oas2`
+- [x] **Title:** Per-operation Update request body in `$oas2`
 
 **Task text:** In `lib/odata_duty/oas2.rb` + `lib/odata_duty/oas2/individual_patch_path.rb`,
 emit a new `<Entity>Update` definition for every update-able entity set and make the `patch`

--- a/doc/prds/property-mutability-oas2-bodies-plan.md
+++ b/doc/prds/property-mutability-oas2-bodies-plan.md
@@ -88,7 +88,7 @@ spec in both trees.
 
 ### Task 3 — Documentation + Features index
 
-- [ ] **Title:** Document per-operation `$oas2` bodies
+- [x] **Title:** Document per-operation `$oas2` bodies
 
 **Task text:** Update `doc/using_mutability.md`: replace the "`$oas2` — not yet
 operation-aware (interim gap)" section (and the "`$oas2` is unchanged"/"addressed in a

--- a/doc/using_create_update_and_delete.md
+++ b/doc/using_create_update_and_delete.md
@@ -235,7 +235,7 @@ A **`create`able** set's collection path exposes both `get` and `post`. The `pos
         "produces": ["application/json"],
         "parameters": [
           { "name": "body", "in": "body", "required": true,
-            "schema": { "$ref": "#/definitions/Person" } }
+            "schema": { "$ref": "#/definitions/PersonCreate" } }
         ],
         "responses": {
           "200": { "description": "Success", "schema": { "$ref": "#/definitions/Person" } },
@@ -248,7 +248,9 @@ A **`create`able** set's collection path exposes both `get` and `post`. The `pos
 }
 ```
 
-An **`update`able** set's *individual* path gains a `patch` alongside its `get`. The `operationId` is `Update<Set>` (e.g. `UpdatePeople`); its parameters are the `id` path parameter plus a required `body` parameter `$ref`ing the entity. Note the responses are `200` Success and `default` Error only — there is no `201`, unlike `create`'s `post`:
+The `post` body references the per-operation `PersonCreate` definition (the create-settable properties), while its responses return the full `Person`. See [`doc/using_mutability.md`](using_mutability.md) for how `mutability:` shapes `<Entity>Create` / `<Entity>Update`.
+
+An **`update`able** set's *individual* path gains a `patch` alongside its `get`. The `operationId` is `Update<Set>` (e.g. `UpdatePeople`); its parameters are the `id` path parameter plus a required `body` parameter `$ref`ing the per-operation `PersonUpdate` definition (the update-settable properties). Note the responses are `200` Success and `default` Error only — there is no `201`, unlike `create`'s `post`:
 
 ```jsonc
 {
@@ -261,7 +263,7 @@ An **`update`able** set's *individual* path gains a `patch` alongside its `get`.
         "parameters": [
           { "name": "id", "in": "path", "required": true, "type": "string" },
           { "name": "body", "in": "body", "required": true,
-            "schema": { "$ref": "#/definitions/Person" } }
+            "schema": { "$ref": "#/definitions/PersonUpdate" } }
         ],
         "responses": {
           "200": { "description": "Success", "schema": { "$ref": "#/definitions/Person" } },
@@ -272,6 +274,8 @@ An **`update`able** set's *individual* path gains a `patch` alongside its `get`.
   }
 }
 ```
+
+These per-operation request-body definitions are emitted for every create-/update-able set, including sets with no constrained properties — there `PersonCreate` / `PersonUpdate` equal the writable set. The `post` and `patch` responses keep returning the full `Person`.
 
 A **`delete`able** set's *individual* path gains a `delete` alongside its `get` (and `patch`, if updatable). The `operationId` is `Delete<Set>` (e.g. `DeletePeople`); its only parameter is the `id` path parameter — there is no body. Its responses are `204` No Content (with no success schema) and `default` Error only:
 

--- a/doc/using_mutability.md
+++ b/doc/using_mutability.md
@@ -183,9 +183,42 @@ The `create_<Set>` tool's `inputSchema` includes `:read_write` and `:immutable` 
 }
 ```
 
-### `$oas2` — not yet operation-aware (interim gap)
+### `$oas2`
 
-`$oas2` is **not** changed in this part. The `post` and `patch` operations still share one request body referencing the entity definition, where only `:computed` properties carry `readOnly: true`. An `:immutable` property therefore still appears writable in the `patch` body, even though the typed input drops it on update; likewise a `:non_insertable` property still appears writable in the `post` body, even though the typed input drops it on create. This is a known, documented interim gap — the per-operation `$oas2` body split lands in a follow-up part.
+`$oas2` emits **three** definitions per writable entity, and the operation bodies are mapped per operation. The `<Entity>` definition is the full response shape — every property, with `:computed` carrying `readOnly: true` and nullable properties carrying `x-nullable: true`. The `post` body references `<Entity>Create` (`:read_write` + `:immutable`; `:computed` and `:non_insertable` omitted) and the `patch` body references `<Entity>Update` (`:read_write` + `:non_insertable`; `:computed` and `:immutable` omitted — the key travels in the path). Responses (and all `GET` / `collection` / `individual` reads) reference `<Entity>`. `<Entity>Create` lists its non-nullable create-settable properties in `required`; `<Entity>Update` has no `required` (PATCH is partial-merge):
+
+```jsonc
+// definitions — three shapes for the Order entity
+{
+  "Order": {
+    "type": "object",
+    "properties": {
+      "id":             { "type": "string", "readOnly": true },
+      "account_number": { "type": "string" },
+      "note":           { "type": "string", "x-nullable": true },
+      "status":         { "type": "string", "x-nullable": true },
+      "created_at":     { "type": "string", "readOnly": true, "x-nullable": true }
+    }
+  },
+  "OrderCreate": {
+    "type": "object",
+    "properties": {
+      "account_number": { "type": "string" },
+      "note":           { "type": "string", "x-nullable": true }
+    },
+    "required": ["account_number"]
+  },
+  "OrderUpdate": {
+    "type": "object",
+    "properties": {
+      "note":   { "type": "string", "x-nullable": true },
+      "status": { "type": "string", "x-nullable": true }
+    }
+  }
+}
+```
+
+The per-operation bodies are emitted for **every** writable set, even one with no constrained properties (where `<Entity>Create` / `<Entity>Update` simply equal the writable set). `x-ms-mutability` is **not** emitted: it is an AutoRest SDK extension that Power Automate / Logic Apps custom connectors do not honour — they consume the separate Create and Update actions with their separate bodies instead, and `readOnly` covers the computed case in the `<Entity>` response.
 
 ## Common errors / edge cases
 
@@ -200,4 +233,4 @@ The `create_<Set>` tool's `inputSchema` includes `:read_write` and `:immutable` 
 - **`mutability:`** is the per-property create/update axis: `:read_write` (default), `:immutable`, `:non_insertable`, `:computed`.
 - **`:immutable`** is set on create, frozen on update; **`:non_insertable`** is the mirror — dropped on create, settable on update; **`:computed`** is read-only on both. All three still render in every read response.
 - **`computed:` is a backward-compatible alias** (`true` ≡ `:computed`, `false` ≡ `:read_write`); keys default to `:computed`. Passing both keywords, or an unknown value, raises `ArgumentError`.
-- **Reflected in** `$metadata` (`Core.Immutable` / `Core.Computed` / none, plus `Capabilities.InsertRestrictions/NonInsertableProperties` for `:non_insertable`) and MCP (create excludes non_insertable + computed, update excludes immutable + computed). **`$oas2` is unchanged in this part** — an immutable property still appears writable in the shared `patch` body and a non_insertable one in the shared `post` body, addressed in a follow-up.
+- **Reflected in** `$metadata` (`Core.Immutable` / `Core.Computed` / none, plus `Capabilities.InsertRestrictions/NonInsertableProperties` for `:non_insertable`) and MCP (create excludes non_insertable + computed, update excludes immutable + computed). **`$oas2`** now emits per-operation `<Entity>Create` / `<Entity>Update` request bodies (create excludes computed + non_insertable; update excludes computed + immutable) alongside the full `<Entity>` response, where `:computed` is `readOnly`.

--- a/lib/odata_duty/oas2.rb
+++ b/lib/odata_duty/oas2.rb
@@ -57,14 +57,10 @@ module OdataDuty
     end
 
     def add_request_body_definitions
-      schema.collection_entity_sets.each do |entity_set|
-        next unless entity_set.supports_create?
-
+      schema.collection_entity_sets.select(&:supports_create?).each do |entity_set|
         register_definition(CollectionPostPath.request_body_definition(entity_set))
       end
-      schema.individual_entity_sets.each do |entity_set|
-        next unless entity_set.supports_update?
-
+      schema.individual_entity_sets.select(&:supports_update?).each do |entity_set|
         register_definition(IndividualPatchPath.request_body_definition(entity_set))
       end
     end

--- a/lib/odata_duty/oas2.rb
+++ b/lib/odata_duty/oas2.rb
@@ -60,8 +60,12 @@ module OdataDuty
       schema.collection_entity_sets.each do |entity_set|
         next unless entity_set.supports_create?
 
-        name, definition = CollectionPostPath.request_body_definition(entity_set)
-        hash['definitions'][name] = definition
+        register_definition(CollectionPostPath.request_body_definition(entity_set))
+      end
+      schema.individual_entity_sets.each do |entity_set|
+        next unless entity_set.supports_update?
+
+        register_definition(IndividualPatchPath.request_body_definition(entity_set))
       end
     end
 
@@ -90,6 +94,10 @@ module OdataDuty
     }.freeze
 
     private
+
+    def register_definition((name, definition))
+      hash['definitions'][name] = definition
+    end
 
     def wrap_context(entity_set)
       ContextWrapper.new(@context, base_url: schema.base_url,

--- a/lib/odata_duty/oas2.rb
+++ b/lib/odata_duty/oas2.rb
@@ -8,6 +8,7 @@ module OdataDuty
       builder.add_error_definition
       builder.add_enum_definitions
       builder.add_complex_definitions
+      builder.add_request_body_definitions
       builder.add_collection_paths
       builder.add_individual_paths
       builder.hash
@@ -52,6 +53,15 @@ module OdataDuty
     def add_complex_definitions
       (schema.complex_types + schema.entity_types).each do |complex_type|
         hash['definitions'][complex_type.name] = complex_type.to_oas2
+      end
+    end
+
+    def add_request_body_definitions
+      schema.collection_entity_sets.each do |entity_set|
+        next unless entity_set.supports_create?
+
+        name, definition = CollectionPostPath.request_body_definition(entity_set)
+        hash['definitions'][name] = definition
       end
     end
 

--- a/lib/odata_duty/oas2/collection_post_path.rb
+++ b/lib/odata_duty/oas2/collection_post_path.rb
@@ -11,6 +11,15 @@ module OdataDuty
         }
       end
 
+      def self.request_body_definition(entity_set)
+        writable = entity_set.entity_type.properties.select(&:settable_on_create?)
+        definition = { 'type' => 'object',
+                       'properties' => writable.to_h { |p| [p.name.to_s, p.to_oas2] } }
+        required = writable.reject(&:nullable).map { |p| p.name.to_s }
+        definition['required'] = required unless required.empty?
+        ["#{entity_set.entity_type.name}Create", definition]
+      end
+
       def initialize(entity_set)
         @entity_set = entity_set
       end
@@ -26,7 +35,7 @@ module OdataDuty
       def parameters
         [
           {
-            'name' => 'body', 'in' => 'body', 'required' => true, 'schema' => entity_type_schema
+            'name' => 'body', 'in' => 'body', 'required' => true, 'schema' => create_schema
           }
         ]
       end
@@ -44,6 +53,10 @@ module OdataDuty
 
       def entity_type_schema
         { '$ref' => "#/definitions/#{@entity_set.entity_type.name}" }
+      end
+
+      def create_schema
+        { '$ref' => "#/definitions/#{@entity_set.entity_type.name}Create" }
       end
     end
   end

--- a/lib/odata_duty/oas2/individual_patch_path.rb
+++ b/lib/odata_duty/oas2/individual_patch_path.rb
@@ -11,6 +11,13 @@ module OdataDuty
         }
       end
 
+      def self.request_body_definition(entity_set)
+        writable = entity_set.entity_type.properties.select(&:settable_on_update?)
+        definition = { 'type' => 'object',
+                       'properties' => writable.to_h { |p| [p.name.to_s, p.to_oas2] } }
+        ["#{entity_set.entity_type.name}Update", definition]
+      end
+
       def initialize(entity_set)
         @entity_set = entity_set
       end
@@ -26,7 +33,7 @@ module OdataDuty
       def parameters
         [
           { 'name' => 'id', 'in' => 'path', 'required' => true, 'type' => id_type },
-          { 'name' => 'body', 'in' => 'body', 'required' => true, 'schema' => entity_type_schema }
+          { 'name' => 'body', 'in' => 'body', 'required' => true, 'schema' => update_schema }
         ]
       end
 
@@ -46,6 +53,10 @@ module OdataDuty
 
       def entity_type_schema
         { '$ref' => "#/definitions/#{@entity_set.entity_type.name}" }
+      end
+
+      def update_schema
+        { '$ref' => "#/definitions/#{@entity_set.entity_type.name}Update" }
       end
     end
   end

--- a/odata_duty.gemspec
+++ b/odata_duty.gemspec
@@ -2,7 +2,7 @@
 
 Gem::Specification.new do |spec|
   spec.name          = 'odata_duty'
-  spec.version       = '0.20.1'
+  spec.version       = '0.21.0'
   spec.authors       = ['Grant Petersen-Speelman']
   spec.email         = ['grant@nexl.io']
 

--- a/spec/odata_duty/entity_set/computed_oas2_spec.rb
+++ b/spec/odata_duty/entity_set/computed_oas2_spec.rb
@@ -42,8 +42,13 @@ RSpec.describe OdataDuty::EntitySet, 'computed properties as readOnly in $oas2' 
     )
   end
 
-  it 'keeps the post body referencing the shared entity definition' do
+  it 'references the <Entity>Create definition in the post body' do
     body = json.dig('paths', '/ComputedOas2Collection', 'post', 'parameters').first
-    expect(body['schema']).to eq('$ref' => '#/definitions/ComputedOas2Entity')
+    expect(body['schema']).to eq('$ref' => '#/definitions/ComputedOas2EntityCreate')
+  end
+
+  it 'omits the computed and key properties from the <Entity>Create definition' do
+    create_properties = json.dig('definitions', 'ComputedOas2EntityCreate', 'properties')
+    expect(create_properties.keys).to contain_exactly('user_name')
   end
 end

--- a/spec/odata_duty/entity_set/create/oas2_spec.rb
+++ b/spec/odata_duty/entity_set/create/oas2_spec.rb
@@ -58,3 +58,109 @@ RSpec.describe OdataDuty::EntitySet, 'gates $oas2 post on create support' do
     end
   end
 end
+
+class MutabilityCreateOas2Resolver < OdataDuty::SetResolver
+  def collection
+    []
+  end
+
+  def create(params)
+    params
+  end
+end
+
+class WritableCreateOas2Resolver < OdataDuty::SetResolver
+  def collection
+    []
+  end
+
+  def create(params)
+    params
+  end
+end
+
+RSpec.describe OdataDuty::EntitySet, 'emits a <Entity>Create request body definition' do
+  let(:oas2_schema) do
+    OdataDuty::SchemaBuilder.build(namespace: 'SampleSpace', host: 'localhost',
+                                   base_path: '/api') do |s|
+      mutability_entity = s.add_entity_type(name: 'MutabilityCreateOas2Entity') do |et|
+        et.property_ref 'id', String
+        et.property 'account_number', String, nullable: false, mutability: :immutable
+        et.property 'note', String
+        et.property 'updated_via', String, mutability: :non_insertable
+        et.property 'created_at', DateTime, mutability: :computed
+      end
+      s.add_entity_set(name: 'MutabilityCreateOas2Collection', entity_type: mutability_entity,
+                       resolver: 'MutabilityCreateOas2Resolver')
+
+      writable_entity = s.add_entity_type(name: 'WritableCreateOas2Entity') do |et|
+        et.property_ref 'id', String
+        et.property 'name', String, nullable: false
+        et.property 'note', String
+      end
+      s.add_entity_set(name: 'WritableCreateOas2Collection', entity_type: writable_entity,
+                       resolver: 'WritableCreateOas2Resolver')
+    end
+  end
+
+  let(:json) { OdataDuty::OAS2.build_json(oas2_schema, context: Context.new) }
+
+  describe 'MutabilityCreateOas2EntityCreate definition' do
+    let(:definition) { json.dig('definitions', 'MutabilityCreateOas2EntityCreate') }
+
+    it 'declares the object type' do
+      expect(definition['type']).to eq('object')
+    end
+
+    it 'includes read_write and immutable properties' do
+      expect(definition['properties']).to include('account_number', 'note')
+    end
+
+    it 'omits computed and non_insertable properties' do
+      expect(definition['properties']).not_to include('created_at', 'updated_via', 'id')
+    end
+
+    it 'requires the non-nullable create-settable properties' do
+      expect(definition['required']).to eq(['account_number'])
+    end
+
+    it 'does not emit x-ms-mutability' do
+      expect(definition.to_s).not_to include('x-ms-mutability')
+    end
+  end
+
+  describe 'MutabilityCreateOas2Collection post operation' do
+    let(:post) { json.dig('paths', '/MutabilityCreateOas2Collection', 'post') }
+
+    it 'references the <Entity>Create definition in the body parameter' do
+      body = post['parameters'].first
+      expect(body['schema']).to eq('$ref' => '#/definitions/MutabilityCreateOas2EntityCreate')
+    end
+
+    it 'still responds with the full entity definition on 200' do
+      expect(post.dig('responses', '200', 'schema'))
+        .to eq('$ref' => '#/definitions/MutabilityCreateOas2Entity')
+    end
+
+    it 'still responds with the full entity definition on 201' do
+      expect(post.dig('responses', '201', 'schema'))
+        .to eq('$ref' => '#/definitions/MutabilityCreateOas2Entity')
+    end
+  end
+
+  describe 'a create-able set with no constrained properties' do
+    let(:definition) { json.dig('definitions', 'WritableCreateOas2EntityCreate') }
+
+    it 'still emits a <Entity>Create definition' do
+      expect(definition).not_to be_nil
+    end
+
+    it 'includes all writable properties' do
+      expect(definition['properties']).to include('name', 'note')
+    end
+
+    it 'requires only the non-nullable writable properties' do
+      expect(definition['required']).to eq(['name'])
+    end
+  end
+end

--- a/spec/odata_duty/entity_set/update/oas2_spec.rb
+++ b/spec/odata_duty/entity_set/update/oas2_spec.rb
@@ -50,7 +50,7 @@ RSpec.describe OdataDuty::EntitySet, 'gates $oas2 patch on update support' do
         [
           { 'name' => 'id', 'in' => 'path', 'required' => true, 'type' => 'string' },
           { 'name' => 'body', 'in' => 'body', 'required' => true,
-            'schema' => { '$ref' => '#/definitions/UpdateOas2TestEntity' } }
+            'schema' => { '$ref' => '#/definitions/UpdateOas2TestEntityUpdate' } }
         ]
       )
     end
@@ -74,6 +74,107 @@ RSpec.describe OdataDuty::EntitySet, 'gates $oas2 patch on update support' do
 
     it 'does not include a patch operation when update is not supported' do
       expect(path).not_to have_key('patch')
+    end
+  end
+end
+
+class MutabilityUpdateOas2Resolver < OdataDuty::SetResolver
+  def individual(id)
+    { 'id' => id }
+  end
+
+  def update(id, params)
+    [id, params]
+  end
+end
+
+class WritableUpdateOas2Resolver < OdataDuty::SetResolver
+  def individual(id)
+    { 'id' => id }
+  end
+
+  def update(id, params)
+    [id, params]
+  end
+end
+
+RSpec.describe OdataDuty::EntitySet, 'emits a <Entity>Update request body definition' do
+  let(:oas2_schema) do
+    OdataDuty::SchemaBuilder.build(namespace: 'SampleSpace', host: 'localhost',
+                                   base_path: '/api') do |s|
+      mutability_entity = s.add_entity_type(name: 'MutabilityUpdateOas2Entity') do |et|
+        et.property_ref 'id', String
+        et.property 'account_number', String, nullable: false, mutability: :immutable
+        et.property 'note', String
+        et.property 'updated_via', String, mutability: :non_insertable
+        et.property 'created_at', DateTime, mutability: :computed
+      end
+      s.add_entity_set(name: 'MutabilityUpdateOas2Collection', entity_type: mutability_entity,
+                       resolver: 'MutabilityUpdateOas2Resolver')
+
+      writable_entity = s.add_entity_type(name: 'WritableUpdateOas2Entity') do |et|
+        et.property_ref 'id', String
+        et.property 'name', String, nullable: false
+        et.property 'note', String
+      end
+      s.add_entity_set(name: 'WritableUpdateOas2Collection', entity_type: writable_entity,
+                       resolver: 'WritableUpdateOas2Resolver')
+    end
+  end
+
+  let(:json) { OdataDuty::OAS2.build_json(oas2_schema, context: Context.new) }
+
+  describe 'MutabilityUpdateOas2EntityUpdate definition' do
+    let(:definition) { json.dig('definitions', 'MutabilityUpdateOas2EntityUpdate') }
+
+    it 'declares the object type' do
+      expect(definition['type']).to eq('object')
+    end
+
+    it 'includes read_write and non_insertable properties' do
+      expect(definition['properties']).to include('note', 'updated_via')
+    end
+
+    it 'omits computed, immutable, and the key properties' do
+      expect(definition['properties']).not_to include('created_at', 'account_number', 'id')
+    end
+
+    it 'does not emit a required key (PATCH is partial-merge)' do
+      expect(definition).not_to have_key('required')
+    end
+
+    it 'does not emit x-ms-mutability' do
+      expect(definition.to_s).not_to include('x-ms-mutability')
+    end
+  end
+
+  describe 'MutabilityUpdateOas2Collection patch operation' do
+    let(:patch) { json.dig('paths', '/MutabilityUpdateOas2Collection({id})', 'patch') }
+
+    it 'references the <Entity>Update definition in the body parameter' do
+      body = patch['parameters'].last
+      expect(body['schema']).to eq('$ref' => '#/definitions/MutabilityUpdateOas2EntityUpdate')
+    end
+
+    it 'still responds with the full entity definition on 200' do
+      expect(patch.dig('responses', '200', 'schema'))
+        .to eq('$ref' => '#/definitions/MutabilityUpdateOas2Entity')
+    end
+  end
+
+  describe 'an update-able set with no constrained properties' do
+    let(:definition) { json.dig('definitions', 'WritableUpdateOas2EntityUpdate') }
+
+    it 'still emits a <Entity>Update definition' do
+      expect(definition).not_to be_nil
+    end
+
+    it 'includes all update-settable properties' do
+      expect(definition['properties']).to include('name', 'note')
+    end
+
+    it 'does not emit a required key' do
+      expect(definition).not_to have_key('required')
     end
   end
 end

--- a/spec/odata_duty/schema_builder/entity_set/computed_oas2_spec.rb
+++ b/spec/odata_duty/schema_builder/entity_set/computed_oas2_spec.rb
@@ -42,8 +42,13 @@ RSpec.describe OdataDuty::SchemaBuilder, 'computed properties as readOnly in $oa
     )
   end
 
-  it 'keeps the post body referencing the shared entity definition' do
+  it 'references the <Entity>Create definition in the post body' do
     body = json.dig('paths', '/ComputedOas2BuilderCollection', 'post', 'parameters').first
-    expect(body['schema']).to eq('$ref' => '#/definitions/ComputedOas2BuilderEntity')
+    expect(body['schema']).to eq('$ref' => '#/definitions/ComputedOas2BuilderEntityCreate')
+  end
+
+  it 'omits the computed and key properties from the <Entity>Create definition' do
+    create_properties = json.dig('definitions', 'ComputedOas2BuilderEntityCreate', 'properties')
+    expect(create_properties.keys).to contain_exactly('user_name')
   end
 end

--- a/spec/odata_duty/schema_builder/entity_set/create/oas2_spec.rb
+++ b/spec/odata_duty/schema_builder/entity_set/create/oas2_spec.rb
@@ -58,3 +58,112 @@ RSpec.describe OdataDuty::SchemaBuilder, 'gates $oas2 post on create support' do
     end
   end
 end
+
+class MutabilityCreateOas2BuilderResolver < OdataDuty::SetResolver
+  def collection
+    []
+  end
+
+  def create(params)
+    params
+  end
+end
+
+class WritableCreateOas2BuilderResolver < OdataDuty::SetResolver
+  def collection
+    []
+  end
+
+  def create(params)
+    params
+  end
+end
+
+RSpec.describe OdataDuty::SchemaBuilder, 'emits a <Entity>Create request body definition' do
+  let(:oas2_schema) do
+    OdataDuty::SchemaBuilder.build(namespace: 'SampleSpace', host: 'localhost',
+                                   base_path: '/api') do |s|
+      mutability_entity = s.add_entity_type(name: 'MutabilityCreateOas2BuilderEntity') do |et|
+        et.property_ref 'id', String
+        et.property 'account_number', String, nullable: false, mutability: :immutable
+        et.property 'note', String
+        et.property 'updated_via', String, mutability: :non_insertable
+        et.property 'created_at', DateTime, mutability: :computed
+      end
+      s.add_entity_set(name: 'MutabilityCreateOas2BuilderCollection',
+                       entity_type: mutability_entity,
+                       resolver: 'MutabilityCreateOas2BuilderResolver')
+
+      writable_entity = s.add_entity_type(name: 'WritableCreateOas2BuilderEntity') do |et|
+        et.property_ref 'id', String
+        et.property 'name', String, nullable: false
+        et.property 'note', String
+      end
+      s.add_entity_set(name: 'WritableCreateOas2BuilderCollection',
+                       entity_type: writable_entity,
+                       resolver: 'WritableCreateOas2BuilderResolver')
+    end
+  end
+
+  let(:json) { OdataDuty::OAS2.build_json(oas2_schema, context: Context.new) }
+
+  describe 'MutabilityCreateOas2BuilderEntityCreate definition' do
+    let(:definition) { json.dig('definitions', 'MutabilityCreateOas2BuilderEntityCreate') }
+
+    it 'declares the object type' do
+      expect(definition['type']).to eq('object')
+    end
+
+    it 'includes read_write and immutable properties' do
+      expect(definition['properties']).to include('account_number', 'note')
+    end
+
+    it 'omits computed and non_insertable properties' do
+      expect(definition['properties']).not_to include('created_at', 'updated_via', 'id')
+    end
+
+    it 'requires the non-nullable create-settable properties' do
+      expect(definition['required']).to eq(['account_number'])
+    end
+
+    it 'does not emit x-ms-mutability' do
+      expect(definition.to_s).not_to include('x-ms-mutability')
+    end
+  end
+
+  describe 'MutabilityCreateOas2BuilderCollection post operation' do
+    let(:post) { json.dig('paths', '/MutabilityCreateOas2BuilderCollection', 'post') }
+
+    it 'references the <Entity>Create definition in the body parameter' do
+      body = post['parameters'].first
+      expect(body['schema'])
+        .to eq('$ref' => '#/definitions/MutabilityCreateOas2BuilderEntityCreate')
+    end
+
+    it 'still responds with the full entity definition on 200' do
+      expect(post.dig('responses', '200', 'schema'))
+        .to eq('$ref' => '#/definitions/MutabilityCreateOas2BuilderEntity')
+    end
+
+    it 'still responds with the full entity definition on 201' do
+      expect(post.dig('responses', '201', 'schema'))
+        .to eq('$ref' => '#/definitions/MutabilityCreateOas2BuilderEntity')
+    end
+  end
+
+  describe 'a create-able set with no constrained properties' do
+    let(:definition) { json.dig('definitions', 'WritableCreateOas2BuilderEntityCreate') }
+
+    it 'still emits a <Entity>Create definition' do
+      expect(definition).not_to be_nil
+    end
+
+    it 'includes all writable properties' do
+      expect(definition['properties']).to include('name', 'note')
+    end
+
+    it 'requires only the non-nullable writable properties' do
+      expect(definition['required']).to eq(['name'])
+    end
+  end
+end

--- a/spec/odata_duty/schema_builder/entity_set/update/oas2_spec.rb
+++ b/spec/odata_duty/schema_builder/entity_set/update/oas2_spec.rb
@@ -50,7 +50,7 @@ RSpec.describe OdataDuty::SchemaBuilder, 'gates $oas2 patch on update support' d
         [
           { 'name' => 'id', 'in' => 'path', 'required' => true, 'type' => 'string' },
           { 'name' => 'body', 'in' => 'body', 'required' => true,
-            'schema' => { '$ref' => '#/definitions/UpdateOas2BuilderTestEntity' } }
+            'schema' => { '$ref' => '#/definitions/UpdateOas2BuilderTestEntityUpdate' } }
         ]
       )
     end
@@ -74,6 +74,112 @@ RSpec.describe OdataDuty::SchemaBuilder, 'gates $oas2 patch on update support' d
 
     it 'does not include a patch operation when update is not supported' do
       expect(path).not_to have_key('patch')
+    end
+  end
+end
+
+class MutabilityBuilderUpdateOas2Resolver < OdataDuty::SetResolver
+  def individual(id)
+    { 'id' => id }
+  end
+
+  def update(id, params)
+    [id, params]
+  end
+end
+
+class WritableBuilderUpdateOas2Resolver < OdataDuty::SetResolver
+  def individual(id)
+    { 'id' => id }
+  end
+
+  def update(id, params)
+    [id, params]
+  end
+end
+
+RSpec.describe OdataDuty::SchemaBuilder, 'emits a <Entity>Update request body definition' do
+  let(:oas2_schema) do
+    OdataDuty::SchemaBuilder.build(namespace: 'SampleSpace', host: 'localhost',
+                                   base_path: '/api') do |s|
+      mutability_entity = s.add_entity_type(name: 'MutabilityBuilderUpdateOas2Entity') do |et|
+        et.property_ref 'id', String
+        et.property 'account_number', String, nullable: false, mutability: :immutable
+        et.property 'note', String
+        et.property 'updated_via', String, mutability: :non_insertable
+        et.property 'created_at', DateTime, mutability: :computed
+      end
+      s.add_entity_set(name: 'MutabilityBuilderUpdateOas2Collection',
+                       entity_type: mutability_entity,
+                       resolver: 'MutabilityBuilderUpdateOas2Resolver')
+
+      writable_entity = s.add_entity_type(name: 'WritableBuilderUpdateOas2Entity') do |et|
+        et.property_ref 'id', String
+        et.property 'name', String, nullable: false
+        et.property 'note', String
+      end
+      s.add_entity_set(name: 'WritableBuilderUpdateOas2Collection',
+                       entity_type: writable_entity,
+                       resolver: 'WritableBuilderUpdateOas2Resolver')
+    end
+  end
+
+  let(:json) { OdataDuty::OAS2.build_json(oas2_schema, context: Context.new) }
+
+  describe 'MutabilityBuilderUpdateOas2EntityUpdate definition' do
+    let(:definition) { json.dig('definitions', 'MutabilityBuilderUpdateOas2EntityUpdate') }
+
+    it 'declares the object type' do
+      expect(definition['type']).to eq('object')
+    end
+
+    it 'includes read_write and non_insertable properties' do
+      expect(definition['properties']).to include('note', 'updated_via')
+    end
+
+    it 'omits computed, immutable, and the key properties' do
+      expect(definition['properties']).not_to include('created_at', 'account_number', 'id')
+    end
+
+    it 'does not emit a required key (PATCH is partial-merge)' do
+      expect(definition).not_to have_key('required')
+    end
+
+    it 'does not emit x-ms-mutability' do
+      expect(definition.to_s).not_to include('x-ms-mutability')
+    end
+  end
+
+  describe 'MutabilityBuilderUpdateOas2Collection patch operation' do
+    let(:patch) do
+      json.dig('paths', '/MutabilityBuilderUpdateOas2Collection({id})', 'patch')
+    end
+
+    it 'references the <Entity>Update definition in the body parameter' do
+      body = patch['parameters'].last
+      expect(body['schema'])
+        .to eq('$ref' => '#/definitions/MutabilityBuilderUpdateOas2EntityUpdate')
+    end
+
+    it 'still responds with the full entity definition on 200' do
+      expect(patch.dig('responses', '200', 'schema'))
+        .to eq('$ref' => '#/definitions/MutabilityBuilderUpdateOas2Entity')
+    end
+  end
+
+  describe 'an update-able set with no constrained properties' do
+    let(:definition) { json.dig('definitions', 'WritableBuilderUpdateOas2EntityUpdate') }
+
+    it 'still emits a <Entity>Update definition' do
+      expect(definition).not_to be_nil
+    end
+
+    it 'includes all update-settable properties' do
+      expect(definition['properties']).to include('name', 'note')
+    end
+
+    it 'does not emit a required key' do
+      expect(definition).not_to have_key('required')
     end
   end
 end


### PR DESCRIPTION
Update the docs to reflect the new per-operation $oas2 request-body
definitions now that the interim gap from Parts A/B is closed.

- doc/using_mutability.md: replace the '$oas2 — not yet operation-aware
  (interim gap)' section with a $oas2 section describing the three
  definitions (&lt;Entity&gt;, &lt;Entity&gt;Create, &lt;Entity&gt;Update), the per-operation
  body mapping, readOnly for :computed in the response, emission for every
  writable set, and why x-ms-mutability is not emitted. Revise the summary
  bullet to drop the deferral note.
- doc/using_create_update_and_delete.md: repoint the post body example to
  #/definitions/PersonCreate and the patch body to #/definitions/PersonUpdate
  (responses still return the full Person), and note the per-operation
  definitions are emitted even for sets with no constrained properties.
- CLAUDE.md: extend the Property mutability Features line to mention the
  $oas2 per-operation &lt;Entity&gt;Create/&lt;Entity&gt;Update request bodies.

Completes doc/prds/property-mutability-oas2-bodies.md.

Co-Authored-By: Claude Opus 4.8 (1M context) &lt;noreply@anthropic.com&gt;