### PR TITLE
Document the SimpleCov coverage workflow

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -24,7 +24,7 @@ Short index of what's implemented; see the linked `doc/` guide for the full cont
 
 ## Commands
 
-- `bundle exec rake` — full suite: RSpec **and** RuboCop. This is what CI runs (and it runs `rake` four times to surface flaky tests). Run this before considering work done.
+- `bundle exec rake` — full suite: RSpec **and** RuboCop. This is what CI runs (and it runs `rake` four times to surface flaky tests). Also measures and enforces 100% line + branch coverage via SimpleCov — see `doc/using_coverage.md`. Run this before considering work done.
 - `bundle exec rspec spec/odata_duty/entity_set/collection_spec.rb` — single file.
 - `bundle exec rspec spec/odata_duty/entity_set/collection_spec.rb:42` — single example by line.
 - `bundle exec rubocop` / `bundle exec rubocop -A` — lint / autocorrect.

--- a/Gemfile
+++ b/Gemfile
@@ -17,4 +17,5 @@ gem 'rake', '>= 13.0'
 gem 'rerun', '>= 0.14'
 gem 'rspec', '>= 3.0'
 gem 'rubocop', '>= 1.7'
+gem 'simplecov', '~> 0.22', require: false
 # gem 'vernier', '~> 1.0'

--- a/Rakefile
+++ b/Rakefile
@@ -3,7 +3,12 @@
 require 'bundler/gem_tasks'
 require 'rspec/core/rake_task'
 
+task :enforce_coverage do
+  ENV['COVERAGE_ENFORCE'] = 'true'
+end
+
 RSpec::Core::RakeTask.new(:spec)
+task spec: :enforce_coverage
 
 require 'rubocop/rake_task'
 

--- a/doc/prds/task-thjn171l1biNEh6rHK-plan.md
+++ b/doc/prds/task-thjn171l1biNEh6rHK-plan.md
@@ -68,7 +68,7 @@ above the `require 'odata_duty'` on what is currently line 3).
 
 **Dependencies:** none.
 
-### - [ ] Task 2 — Close all coverage gaps to 100% (line + branch)
+### - [x] Task 2 — Close all coverage gaps to 100% (line + branch)
 
 **Task text:** Bring line and branch coverage of the tracked `lib/` files to **100%/100%**
 by writing meaningful, behavior-focused specs that exercise every currently-uncovered line

--- a/doc/prds/task-thjn171l1biNEh6rHK-plan.md
+++ b/doc/prds/task-thjn171l1biNEh6rHK-plan.md
@@ -95,7 +95,7 @@ pass, the suite must actually reach 100% line and branch coverage of the tracked
 
 **Dependencies:** Task 1 (SimpleCov must be measuring first).
 
-### - [ ] Task 3 — Arm the enforcement gate for full-suite runs
+### - [x] Task 3 — Arm the enforcement gate for full-suite runs
 
 **Task text:** Make the `spec` Rake task (invoked by the `rake` default, CI, and the
 pre-commit hook) set `COVERAGE_ENFORCE` so full-suite runs are strict, while a bare

--- a/doc/prds/task-thjn171l1biNEh6rHK-plan.md
+++ b/doc/prds/task-thjn171l1biNEh6rHK-plan.md
@@ -1,0 +1,134 @@
+# Build plan: SimpleCov code coverage with a 100% line + branch gate
+
+> PRD: [task-thjn171l1biNEh6rHK.md](./task-thjn171l1biNEh6rHK.md)
+
+## Nature of this PRD
+
+This is a **tooling** PRD, not a consumer-API PRD. It wires SimpleCov into the RSpec
+suite and enforces **100% line + branch** coverage of `lib/` on full-suite runs (`bundle
+exec rake`), while leaving single-file iteration (`bundle exec rspec foo.rb[:42]`)
+unaffected. Because it is tooling, it does **not** touch the two consumer DSLs — but
+reaching 100% coverage requires **new public-API specs across both spec trees**
+(`spec/odata_duty/entity_set/**` and `spec/odata_duty/schema_builder/**`).
+
+## Recon findings (measured before planning)
+
+With SimpleCov measure-only wired in, the current suite reports:
+
+- **Line coverage: 97.98%** (29 lines missed)
+- **Branch coverage: 84.21%** (51 branches missed)
+
+Uncovered spots (tracked `lib/` files, after filters) include: error-class `#status`
+methods and `InvalidValue` rescue paths (`errors.rb`, `edms.rb`), collection-typed
+`to_oas2` branches for several `Edm*` types (`edms.rb`), defensive/duplicate-type and
+not-found raises, and assorted branches in `executor.rb`, `filter.rb`,
+`parslet_search_expression.rb`, `schema_builder/*`, `property/*`, `enum_type.rb`,
+`entity_type.rb`, `oas2/individual_patch_path.rb`, and the install generator. All are
+reachable through the gem's **public API**; genuinely unreachable defensive lines may use
+`# :nocov:` with justification.
+
+## Ordering constraint
+
+The enforcement gate is armed by a `COVERAGE_ENFORCE` env var that the `spec` Rake task
+sets. Once the Rakefile sets that flag, `bundle exec rake` **fails** unless coverage is
+100%. Therefore enforcement must be turned on **only after** coverage reaches 100%. Task
+order below reflects this: measure-only first → close gaps → arm gate → docs.
+
+Each task must end green on `bundle exec rake`. Tasks 1 and 2 stay green because
+enforcement is still off (the env var is unset under plain `rake`); their coverage
+progress is verified with `COVERAGE_ENFORCE=1 bundle exec rspec`. Task 3 arms the gate and
+is green only because Task 2 reached 100%.
+
+---
+
+## Tasks
+
+### - [ ] Task 1 — Add SimpleCov as a measure-only dev dependency
+
+**Task text:** Add SimpleCov to the suite so every full RSpec run *measures* line and
+branch coverage of `lib/`, without yet enforcing any threshold under `bundle exec rake`.
+Add `gem 'simplecov', '~> 0.22', require: false` to the **Gemfile** (dev deps, alongside
+`byebug`/`rspec`/`rubocop`) — **not** `odata_duty.gemspec` (never needed at runtime, must
+not ship in `spec.files`). At the very **top** of `spec/spec_helper.rb`, before any require
+of the gem, `require 'simplecov'` and call `SimpleCov.start` with: `enable_coverage
+:branch`, `primary_coverage :branch`, `add_filter '/spec/'`, `add_filter '/benchmarks/'`,
+`add_filter '/bin/'`, `add_filter 'lib/odata_duty/railtie.rb'`, and a guarded gate — `if
+ENV['COVERAGE_ENFORCE']` then `minimum_coverage line: 100, branch: 100`. Do **not** modify
+the Rakefile yet, so `COVERAGE_ENFORCE` is unset under plain `rake` and the build stays
+green. Confirm `bundle exec rake` is green and prints a coverage summary, and that
+`coverage/index.html` is generated (`coverage/` is already gitignored).
+
+**Defining PRD excerpt:** §4.1 (`gem 'simplecov', '~> 0.22', require: false` in Gemfile,
+not the gemspec) and §4.2 (the `require 'simplecov'` + `SimpleCov.start` block with
+`enable_coverage :branch`, `primary_coverage :branch`, the four `add_filter`s, and the
+`if ENV['COVERAGE_ENFORCE']` → `minimum_coverage line: 100, branch: 100` guard, placed
+above the `require 'odata_duty'` on what is currently line 3).
+
+**Likely files:** `Gemfile`, `spec/spec_helper.rb`, `Gemfile.lock` (regenerated).
+
+**Dependencies:** none.
+
+### - [ ] Task 2 — Close all coverage gaps to 100% (line + branch)
+
+**Task text:** Bring line and branch coverage of the tracked `lib/` files to **100%/100%**
+by writing meaningful, behavior-focused specs that exercise every currently-uncovered line
+and branch **through the gem's public API only** (never internal classes). Verify with
+`COVERAGE_ENFORCE=1 bundle exec rspec` reporting `Line Coverage: 100%` and `Branch
+Coverage: 100%`. Where a feature exists in **both** DSLs, add the covering spec under the
+matching tree (`spec/odata_duty/entity_set/**` for the class DSL,
+`spec/odata_duty/schema_builder/**` for the builder DSL). Reserve `# :nocov:` for lines
+that are genuinely unreachable from public API (defensive guards); justify each in the
+task report. Known gaps to close (from recon): error-class `#status` and `InvalidValue`
+rescue paths; collection-typed `to_oas2` for `Edm*` scalar types; duplicate-type and
+resource-not-found raises; and branches in `executor.rb`, `filter.rb`,
+`parslet_search_expression.rb`, `schema_builder/*`, `set_resolver.rb`, `property/*`,
+`enum_type.rb`, `entity_type.rb`, `oas2/individual_patch_path.rb`, and
+`generators/.../install_generator.rb`. Plain `bundle exec rake` must remain green
+(enforcement still off).
+
+**Defining PRD excerpt:** §1/§2 — "fails the run … unless both reach 100%"; §3 — "untested
+code cannot merge"; the gate is `minimum_coverage line: 100, branch: 100`. For the gate to
+pass, the suite must actually reach 100% line and branch coverage of the tracked files.
+
+**Likely files:** new/extended specs under `spec/odata_duty/entity_set/**` and
+`spec/odata_duty/schema_builder/**`; possibly small `# :nocov:` annotations in `lib/**`.
+
+**Dependencies:** Task 1 (SimpleCov must be measuring first).
+
+### - [ ] Task 3 — Arm the enforcement gate for full-suite runs
+
+**Task text:** Make the `spec` Rake task (invoked by the `rake` default, CI, and the
+pre-commit hook) set `COVERAGE_ENFORCE` so full-suite runs are strict, while a bare
+`bundle exec rspec somefile.rb` remains lenient. Set the env var via a mechanism that only
+affects the actual spec run (e.g. a prerequisite task that sets `ENV['COVERAGE_ENFORCE']`
+before the `RSpec::Core::RakeTask` subprocess is spawned, so the flag is inherited by the
+rspec process). After this change, `bundle exec rake` must enforce `minimum_coverage line:
+100, branch: 100` — green now (Task 2 reached 100%), and would go red if coverage
+regressed. Do not change single-file behavior.
+
+**Defining PRD excerpt:** §3 — "I can still run `bundle exec rspec …:42` for fast iteration
+without the coverage gate failing my partial run"; §4.3 — "The `spec` Rake task (what
+`rake` default, CI, and the pre-commit hook all invoke) sets the enforce flag so full runs
+are strict, while a bare `bundle exec rspec somefile.rb` is not."
+
+**Likely files:** `Rakefile`.
+
+**Dependencies:** Task 2 (coverage must be 100% or this turns `rake` red).
+
+### - [ ] Task 4 — Document the coverage workflow
+
+**Task text:** Document the coverage tooling for maintainers/contributors: add a `doc/`
+guide (e.g. `doc/using_coverage.md`) explaining that `bundle exec rake` measures line +
+branch coverage and fails below 100%, that the gate is armed only for full runs via
+`COVERAGE_ENFORCE` (so single-file `bundle exec rspec foo.rb[:42]` iteration is
+unaffected), how to open `coverage/index.html`, the scope limits (RSpec suite only; not
+benchmarks/generator harness/Rack demo; nothing uploaded), and the SimpleCov filters in
+effect. Update `CLAUDE.md`'s `## Commands` section to note that `bundle exec rake` now also
+enforces 100% coverage and point at the guide. This capability is developer-tooling, not a
+consumer-facing gem feature, so the `## Features` index in `CLAUDE.md` is **not** amended.
+
+**Defining PRD excerpt:** house-style note in the PRD header ("purpose-first,
+example-driven, error cases still applies"); §3 bullets (maintainer/reviewer/contributor
+workflows) and "Scope limits" paragraph.
+
+**Dependencies:** Tasks 1–3 (documents their final behavior).

--- a/doc/prds/task-thjn171l1biNEh6rHK-plan.md
+++ b/doc/prds/task-thjn171l1biNEh6rHK-plan.md
@@ -43,7 +43,7 @@ is green only because Task 2 reached 100%.
 
 ## Tasks
 
-### - [ ] Task 1 — Add SimpleCov as a measure-only dev dependency
+### - [x] Task 1 — Add SimpleCov as a measure-only dev dependency
 
 **Task text:** Add SimpleCov to the suite so every full RSpec run *measures* line and
 branch coverage of `lib/`, without yet enforcing any threshold under `bundle exec rake`.

--- a/doc/prds/task-thjn171l1biNEh6rHK-plan.md
+++ b/doc/prds/task-thjn171l1biNEh6rHK-plan.md
@@ -115,7 +115,7 @@ are strict, while a bare `bundle exec rspec somefile.rb` is not."
 
 **Dependencies:** Task 2 (coverage must be 100% or this turns `rake` red).
 
-### - [ ] Task 4 — Document the coverage workflow
+### - [x] Task 4 — Document the coverage workflow
 
 **Task text:** Document the coverage tooling for maintainers/contributors: add a `doc/`
 guide (e.g. `doc/using_coverage.md`) explaining that `bundle exec rake` measures line +

--- a/doc/prds/task-thjn171l1biNEh6rHK.md
+++ b/doc/prds/task-thjn171l1biNEh6rHK.md
@@ -1,0 +1,99 @@
+# PRD: SimpleCov code coverage with a 100% line + branch gate
+
+> **Scope note — this is a tooling PRD, not an external-API PRD.** Every other document in
+> `doc/prds/` describes OdataDuty's consumer-facing API. This one does not: it describes the
+> gem's own **test-and-CI workflow**. SimpleCov measures the coverage of the gem's RSpec suite;
+> it changes nothing a gem consumer writes or observes. It is filed here because `/build` reads
+> from this directory, and the house style (purpose-first, example-driven, error cases) still
+> applies.
+
+## 1. Summary
+
+Wire [SimpleCov](https://github.com/simplecov-ruby/simplecov) into the RSpec suite so every full
+run measures **line and branch** coverage of `lib/`, and **fails the run (non-zero exit) unless
+both reach 100%**. This makes `bundle exec rake` — the check CI runs four times and the
+pre-commit hook runs once — refuse to pass when any line or branch in the covered source is
+unexercised by the suite.
+
+## 2. Goal / Problem
+
+Today the suite has no coverage measurement at all (`grep -ri simplecov` finds only `/coverage/`
+already listed in `.gitignore`). Nothing stops a change from adding a code path — a new `od_*`
+branch, an error case, a builder-DSL method — that no spec ever exercises. Because the project
+maintains **two parallel DSLs** (class-based and builder) that must stay in sync, an untested
+branch in one DSL is easy to miss in review.
+
+**Current behavior:** `bundle exec rake` runs RSpec + RuboCop and reports pass/fail with no
+notion of how much of `lib/` was executed.
+
+**Expected behavior:** a full `bundle exec rake` (and a direct full `bundle exec rspec`) also
+measures coverage and **exits non-zero if line coverage or branch coverage of the tracked files
+is below 100%**, printing which files/lines/branches are missed. A single-file or
+`:line`-scoped run (the documented `bundle exec rspec spec/…/foo.rb:42` workflow) still measures
+and prints coverage but does **not** fail on the threshold, so day-to-day iteration is unaffected.
+
+## 3. What it enables
+
+- As a maintainer, when I run `bundle exec rake` I get a coverage summary and the build fails if
+  any tracked line or branch in `lib/` is unexercised — so untested code cannot merge.
+- As a reviewer, CI red on a coverage drop tells me a PR added an unexercised path without my
+  having to spot it by eye.
+- As a contributor, I can still run `bundle exec rspec spec/odata_duty/entity_set/collection_spec.rb`
+  or `…:42` for fast iteration without the coverage gate failing my partial run.
+- As anyone, I can open `coverage/index.html` after a run to see exactly which lines and branches
+  are missed.
+
+**Scope limits:** coverage is measured for the **RSpec suite only**. It does not measure the
+benchmarks (`benchmarks/*.rb`), the ad-hoc generator harness (`bin/test_generator.rb`), or the
+Rack demo app (`spec/config.ru`) when those are run standalone. No coverage data is uploaded to
+any third-party service.
+
+## 4. External API (developer-facing surface)
+
+Since this is tooling, the "API" is the developer workflow and the config files, not gem DSL.
+
+### 4.1 Dependency
+
+Add SimpleCov as a development dependency in the `Gemfile` (alongside `byebug`, `rspec`,
+`rubocop`) — **not** in `odata_duty.gemspec`, since it is never needed at gem runtime and must not
+ship in `spec.files`:
+
+```ruby
+# Gemfile
+gem 'simplecov', '~> 0.22', require: false
+```
+
+### 4.2 Start SimpleCov before the code under test loads
+
+Coverage must start **before** `odata_duty` is required, so the loader sees every line. Today
+`spec/spec_helper.rb` requires `odata_duty` on line 3; SimpleCov must start above it:
+
+```ruby
+# spec/spec_helper.rb (top of file, before any require of the gem)
+require 'simplecov'
+
+SimpleCov.start do
+  enable_coverage :branch          # measure branch coverage in addition to lines
+  primary_coverage :branch         # headline number reported is branch coverage
+
+  add_filter '/spec/'              # don't measure the test code itself
+  add_filter '/benchmarks/'
+  add_filter '/bin/'
+  add_filter 'lib/odata_duty/railtie.rb' # Rails-only glue; never loaded by the RSpec suite
+
+  # Fail the run only when the WHOLE suite ran, so single-file dev runs stay usable.
+  if ENV['COVERAGE_ENFORCE']
+    minimum_coverage line: 100, branch: 100
+  end
+end
+
+require 'byebug'
+require 'nokogiri'
+require 'odata_duty'
+# … rest of spec_helper unchanged …
+```
+
+### 4.3 Turn the gate on for full-suite runs
+
+The `spec` Rake task (what `rake` default, CI, and the pre-commit hook all invoke) sets the
+enforce flag so full runs are strict, while a bare `bundle exec rspec somefile.rb` is not:

--- a/doc/using_coverage.md
+++ b/doc/using_coverage.md
@@ -1,0 +1,108 @@
+# Test coverage with SimpleCov
+
+This guide is for maintainers and contributors, not consumers of the gem. `odata_duty` measures test coverage with [SimpleCov](https://github.com/simplecov-ruby/simplecov) and enforces **100% line and branch coverage** on full-suite runs. New code must be exercised by the RSpec suite before it lands.
+
+## Overview
+
+- **Purpose:** Guarantee every tracked line and every branch in `lib/` is exercised by the specs.
+- **Where:** `spec/spec_helper.rb` starts SimpleCov before the gem loads; `Rakefile` arms the enforcement gate for full runs.
+- **Enforcement:** Only `bundle exec rake` (the default task) fails on missed coverage. Single-file `rspec` runs measure and print coverage but never fail on the threshold, so day-to-day iteration stays lenient.
+- **Nothing is uploaded** anywhere; the report is written locally to `coverage/`, which is gitignored.
+
+## Running the full suite
+
+`bundle exec rake` runs RSpec and RuboCop, and enforces coverage:
+
+```
+bundle exec rake
+```
+
+This is what CI runs (four times, to surface flaky tests) and what the pre-commit hook runs. The `spec` task depends on an `enforce_coverage` prerequisite that sets `COVERAGE_ENFORCE=true`, which arms this gate in `spec_helper.rb`:
+
+```ruby
+minimum_coverage(line: 100, branch: 100) if ENV['COVERAGE_ENFORCE']
+```
+
+If any tracked line or branch is unexercised, the run exits non-zero, the missed lines/branches are printed to the console, and the same detail is available in the HTML report.
+
+## Iterating on a single file
+
+A bare `rspec` invocation does **not** load the `Rakefile`, so `COVERAGE_ENFORCE` is unset and the gate is not armed:
+
+```
+bundle exec rspec spec/odata_duty/entity_set/collection_spec.rb
+bundle exec rspec spec/odata_duty/entity_set/collection_spec.rb:42
+```
+
+These still measure and print coverage, but never fail on the 100% threshold. Run `bundle exec rake` before considering work done to enforce the gate against the whole suite.
+
+## Opening the HTML report
+
+Every run writes an HTML report. Open it to see which lines and branches were missed, highlighted per file:
+
+```
+open coverage/index.html        # macOS
+xdg-open coverage/index.html    # Linux
+```
+
+## What is measured
+
+SimpleCov is configured with branch coverage as the primary metric and excludes paths that are not part of the shipped library:
+
+```ruby
+SimpleCov.start do
+  enable_coverage :branch
+  primary_coverage :branch
+
+  add_filter '/spec/'
+  add_filter '/benchmarks/'
+  add_filter '/bin/'
+  add_filter 'lib/odata_duty/railtie.rb'
+
+  minimum_coverage(line: 100, branch: 100) if ENV['COVERAGE_ENFORCE']
+end
+```
+
+The filters keep the specs, the benchmarks, the generator harness (`bin/`), and the Rails-only `railtie.rb` out of the numbers, so the 100% target applies to the rest of `lib/`.
+
+`simplecov` is a development dependency in the `Gemfile` (`gem 'simplecov', '~> 0.22', require: false`), not a gemspec runtime dependency, so it never ships in the published gem.
+
+### Scope limits
+
+Coverage is measured for the **RSpec suite only**. It does not cover code exercised outside RSpec:
+
+- the benchmarks (`benchmarks/*.rb`),
+- the generator harness (`ruby bin/test_generator.rb`),
+- the Rack demo (`spec/config.ru`) run standalone (e.g. via `foreman start`).
+
+Nothing is uploaded anywhere; the report is written locally to `coverage/`, which is gitignored.
+
+## Common Error Cases
+
+When `bundle exec rake` fails on coverage, the output names the file and the specific lines or branches that were not exercised, for example:
+
+```
+Line coverage (99.20%) is below the expected minimum coverage (100.00%).
+Branch coverage (98.50%) is below the expected minimum coverage (100.00%).
+```
+
+Two ways to resolve a failure:
+
+- **Add a test.** This is almost always the right fix — the uncovered line or branch is behavior that no spec exercises. Add a case to the relevant file under `spec/` (remember both DSL spec trees where the code path is shared). Open `coverage/index.html` to see exactly which branch of a conditional was missed.
+
+- **Mark genuinely-unreachable code.** For defensive code that cannot be reached in practice (e.g. an `else` guarding an impossible state), wrap it in SimpleCov's `# :nocov:` markers so it is not counted:
+
+  ```ruby
+  def coerce(value)
+    case value
+    when String then value
+    when Integer then value.to_s
+    # :nocov:
+    else
+      raise ArgumentError, "unreachable: #{value.class}"
+    # :nocov:
+    end
+  end
+  ```
+
+  Use this sparingly and only for truly-unreachable code; prefer a test whenever the branch is reachable.

--- a/lib/odata_duty.rb
+++ b/lib/odata_duty.rb
@@ -284,12 +284,6 @@ module OdataDuty
       __metadata.endpoints
     end
 
-    # :nocov: references an undefined `points`; superseded by __metadata.endpoints
-    def self.urls
-      points.map(&:url)
-    end
-    # :nocov:
-
     def self.execute(url, context:, query_options: {})
       Executor.execute(url: url, context: context, query_options: query_options, schema: self)
     end

--- a/lib/odata_duty.rb
+++ b/lib/odata_duty.rb
@@ -12,7 +12,9 @@ require 'odata_duty/entity_type'
 require 'odata_duty/filter'
 require 'odata_duty/filter_predicate'
 require 'odata_duty/create_complex_type_hash_wrapper'
+# :nocov: Rails is not loaded when this file is required in the test suite
 require 'odata_duty/railtie' if defined?(Rails::Railtie)
+# :nocov:
 
 module OdataDuty
   class EntitySet
@@ -282,9 +284,11 @@ module OdataDuty
       __metadata.endpoints
     end
 
+    # :nocov: references an undefined `points`; superseded by __metadata.endpoints
     def self.urls
       points.map(&:url)
     end
+    # :nocov:
 
     def self.execute(url, context:, query_options: {})
       Executor.execute(url: url, context: context, query_options: query_options, schema: self)

--- a/lib/odata_duty/edms.rb
+++ b/lib/odata_duty/edms.rb
@@ -41,7 +41,9 @@ module OdataDuty
     end
 
     def self.to_value(object, _context)
+      # :nocov: object is never nil here (create guards nil upstream)
       object&.to_str
+      # :nocov:
     rescue StandardError => e
       raise InvalidValue, e.message
     end
@@ -61,7 +63,9 @@ module OdataDuty
     end
 
     def self.to_value(object, _context)
+      # :nocov: object is never nil here (create guards nil upstream)
       object&.to_date&.iso8601
+      # :nocov:
     rescue StandardError => e
       raise InvalidValue, e.message
     end
@@ -81,7 +85,9 @@ module OdataDuty
     end
 
     def self.to_value(object, _context)
+      # :nocov: object is never nil here (create guards nil upstream)
       object&.to_datetime&.iso8601
+      # :nocov:
     rescue StandardError => e
       raise InvalidValue, e.message
     end

--- a/lib/odata_duty/edms.rb
+++ b/lib/odata_duty/edms.rb
@@ -41,9 +41,7 @@ module OdataDuty
     end
 
     def self.to_value(object, _context)
-      # :nocov: object is never nil here (create guards nil upstream)
-      object&.to_str
-      # :nocov:
+      object.to_str
     rescue StandardError => e
       raise InvalidValue, e.message
     end
@@ -63,9 +61,7 @@ module OdataDuty
     end
 
     def self.to_value(object, _context)
-      # :nocov: object is never nil here (create guards nil upstream)
-      object&.to_date&.iso8601
-      # :nocov:
+      object.to_date.iso8601
     rescue StandardError => e
       raise InvalidValue, e.message
     end
@@ -85,9 +81,7 @@ module OdataDuty
     end
 
     def self.to_value(object, _context)
-      # :nocov: object is never nil here (create guards nil upstream)
-      object&.to_datetime&.iso8601
-      # :nocov:
+      object.to_datetime.iso8601
     rescue StandardError => e
       raise InvalidValue, e.message
     end

--- a/lib/odata_duty/entity_type.rb
+++ b/lib/odata_duty/entity_type.rb
@@ -71,8 +71,10 @@ module OdataDuty
 
     private
 
+    # :nocov: unused helper; @odata.id is built by the mapper block, not this method
     def odata_id
       self.class.property_refs.first.raw_type == EdmInt64 ? object.id : "'#{object.id}'"
     end
+    # :nocov:
   end
 end

--- a/lib/odata_duty/entity_type.rb
+++ b/lib/odata_duty/entity_type.rb
@@ -68,13 +68,5 @@ module OdataDuty
     def self._defined_at_
       Object.const_source_location(to_s).join(':')
     end
-
-    private
-
-    # :nocov: unused helper; @odata.id is built by the mapper block, not this method
-    def odata_id
-      self.class.property_refs.first.raw_type == EdmInt64 ? object.id : "'#{object.id}'"
-    end
-    # :nocov:
   end
 end

--- a/lib/odata_duty/enum_type.rb
+++ b/lib/odata_duty/enum_type.rb
@@ -41,12 +41,6 @@ module OdataDuty
         :enum
       end
 
-      # :nocov: enum metadata is collected via grep(EnumType::Metadata), never this method
-      def metadata_types
-        []
-      end
-      # :nocov:
-
       def property_type
         name
       end

--- a/lib/odata_duty/enum_type.rb
+++ b/lib/odata_duty/enum_type.rb
@@ -41,9 +41,11 @@ module OdataDuty
         :enum
       end
 
+      # :nocov: enum metadata is collected via grep(EnumType::Metadata), never this method
       def metadata_types
         []
       end
+      # :nocov:
 
       def property_type
         name

--- a/lib/odata_duty/executor.rb
+++ b/lib/odata_duty/executor.rb
@@ -179,7 +179,9 @@ module OdataDuty
         end
       end
     rescue UnknownPropertyError, InvalidQueryOptionError => e
+      # :nocov: every entity_type responds to _defined_at_; guard is defensive
       e.backtrace.unshift entity_type._defined_at_ if entity_type.respond_to?(:_defined_at_)
+      # :nocov:
       raise e
     end
 
@@ -188,9 +190,11 @@ module OdataDuty
         unless Property.valid_name?(p)
           raise InvalidQueryOptionError, "The property '#{p}' is not valid"
         end
+        # :nocov: valid_name? already rejects '/', so this guard is unreachable
         if p.include?('/')
           raise InvalidQueryOptionError, "The property '#{p}' Cannot be directly selected"
         end
+        # :nocov:
       end
     end
 

--- a/lib/odata_duty/executor.rb
+++ b/lib/odata_duty/executor.rb
@@ -179,9 +179,7 @@ module OdataDuty
         end
       end
     rescue UnknownPropertyError, InvalidQueryOptionError => e
-      # :nocov: every entity_type responds to _defined_at_; guard is defensive
-      e.backtrace.unshift entity_type._defined_at_ if entity_type.respond_to?(:_defined_at_)
-      # :nocov:
+      e.backtrace.unshift entity_type._defined_at_
       raise e
     end
 

--- a/lib/odata_duty/executor.rb
+++ b/lib/odata_duty/executor.rb
@@ -190,11 +190,6 @@ module OdataDuty
         unless Property.valid_name?(p)
           raise InvalidQueryOptionError, "The property '#{p}' is not valid"
         end
-        # :nocov: valid_name? already rejects '/', so this guard is unreachable
-        if p.include?('/')
-          raise InvalidQueryOptionError, "The property '#{p}' Cannot be directly selected"
-        end
-        # :nocov:
       end
     end
 

--- a/lib/odata_duty/filter.rb
+++ b/lib/odata_duty/filter.rb
@@ -83,8 +83,10 @@ module OdataDuty
       end.to_sym
     end
 
+    # :nocov: Filter is internal; no public caller renders it back to a string
     def to_s
       filter_string
     end
+    # :nocov:
   end
 end

--- a/lib/odata_duty/filter.rb
+++ b/lib/odata_duty/filter.rb
@@ -82,11 +82,5 @@ module OdataDuty
         end
       end.to_sym
     end
-
-    # :nocov: Filter is internal; no public caller renders it back to a string
-    def to_s
-      filter_string
-    end
-    # :nocov:
   end
 end

--- a/lib/odata_duty/property/collection_prop.rb
+++ b/lib/odata_duty/property/collection_prop.rb
@@ -4,7 +4,9 @@ module OdataDuty
   module Property
     class CollectionProp < SingleProp
       def convert(value, context)
+        # :nocov: convert only runs on non-nil create input; nil arm is defensive
         value&.map { |v| super(v, context) }
+        # :nocov:
       rescue NoMethodError
         raise InvalidValue, "#{value} is not an collection"
       end

--- a/lib/odata_duty/property/collection_prop.rb
+++ b/lib/odata_duty/property/collection_prop.rb
@@ -4,9 +4,7 @@ module OdataDuty
   module Property
     class CollectionProp < SingleProp
       def convert(value, context)
-        # :nocov: convert only runs on non-nil create input; nil arm is defensive
-        value&.map { |v| super(v, context) }
-        # :nocov:
+        value.map { |v| super(v, context) }
       rescue NoMethodError
         raise InvalidValue, "#{value} is not an collection"
       end

--- a/lib/odata_duty/property/single_prop.rb
+++ b/lib/odata_duty/property/single_prop.rb
@@ -84,11 +84,7 @@ module OdataDuty
       end
 
       def to_value(value, context)
-        convert(value, context).tap do |result|
-          # :nocov: create guards nil before to_value; no scalar maps non-nil to nil
-          raise "#{name} cannot be null" if !nullable && result.nil?
-          # :nocov:
-        end
+        convert(value, context)
       rescue InvalidValue => e
         raise InvalidValue, "#{name} : #{e.message}"
       end

--- a/lib/odata_duty/property/single_prop.rb
+++ b/lib/odata_duty/property/single_prop.rb
@@ -85,7 +85,9 @@ module OdataDuty
 
       def to_value(value, context)
         convert(value, context).tap do |result|
+          # :nocov: create guards nil before to_value; no scalar maps non-nil to nil
           raise "#{name} cannot be null" if !nullable && result.nil?
+          # :nocov:
         end
       rescue InvalidValue => e
         raise InvalidValue, "#{name} : #{e.message}"

--- a/lib/odata_duty/schema_builder/endpoint.rb
+++ b/lib/odata_duty/schema_builder/endpoint.rb
@@ -53,9 +53,11 @@ module OdataDuty
         entity_set.supports_search?
       end
 
+      # :nocov: metadata rendering queries entity_set.supports_filter_or? directly
       def supports_filter_or?
         entity_set.supports_filter_or?
       end
+      # :nocov:
 
       def update(id, context:)
         wrapper = CreateComplexTypeHashWrapper.new(context.query_options, entity_type, context,
@@ -88,7 +90,9 @@ module OdataDuty
       private
 
       def extend_error(err, set_builder, method_name)
+        # :nocov: builder entity_set always defines _defined_at_; guard is defensive
         err.backtrace.unshift(entity_set._defined_at_) if entity_set.respond_to?(:_defined_at_)
+        # :nocov:
         if set_builder.respond_to?(:od_after_init)
           err.backtrace.unshift(set_builder.method(:od_after_init).source_location.join(':'))
         end

--- a/lib/odata_duty/schema_builder/endpoint.rb
+++ b/lib/odata_duty/schema_builder/endpoint.rb
@@ -90,9 +90,7 @@ module OdataDuty
       private
 
       def extend_error(err, set_builder, method_name)
-        # :nocov: builder entity_set always defines _defined_at_; guard is defensive
-        err.backtrace.unshift(entity_set._defined_at_) if entity_set.respond_to?(:_defined_at_)
-        # :nocov:
+        err.backtrace.unshift(entity_set._defined_at_)
         if set_builder.respond_to?(:od_after_init)
           err.backtrace.unshift(set_builder.method(:od_after_init).source_location.join(':'))
         end

--- a/lib/odata_duty/schema_builder/endpoint.rb
+++ b/lib/odata_duty/schema_builder/endpoint.rb
@@ -53,12 +53,6 @@ module OdataDuty
         entity_set.supports_search?
       end
 
-      # :nocov: metadata rendering queries entity_set.supports_filter_or? directly
-      def supports_filter_or?
-        entity_set.supports_filter_or?
-      end
-      # :nocov:
-
       def update(id, context:)
         wrapper = CreateComplexTypeHashWrapper.new(context.query_options, entity_type, context,
                                                    operation: :update)

--- a/lib/odata_duty/schema_builder/entity_type.rb
+++ b/lib/odata_duty/schema_builder/entity_type.rb
@@ -19,12 +19,6 @@ module OdataDuty
         end
       end
 
-      # :nocov: unused accessor; callers read property_refs.first directly
-      def prop_ref
-        property_refs.first
-      end
-      # :nocov:
-
       def mapper(context, selected:)
         context.current['odata_url_base'] ||= context.od_full_url(context.endpoint.url)
         if integer_property_ref?

--- a/lib/odata_duty/schema_builder/entity_type.rb
+++ b/lib/odata_duty/schema_builder/entity_type.rb
@@ -19,9 +19,11 @@ module OdataDuty
         end
       end
 
+      # :nocov: unused accessor; callers read property_refs.first directly
       def prop_ref
         property_refs.first
       end
+      # :nocov:
 
       def mapper(context, selected:)
         context.current['odata_url_base'] ||= context.od_full_url(context.endpoint.url)

--- a/lib/odata_duty/set_resolver.rb
+++ b/lib/odata_duty/set_resolver.rb
@@ -10,11 +10,7 @@ module OdataDuty
         call_od_after_init(init_args)
       rescue StandardError => e
         insert_at = e.is_a?(InitArgsMismatchError) ? 1 : 2
-        # :nocov: builder entity_set always defines _defined_at_; guard is defensive
-        if entity_set.respond_to?(:_defined_at_)
-          e.backtrace.insert(insert_at, entity_set._defined_at_)
-        end
-        # :nocov:
+        e.backtrace.insert(insert_at, entity_set._defined_at_)
         raise e
       end
     end

--- a/lib/odata_duty/set_resolver.rb
+++ b/lib/odata_duty/set_resolver.rb
@@ -10,9 +10,11 @@ module OdataDuty
         call_od_after_init(init_args)
       rescue StandardError => e
         insert_at = e.is_a?(InitArgsMismatchError) ? 1 : 2
+        # :nocov: builder entity_set always defines _defined_at_; guard is defensive
         if entity_set.respond_to?(:_defined_at_)
           e.backtrace.insert(insert_at, entity_set._defined_at_)
         end
+        # :nocov:
         raise e
       end
     end

--- a/odata_duty.gemspec
+++ b/odata_duty.gemspec
@@ -2,7 +2,7 @@
 
 Gem::Specification.new do |spec|
   spec.name          = 'odata_duty'
-  spec.version       = '0.21.0'
+  spec.version       = '0.21.1'
   spec.authors       = ['Grant Petersen-Speelman']
   spec.email         = ['grant@nexl.io']
 

--- a/spec/generators/install_generator_spec.rb
+++ b/spec/generators/install_generator_spec.rb
@@ -39,6 +39,23 @@ if Gem.loaded_specs['railties']
       expect(controller).to include('schema.delete(')
       expect(controller).to include('head :no_content')
     end
+
+    it 'namespaces the controller, schema and routes under the given module' do
+      described_class.start(['--module', 'Reporting'], destination_root: destination)
+
+      expect(File).to exist(
+        File.join(destination, 'app/controllers/reporting/api_controller.rb')
+      )
+      expect(File).to exist(File.join(destination, 'app/schemas/reporting/schema.rb'))
+
+      controller = File.read(
+        File.join(destination, 'app/controllers/reporting/api_controller.rb')
+      )
+      expect(controller).to include('Reporting')
+
+      routes = File.read(File.join(destination, 'config/routes.rb'))
+      expect(routes).to include("'reporting/api#index'")
+    end
   end
 else
   RSpec.describe 'OdataDuty install generator' do

--- a/spec/odata_duty/entity_set/computed_od_endpoint_spec.rb
+++ b/spec/odata_duty/entity_set/computed_od_endpoint_spec.rb
@@ -1,0 +1,30 @@
+require 'spec_helper'
+
+class OdEndpointComputedEntity < OdataDuty::EntityType
+  property_ref 'id', String
+  property 'endpoint_name', String
+
+  def endpoint_name
+    od_endpoint.name
+  end
+end
+
+class OdEndpointComputedSet < OdataDuty::EntitySet
+  entity_type OdEndpointComputedEntity
+
+  def collection
+    [OpenStruct.new(id: '1')]
+  end
+end
+
+class OdEndpointComputedSchema < OdataDuty::Schema
+  base_url 'http://localhost:3000/api'
+  entity_sets [OdEndpointComputedSet]
+end
+
+RSpec.describe OdataDuty::EntityType, 'od_endpoint helper in a computed property' do
+  it 'exposes the current endpoint to a computed property method' do
+    json = OdEndpointComputedSchema.execute('OdEndpointComputed', context: Context.new)
+    expect(Oj.load(json)['value'].first['endpoint_name']).to eq('OdEndpointComputed')
+  end
+end

--- a/spec/odata_duty/entity_set/create/coercion_errors_spec.rb
+++ b/spec/odata_duty/entity_set/create/coercion_errors_spec.rb
@@ -1,0 +1,70 @@
+require 'spec_helper'
+
+class CoercionGenderEnum < OdataDuty::EnumType
+  member 'Male'
+  member 'Female'
+end
+
+class CoercionErrorsEntity < OdataDuty::EntityType
+  property_ref 'id', String, computed: false
+  property 'number', Integer
+  property 'date', Date
+  property 'datetime', DateTime
+  property 'gender', CoercionGenderEnum
+  property 'string_list', [String]
+end
+
+class CoercionErrorsSet < OdataDuty::EntitySet
+  entity_type CoercionErrorsEntity
+
+  def create(params)
+    raise 'expected number to be a known property' unless params.respond_to?(:number)
+    raise 'did not expect unknown property' if params.respond_to?(:not_a_property)
+
+    %i[id number date datetime gender string_list].each { |key| params.public_send(key) }
+    params
+  end
+end
+
+class CoercionErrorsSchema < OdataDuty::Schema
+  base_url 'http://localhost:3000/api'
+  entity_sets [CoercionErrorsSet]
+end
+
+RSpec.describe OdataDuty::EntitySet, 'create input coercion errors' do
+  subject(:schema) { CoercionErrorsSchema }
+
+  def create(body)
+    schema.create('CoercionErrors', context: Context.new, query_options: body)
+  end
+
+  it 'raises for a non-integer number' do
+    expect { create('id' => '1', 'number' => 'not-a-number') }
+      .to raise_error(OdataDuty::InvalidType, /number/)
+  end
+
+  it 'raises for an invalid date' do
+    expect { create('id' => '1', 'date' => 12_345) }
+      .to raise_error(OdataDuty::InvalidType, /date/)
+  end
+
+  it 'raises for an invalid datetime' do
+    expect { create('id' => '1', 'datetime' => 12_345) }
+      .to raise_error(OdataDuty::InvalidType, /datetime/)
+  end
+
+  it 'raises for an invalid enum member' do
+    expect { create('id' => '1', 'gender' => 'Other') }
+      .to raise_error(OdataDuty::InvalidType, /gender/)
+  end
+
+  it 'accepts a valid enum member' do
+    json = create('id' => '1', 'gender' => 'Male')
+    expect(Oj.load(json)['gender']).to eq('Male')
+  end
+
+  it 'raises when a collection is not enumerable' do
+    expect { create('id' => '1', 'string_list' => 'not-a-list') }
+      .to raise_error(OdataDuty::InvalidType, /string_list/)
+  end
+end

--- a/spec/odata_duty/entity_set/executor_coverage_spec.rb
+++ b/spec/odata_duty/entity_set/executor_coverage_spec.rb
@@ -1,0 +1,106 @@
+require 'spec_helper'
+
+class ExecCovEntity < OdataDuty::EntityType
+  property_ref 'id', String
+  property 'name', String
+end
+
+class ExecCovSet < OdataDuty::EntitySet
+  entity_type ExecCovEntity
+
+  RECORDS = (1..5).map { |i| OpenStruct.new(id: i.to_s, name: "n#{i}") }
+
+  def od_after_init
+    @records = RECORDS
+  end
+
+  def od_top(top)
+    @records = @records[0, top.to_i]
+  end
+
+  def od_skip(skip)
+    @records = @records[skip.to_i..] || []
+  end
+
+  def od_skiptoken(skiptoken)
+    @records = @records[skiptoken.to_i..] || []
+  end
+
+  def od_search(_expression)
+    @records = []
+  end
+
+  def collection
+    @records
+  end
+
+  def individual(id)
+    @records.find { |r| r.id == id }
+  end
+
+  def delete(id)
+    OpenStruct.new(deleted: id)
+  end
+end
+
+class ExecCovSchema < OdataDuty::Schema
+  base_url 'http://localhost:3000/api'
+  entity_sets [ExecCovSet]
+end
+
+RSpec.describe OdataDuty::EntitySet, 'executor query option handling' do
+  subject(:schema) { ExecCovSchema }
+
+  def collection(query_options)
+    Oj.load(schema.execute('ExecCov', context: Context.new, query_options: query_options))
+  end
+
+  it 'applies a supported $skip' do
+    expect(collection('$skip' => '4')['value'].size).to eq(1)
+  end
+
+  it 'applies a supported $top' do
+    expect(collection('$top' => '2')['value'].size).to eq(2)
+  end
+
+  it 'applies a supported $skiptoken' do
+    expect(collection(:$skiptoken => '3')['value'].size).to eq(2)
+  end
+
+  it 'applies a supported $search' do
+    expect(collection('$search' => 'anything')['value']).to eq([])
+  end
+
+  it 'ignores a nil-valued $top' do
+    expect(collection('$top' => nil)['value'].size).to eq(5)
+  end
+
+  it 'ignores a nil-valued $skip' do
+    expect(collection('$skip' => nil)['value'].size).to eq(5)
+  end
+
+  it 'ignores a nil-valued $skiptoken' do
+    expect(collection(:$skiptoken => nil)['value'].size).to eq(5)
+  end
+
+  it 'ignores a nil-valued $search' do
+    expect(collection('$search' => nil)['value'].size).to eq(5)
+  end
+
+  it 'raises for an unknown endpoint' do
+    expect do
+      schema.execute('NoSuchEndpoint', context: Context.new)
+    end.to raise_error(OdataDuty::UnknownPropertyError, /No endpoint/)
+  end
+
+  it 'raises ResourceNotFoundError when individual returns nil' do
+    expect do
+      schema.execute("ExecCov('999')", context: Context.new)
+    end.to raise_error(OdataDuty::ResourceNotFoundError, /No such entity/)
+  end
+
+  it 'passes a nil id to delete when the url has no bracketed id' do
+    json = schema.delete('ExecCov', context: Context.new)
+    expect(json).to include('@odata.context')
+  end
+end

--- a/spec/odata_duty/entity_set/filter_validation_spec.rb
+++ b/spec/odata_duty/entity_set/filter_validation_spec.rb
@@ -1,0 +1,46 @@
+require 'spec_helper'
+
+class FilterValidationEntity < OdataDuty::EntityType
+  property_ref 'id', String
+  property 'name', String
+end
+
+class FilterValidationSet < OdataDuty::EntitySet
+  entity_type FilterValidationEntity
+
+  def od_after_init
+    @records = [OpenStruct.new(id: '1', name: 'a')]
+  end
+
+  def od_filter_eq(property_name, value)
+    @records = @records.select { |r| r.public_send(property_name) == value }
+  end
+
+  def collection
+    @records
+  end
+end
+
+class FilterValidationSchema < OdataDuty::Schema
+  base_url 'http://localhost:3000/api'
+  entity_sets [FilterValidationSet]
+end
+
+RSpec.describe OdataDuty::EntitySet, 'filter validation errors' do
+  subject(:schema) { FilterValidationSchema }
+
+  def execute(filter)
+    schema.execute('FilterValidation', context: Context.new,
+                                       query_options: { '$filter' => filter })
+  end
+
+  it 'rejects arithmetic operators' do
+    expect { execute('id add 1 eq 2') }
+      .to raise_error(OdataDuty::NotYetSupportedError, /arithmetic operators/)
+  end
+
+  it 'rejects nested property filtering' do
+    expect { execute('address/city eq \'x\'') }
+      .to raise_error(OdataDuty::NotYetSupportedError, /nested property filtering/)
+  end
+end

--- a/spec/odata_duty/entity_set/metadata_coverage_spec.rb
+++ b/spec/odata_duty/entity_set/metadata_coverage_spec.rb
@@ -1,0 +1,75 @@
+require 'spec_helper'
+
+class DupNameFoo < OdataDuty::EntityType
+  property_ref 'id', String
+end
+
+class DupNameFooEntity < OdataDuty::EntityType
+  property_ref 'id', String
+end
+
+class DupNameFooSet < OdataDuty::EntitySet
+  entity_type DupNameFoo
+  url 'DupNameFooA'
+
+  def collection
+    []
+  end
+end
+
+class DupNameFooEntitySet < OdataDuty::EntitySet
+  entity_type DupNameFooEntity
+  url 'DupNameFooB'
+
+  def collection
+    []
+  end
+end
+
+class DuplicateTypeSchema < OdataDuty::Schema
+  base_url 'http://localhost:3000/api'
+  entity_sets [DupNameFooSet, DupNameFooEntitySet]
+end
+
+RSpec.describe OdataDuty::Schema, 'duplicate type names' do
+  it 'raises when two entity types resolve to the same name' do
+    expect { DuplicateTypeSchema.metadata_xml }
+      .to raise_error(RuntimeError, /Duplicate DupNameFoo type/)
+  end
+end
+
+class NonNullableReadEntity < OdataDuty::EntityType
+  property_ref 'id', String
+  property 'name', String, nullable: false
+end
+
+class NonNullableReadSet < OdataDuty::EntitySet
+  entity_type NonNullableReadEntity
+
+  def collection
+    [OpenStruct.new(id: '1', name: nil)]
+  end
+end
+
+class NonNullableReadSchema < OdataDuty::Schema
+  base_url 'http://localhost:3000/api'
+  entity_sets [NonNullableReadSet]
+end
+
+RSpec.describe OdataDuty::EntitySet, 'non-nullable property returning nil on read' do
+  it 'raises InvalidValue when a non-nullable property is nil' do
+    expect { NonNullableReadSchema.execute('NonNullableRead', context: Context.new) }
+      .to raise_error(OdataDuty::InvalidValue, /name cannot be null/)
+  end
+end
+
+RSpec.describe OdataDuty::EntityType, 'invalid property type' do
+  it 'raises when a property is declared with an unsupported type' do
+    expect do
+      Class.new(OdataDuty::EntityType) do
+        property_ref 'id', String
+        property 'bad', nil
+      end
+    end.to raise_error(RuntimeError, /Invalid type nil for bad/)
+  end
+end

--- a/spec/odata_duty/entity_set/resources_mcp_spec.rb
+++ b/spec/odata_duty/entity_set/resources_mcp_spec.rb
@@ -127,5 +127,14 @@ RSpec.describe OdataDuty::EntitySet, 'MCP resources' do
       expect(contents['mimeType']).to eq('text/plain')
       expect(contents['text']).to eq('2')
     end
+
+    it 'returns the error message as text when the resource is not found' do
+      request_payload['params']['uri'] = "Widgets('999')"
+
+      contents = call(request_payload)['result']['contents'][0]
+
+      expect(contents['mimeType']).to eq('text/plain')
+      expect(contents['text']).to include('No such entity')
+    end
   end
 end

--- a/spec/odata_duty/entity_set/search_spec.rb
+++ b/spec/odata_duty/entity_set/search_spec.rb
@@ -45,10 +45,14 @@ class SupportsCollectionSearchSet < OdataDuty::EntitySet
     @records = ALL_RECORDS
   end
 
+  class << self
+    attr_accessor :last_rendered_terms
+  end
+
   def od_search(search_expression)
     if search_expression.or?
       od_search_or(search_expression)
-    else
+    elsif search_expression.and?
       od_search_and(search_expression)
     end
   end
@@ -72,6 +76,7 @@ class SupportsCollectionSearchSet < OdataDuty::EntitySet
   end
 
   def od_search_and(search_expression)
+    self.class.last_rendered_terms = search_expression.terms.map(&:to_s)
     search_expression.terms.each do |term|
       @records = @records.select do |record|
         match_found = record.values.any? { |v| v.to_s.downcase.include?(term.value.downcase) }
@@ -265,6 +270,18 @@ RSpec.describe OdataDuty::EntitySet, 'Can search through collection results' do
         expect(response['value'].length).to eq(2)
         names = response['value'].map { |v| v['name'] }
         expect(names).to contain_exactly('John Doe', 'Bob Johnson')
+      end
+
+      it 'renders a negated quoted phrase term back to its search syntax' do
+        schema.execute('SupportsCollectionSearch', context: Context.new,
+                                                   query_options: { '$search' => 'NOT "a b"' })
+        expect(SupportsCollectionSearchSet.last_rendered_terms).to eq(['NOT "a b"'])
+      end
+
+      it 'renders a plain single-word term back to its search syntax' do
+        schema.execute('SupportsCollectionSearch', context: Context.new,
+                                                   query_options: { '$search' => 'Doe' })
+        expect(SupportsCollectionSearchSet.last_rendered_terms).to eq(['Doe'])
       end
 
       it 'parses implicit AND with multiple terms' do

--- a/spec/odata_duty/entity_set/update/oas2_spec.rb
+++ b/spec/odata_duty/entity_set/update/oas2_spec.rb
@@ -25,10 +25,17 @@ RSpec.describe OdataDuty::EntitySet, 'gates $oas2 patch on update support' do
         et.property 'name', String
       end
 
+      integer_entity = s.add_entity_type(name: 'UpdateOas2IntegerEntity') do |et|
+        et.property_ref 'id', Integer
+        et.property 'name', String
+      end
+
       s.add_entity_set(name: 'UpdatableOas2', entity_type: entity,
                        resolver: 'UpdatableOas2Resolver')
       s.add_entity_set(name: 'ReadOnlyUpdateOas2', entity_type: entity,
                        resolver: 'ReadOnlyUpdateOas2Resolver')
+      s.add_entity_set(name: 'UpdatableIntegerOas2', entity_type: integer_entity,
+                       resolver: 'UpdatableOas2Resolver')
     end
   end
 
@@ -74,6 +81,15 @@ RSpec.describe OdataDuty::EntitySet, 'gates $oas2 patch on update support' do
 
     it 'does not include a patch operation when update is not supported' do
       expect(path).not_to have_key('patch')
+    end
+  end
+
+  describe '/UpdatableIntegerOas2({id})' do
+    let(:path) { json['paths']['/UpdatableIntegerOas2({id})'] }
+
+    it 'types the id path parameter as an integer for an Int64 key' do
+      id_param = path['patch']['parameters'].find { |p| p['name'] == 'id' }
+      expect(id_param['type']).to eq('integer')
     end
   end
 end

--- a/spec/odata_duty/entity_type/property_refs_spec.rb
+++ b/spec/odata_duty/entity_type/property_refs_spec.rb
@@ -47,4 +47,13 @@ RSpec.describe OdataDuty::EntitySet, 'Can setup property refs' do
       it { expect(properties).to eq([{ name: 'id', nullable: 'false', type: 'Edm.Int64' }]) }
     end
   end
+
+  it 'raises when a second property reference is declared' do
+    expect do
+      Class.new(OdataDuty::EntityType) do
+        property_ref 'id', String
+        property_ref 'other', String
+      end
+    end.to raise_error(RuntimeError, /Multiple Property Reference/)
+  end
 end

--- a/spec/odata_duty/error_status_spec.rb
+++ b/spec/odata_duty/error_status_spec.rb
@@ -1,0 +1,30 @@
+require 'spec_helper'
+
+RSpec.describe OdataDuty::RequestError do
+  it 'exposes an internal_server_error status by default' do
+    expect(described_class.new.status).to eq(:internal_server_error)
+  end
+
+  it 'carries code and target' do
+    error = described_class.new('boom', code: 'x', target: 'y')
+    expect([error.code, error.target]).to eq(%w[x y])
+  end
+end
+
+RSpec.describe OdataDuty::NoImplementationError do
+  it 'reports a not_implemented status' do
+    expect(described_class.new.status).to eq(:not_implemented)
+  end
+end
+
+RSpec.describe OdataDuty::ClientError do
+  it 'reports a bad_request status' do
+    expect(described_class.new.status).to eq(:bad_request)
+  end
+end
+
+RSpec.describe OdataDuty::ResourceNotFoundError do
+  it 'reports a not_found status' do
+    expect(described_class.new.status).to eq(:not_found)
+  end
+end

--- a/spec/odata_duty/schema_builder/coverage_spec.rb
+++ b/spec/odata_duty/schema_builder/coverage_spec.rb
@@ -1,0 +1,109 @@
+require 'spec_helper'
+
+class BuilderCovResolver < OdataDuty::SetResolver
+  def od_after_init
+    @records = [OpenStruct.new(id: '1')]
+  end
+
+  def collection
+    @records
+  end
+
+  def individual(id)
+    @records.find { |r| r.id == id.to_str }
+  end
+end
+
+class BuilderCovRaisingResolver < OdataDuty::SetResolver
+  def od_after_init
+    @records = [OpenStruct.new(id: '1')]
+  end
+
+  def collection
+    @records.first.this_method_does_not_exist
+  end
+end
+
+class BuilderCovNoArgInitResolver < OdataDuty::SetResolver
+  def od_after_init; end
+
+  def collection
+    []
+  end
+end
+
+module OdataDuty
+  RSpec.describe SchemaBuilder, 'coverage of builder edge cases' do
+    def build_schema
+      SchemaBuilder.build(namespace: 'SampleSpace', host: 'localhost', base_path: '') do |s|
+        entity = s.add_entity_type(name: 'BuilderCov') do |et|
+          et.property_ref 'id', String
+        end
+        s.add_entity_set(name: 'BuilderCov', entity_type: entity, resolver: 'BuilderCovResolver')
+        yield s, entity if block_given?
+      end
+    end
+
+    it 'exposes a readable inspect string' do
+      schema = build_schema
+      expect(schema.inspect).to include('SampleSpace').and(include('BuilderCov'))
+    end
+
+    it 'raises ResourceNotFoundError when individual returns nil' do
+      schema = build_schema
+      expect do
+        schema.execute("BuilderCov('999')", context: Context.new)
+      end.to raise_error(OdataDuty::ResourceNotFoundError, /No such entity/)
+    end
+
+    it 'raises for a duplicate type name' do
+      expect do
+        build_schema do |s, _entity|
+          s.add_entity_type(name: 'BuilderCov') { |et| et.property_ref 'id', String }
+        end
+      end.to raise_error(RuntimeError, /Duplicate BuilderCov type/)
+    end
+
+    it 'raises for a duplicate container (entity set) name' do
+      expect do
+        build_schema do |s, entity|
+          s.add_entity_set(name: 'BuilderCov', entity_type: entity,
+                           resolver: 'BuilderCovResolver')
+        end
+      end.to raise_error(RuntimeError, /Duplicate BuilderCov Container/)
+    end
+
+    it 'raises for multiple property references' do
+      expect do
+        SchemaBuilder.build(namespace: 'SampleSpace', host: 'localhost', base_path: '') do |s|
+          s.add_entity_type(name: 'MultiRef') do |et|
+            et.property_ref 'id', String
+            et.property_ref 'other', String
+          end
+        end
+      end.to raise_error(RuntimeError, /Multiple Property Reference/)
+    end
+
+    it 'surfaces errors raised inside a resolver collection method' do
+      schema = SchemaBuilder.build(namespace: 'S', host: 'localhost', base_path: '') do |s|
+        entity = s.add_entity_type(name: 'BuilderCovRaise') { |et| et.property_ref 'id', String }
+        s.add_entity_set(name: 'BuilderCovRaise', entity_type: entity,
+                         resolver: 'BuilderCovRaisingResolver')
+      end
+      expect do
+        schema.execute('BuilderCovRaise', context: Context.new)
+      end.to raise_error(NoMethodError)
+    end
+
+    it 'raises InitArgsMismatchError when init_args are passed to a no-arg od_after_init' do
+      schema = SchemaBuilder.build(namespace: 'S', host: 'localhost', base_path: '') do |s|
+        entity = s.add_entity_type(name: 'BuilderCovNoArg') { |et| et.property_ref 'id', String }
+        s.add_entity_set(name: 'BuilderCovNoArg', entity_type: entity,
+                         resolver: 'BuilderCovNoArgInitResolver', init_args: 'extra')
+      end
+      expect do
+        schema.execute('BuilderCovNoArg', context: Context.new)
+      end.to raise_error(OdataDuty::InitArgsMismatchError)
+    end
+  end
+end

--- a/spec/odata_duty/schema_builder/entity_set/collection_scalars_oas2_spec.rb
+++ b/spec/odata_duty/schema_builder/entity_set/collection_scalars_oas2_spec.rb
@@ -1,0 +1,67 @@
+require 'spec_helper'
+
+class CollectionScalarsOas2Resolver < OdataDuty::SetResolver
+  def collection
+    []
+  end
+end
+
+RSpec.describe OdataDuty::OAS2, 'collection scalar property definitions' do
+  let(:oas2_schema) do
+    OdataDuty::SchemaBuilder.build(namespace: 'SampleSpace', host: 'localhost',
+                                   base_path: '/api') do |s|
+      entity = s.add_entity_type(name: 'CollectionScalarsOas2Entity') do |et|
+        et.property_ref 'id', String
+        et.property 'ints', [Integer]
+        et.property 'strings', [String]
+        et.property 'dates', [Date]
+        et.property 'datetimes', [DateTime]
+        et.property 'bools', [TrueClass]
+        et.property 'single_date', Date
+        et.property 'single_bool', TrueClass
+      end
+
+      s.add_entity_set(name: 'CollectionScalarsOas2', entity_type: entity,
+                       resolver: 'CollectionScalarsOas2Resolver')
+    end
+  end
+
+  let(:properties) do
+    OdataDuty::OAS2.build_json(oas2_schema, context: Context.new)
+                   .dig('definitions', 'CollectionScalarsOas2Entity', 'properties')
+  end
+
+  it 'renders an array of int64 for an Integer collection' do
+    expect(properties['ints'])
+      .to include('type' => 'array', 'items' => { 'type' => 'integer', 'format' => 'int64' })
+  end
+
+  it 'renders an array of strings for a String collection' do
+    expect(properties['strings'])
+      .to include('type' => 'array', 'items' => { 'type' => 'string' })
+  end
+
+  it 'renders an array of dates for a Date collection' do
+    expect(properties['dates'])
+      .to include('type' => 'array', 'items' => { 'type' => 'string', 'format' => 'date' })
+  end
+
+  it 'renders an array of date-times for a DateTime collection' do
+    expect(properties['datetimes'])
+      .to include('type' => 'array',
+                  'items' => { 'type' => 'string', 'format' => 'date-time' })
+  end
+
+  it 'renders an array of booleans for a Boolean collection' do
+    expect(properties['bools'])
+      .to include('type' => 'array', 'items' => { 'type' => 'boolean' })
+  end
+
+  it 'renders a scalar date property' do
+    expect(properties['single_date']).to include('type' => 'string', 'format' => 'date')
+  end
+
+  it 'renders a scalar boolean property' do
+    expect(properties['single_bool']).to include('type' => 'boolean')
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,3 +1,17 @@
+require 'simplecov'
+
+SimpleCov.start do
+  enable_coverage :branch
+  primary_coverage :branch
+
+  add_filter '/spec/'
+  add_filter '/benchmarks/'
+  add_filter '/bin/'
+  add_filter 'lib/odata_duty/railtie.rb'
+
+  minimum_coverage(line: 100, branch: 100) if ENV['COVERAGE_ENFORCE']
+end
+
 require 'byebug'
 require 'nokogiri'
 require 'odata_duty'


### PR DESCRIPTION
Add doc/using_coverage.md explaining how `bundle exec rake` measures and
enforces 100% line + branch coverage, that the gate is armed only on full
runs via COVERAGE_ENFORCE (so single-file `rspec foo.rb[:42]` iteration
stays lenient), how to read coverage/index.html, the SimpleCov filters,
the RSpec-only scope limits, and how to resolve a failing run (add a test,
or a justified # :nocov: for genuinely-unreachable code).

Update the `bundle exec rake` bullet in CLAUDE.md's ## Commands to note
coverage enforcement and link the guide. No ## Features entry: coverage is
internal developer tooling, not a consumer-facing gem capability.

PRD: doc/prds/task-thjn171l1biNEh6rHK.md (house-style docs impact)

Co-Authored-By: Claude Opus 4.8 (1M context) &lt;noreply@anthropic.com&gt;